### PR TITLE
cmd/api: auto-handle JSON:API v2 content type, wrapping, and unwrapping

### DIFF
--- a/cmd/api/http.go
+++ b/cmd/api/http.go
@@ -52,7 +52,7 @@ func buildRequest(method, baseURL, path string, fields map[string]any, body io.R
 	}
 
 	if body != nil && req.Header.Get("Content-Type") == "" {
-		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Content-Type", contentTypeForPath(path))
 	}
 
 	for _, h := range headers {

--- a/cmd/api/jsonapi.go
+++ b/cmd/api/jsonapi.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"encoding/json"
+	"maps"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+func isV2Path(path string) bool {
+	return strings.HasPrefix(extractPath(path), "/2/")
+}
+
+func extractPath(path string) string {
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		if u, err := url.Parse(path); err == nil {
+			return u.Path
+		}
+	}
+	return path
+}
+
+func contentTypeForPath(path string) string {
+	if isV2Path(path) {
+		return "application/vnd.api+json"
+	}
+	return "application/json"
+}
+
+func inferResourceType(method, path string) string {
+	path = extractPath(path)
+	if idx := strings.IndexByte(path, '?'); idx >= 0 {
+		path = path[:idx]
+	}
+	path = strings.TrimRight(path, "/")
+
+	segments := strings.Split(path, "/")
+
+	if (method == http.MethodPatch || method == http.MethodPut) && len(segments) >= 2 {
+		return segments[len(segments)-2]
+	}
+
+	return segments[len(segments)-1]
+}
+
+type jsonAPIResource struct {
+	ID         string         `json:"id,omitempty"`
+	Type       string         `json:"type"`
+	Attributes map[string]any `json:"attributes"`
+}
+
+func wrapJSONAPI(fields map[string]any, resourceType string) map[string]any {
+	return map[string]any{
+		"data": jsonAPIResource{
+			Type:       resourceType,
+			Attributes: fields,
+		},
+	}
+}
+
+func unwrapJSONAPI(data []byte) ([]byte, error) {
+	var probe struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil || probe.Data == nil {
+		return data, nil
+	}
+
+	// Try single resource
+	var single jsonAPIResource
+	if err := json.Unmarshal(probe.Data, &single); err == nil && single.Type != "" {
+		return json.Marshal(flattenResource(single))
+	}
+
+	// Try list of resources
+	var list []jsonAPIResource
+	if err := json.Unmarshal(probe.Data, &list); err == nil {
+		flat := make([]map[string]any, len(list))
+		for i, r := range list {
+			flat[i] = flattenResource(r)
+		}
+		return json.Marshal(flat)
+	}
+
+	return data, nil
+}
+
+func flattenResource(r jsonAPIResource) map[string]any {
+	flat := make(map[string]any)
+	maps.Copy(flat, r.Attributes)
+
+	// id and type from the envelope take precedence over attributes
+	if r.ID != "" {
+		flat["id"] = r.ID
+	}
+	flat["type"] = r.Type
+	return flat
+}

--- a/cmd/api/jsonapi_test.go
+++ b/cmd/api/jsonapi_test.go
@@ -1,0 +1,183 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestIsV2Path(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/1/auth", false},
+		{"/1/boards", false},
+		{"/2/teams", true},
+		{"/2/environments", true},
+		{"https://api.honeycomb.io/2/teams?cursor=abc", true},
+		{"https://api.honeycomb.io/1/boards", false},
+		{"http://localhost:8080/2/environments", true},
+		{"/other", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := isV2Path(tt.path)
+			if got != tt.want {
+				t.Errorf("isV2Path(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContentTypeForPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/1/boards", "application/json"},
+		{"/2/teams", "application/vnd.api+json"},
+		{"https://api.honeycomb.io/2/teams", "application/vnd.api+json"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := contentTypeForPath(tt.path)
+			if got != tt.want {
+				t.Errorf("contentTypeForPath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInferResourceType(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		want   string
+	}{
+		{"POST collection", http.MethodPost, "/2/teams/slug/environments", "environments"},
+		{"PATCH resource", http.MethodPatch, "/2/teams/slug/environments/env-id", "environments"},
+		{"PUT resource", http.MethodPut, "/2/teams/slug/environments/env-id", "environments"},
+		{"POST with trailing slash", http.MethodPost, "/2/teams/slug/environments/", "environments"},
+		{"POST with query", http.MethodPost, "/2/teams/slug/environments?foo=bar", "environments"},
+		{"GET collection", http.MethodGet, "/2/teams/slug/environments", "environments"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := inferResourceType(tt.method, tt.path)
+			if got != tt.want {
+				t.Errorf("inferResourceType(%q, %q) = %q, want %q", tt.method, tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWrapJSONAPI(t *testing.T) {
+	fields := map[string]any{"name": "prod", "slug": "prod"}
+	wrapped := wrapJSONAPI(fields, "environments")
+
+	data, ok := wrapped["data"].(jsonAPIResource)
+	if !ok {
+		t.Fatal("missing data key")
+	}
+	if data.Type != "environments" {
+		t.Errorf("type = %v, want environments", data.Type)
+	}
+	if data.Attributes["name"] != "prod" {
+		t.Errorf("attributes.name = %v, want prod", data.Attributes["name"])
+	}
+}
+
+func TestUnwrapJSONAPI(t *testing.T) {
+	t.Run("single resource", func(t *testing.T) {
+		input := `{"data":{"id":"abc","type":"environments","attributes":{"name":"prod","slug":"prod"}}}`
+		got, err := unwrapJSONAPI([]byte(input))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var flat map[string]any
+		if err := json.Unmarshal(got, &flat); err != nil {
+			t.Fatal(err)
+		}
+		if flat["id"] != "abc" {
+			t.Errorf("id = %v, want abc", flat["id"])
+		}
+		if flat["type"] != "environments" {
+			t.Errorf("type = %v, want environments", flat["type"])
+		}
+		if flat["name"] != "prod" {
+			t.Errorf("name = %v, want prod", flat["name"])
+		}
+	})
+
+	t.Run("list of resources", func(t *testing.T) {
+		input := `{"data":[{"id":"a","type":"environments","attributes":{"name":"prod"}},{"id":"b","type":"environments","attributes":{"name":"staging"}}]}`
+		got, err := unwrapJSONAPI([]byte(input))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var flat []map[string]any
+		if err := json.Unmarshal(got, &flat); err != nil {
+			t.Fatal(err)
+		}
+		if len(flat) != 2 {
+			t.Fatalf("len = %d, want 2", len(flat))
+		}
+		if flat[0]["name"] != "prod" {
+			t.Errorf("first name = %v, want prod", flat[0]["name"])
+		}
+		if flat[1]["id"] != "b" {
+			t.Errorf("second id = %v, want b", flat[1]["id"])
+		}
+	})
+
+	t.Run("envelope id takes precedence over attribute id", func(t *testing.T) {
+		input := `{"data":{"id":"envelope-id","type":"environments","attributes":{"id":"attr-id","name":"prod"}}}`
+		got, err := unwrapJSONAPI([]byte(input))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var flat map[string]any
+		if err := json.Unmarshal(got, &flat); err != nil {
+			t.Fatal(err)
+		}
+		if flat["id"] != "envelope-id" {
+			t.Errorf("id = %v, want envelope-id (envelope should take precedence)", flat["id"])
+		}
+		if flat["type"] != "environments" {
+			t.Errorf("type = %v, want environments", flat["type"])
+		}
+		if flat["name"] != "prod" {
+			t.Errorf("name = %v, want prod", flat["name"])
+		}
+	})
+
+	t.Run("non-jsonapi passthrough", func(t *testing.T) {
+		input := `{"name":"plain json"}`
+		got, err := unwrapJSONAPI([]byte(input))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != input {
+			t.Errorf("got %q, want passthrough", string(got))
+		}
+	})
+
+	t.Run("invalid json passthrough", func(t *testing.T) {
+		input := `not json`
+		got, err := unwrapJSONAPI([]byte(input))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != input {
+			t.Errorf("got %q, want passthrough", string(got))
+		}
+	})
+}

--- a/cmd/api/keytype.go
+++ b/cmd/api/keytype.go
@@ -7,7 +7,7 @@ import (
 )
 
 func inferKeyType(path string) config.KeyType {
-	if strings.HasPrefix(path, "/2/") {
+	if isV2Path(path) {
 		return config.KeyManagement
 	}
 


### PR DESCRIPTION
Auto-detects API version from the request path and handles v1/v2 differences transparently, so users don't need to manually manage content types, request envelopes, or response unwrapping.

## Changes

- **`cmd/api/jsonapi.go`**: New file with JSON:API helpers — `isV2Path`, `contentTypeForPath`, `inferResourceType`, `wrapJSONAPI`/`unwrapJSONAPI`
- **`cmd/api/http.go`**: `buildRequest` uses `contentTypeForPath` instead of hardcoded `application/json`
- **`cmd/api/keytype.go`**: `inferKeyType` delegates to `isV2Path`
- **`cmd/api/api.go`**: Wraps `-f` fields in JSON:API envelope for v2 write methods, unwraps v2 responses to flat JSON by default, adds `--raw` flag to preserve the full envelope

| Aspect | v1 (`/1/...`) | v2 (`/2/...`) |
|--------|---------------|---------------|
| Content-Type | `application/json` | `application/vnd.api+json` |
| Request body | plain JSON | auto-wrapped in `{data: {type, attributes}}` |
| Response body | plain JSON | auto-unwrapped to flat object |

`--raw` disables response unwrapping. `--input` bypasses request wrapping. Explicit `-H Content-Type:` overrides inference.

## Testing

- Unit tests for all `jsonapi.go` helpers including key collision precedence (envelope `id`/`type` win over attributes)
- Integration tests: field wrapping (POST + PATCH), response unwrap (single + list), `--raw`, `--input` passthrough, header override, GET fields as query params, v2 error responses, `--jq` on unwrapped output

Closes #9
