### PR TITLE
cmd/marker: add CRUD commands

### DIFF
--- a/cmd/marker/create.go
+++ b/cmd/marker/create.go
@@ -1,0 +1,103 @@
+package marker
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/internal/api"
+	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/bendrucker/honeycomb-cli/internal/prompt"
+	"github.com/spf13/cobra"
+)
+
+func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
+	var (
+		markerType string
+		message    string
+		url        string
+		startTime  int
+		endTime    int
+		color      string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a marker",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if markerType == "" && opts.IOStreams.CanPrompt() {
+				v, err := prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Type: ")
+				if err != nil {
+					return err
+				}
+				markerType = v
+			}
+
+			if message == "" && opts.IOStreams.CanPrompt() {
+				v, err := prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Message: ")
+				if err != nil {
+					return err
+				}
+				message = v
+			}
+
+			if !cmd.Flags().Changed("start-time") {
+				startTime = int(time.Now().Unix())
+			}
+
+			body := api.CreateMarkerJSONRequestBody{
+				Type:      &markerType,
+				Message:   &message,
+				StartTime: &startTime,
+			}
+			if url != "" {
+				body.Url = &url
+			}
+			if cmd.Flags().Changed("end-time") {
+				body.EndTime = &endTime
+			}
+			if color != "" {
+				body.Color = &color
+			}
+
+			return runMarkerCreate(cmd.Context(), opts, *dataset, body)
+		},
+	}
+
+	cmd.Flags().StringVar(&markerType, "type", "", "Marker type (e.g., deploy)")
+	cmd.Flags().StringVar(&message, "message", "", "Marker message")
+	cmd.Flags().StringVar(&url, "url", "", "URL associated with the marker")
+	cmd.Flags().IntVar(&startTime, "start-time", 0, "Start time as Unix timestamp (defaults to now)")
+	cmd.Flags().IntVar(&endTime, "end-time", 0, "End time as Unix timestamp")
+	cmd.Flags().StringVar(&color, "color", "", "Marker color")
+
+	return cmd
+}
+
+func runMarkerCreate(ctx context.Context, opts *options.RootOptions, dataset string, body api.CreateMarkerJSONRequestBody) error {
+	key, err := opts.RequireKey(config.KeyConfig)
+	if err != nil {
+		return err
+	}
+
+	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
+	if err != nil {
+		return fmt.Errorf("creating API client: %w", err)
+	}
+
+	resp, err := client.CreateMarkerWithResponse(ctx, dataset, body, keyEditor(key))
+	if err != nil {
+		return fmt.Errorf("creating marker: %w", err)
+	}
+
+	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+		return err
+	}
+
+	if resp.JSON201 == nil {
+		return fmt.Errorf("unexpected response: %s", resp.Status())
+	}
+
+	return writeDetail(opts, markerToItem(*resp.JSON201))
+}

--- a/cmd/marker/create_test.go
+++ b/cmd/marker/create_test.go
@@ -1,0 +1,86 @@
+package marker
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestCreate(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		if r.URL.Path != "/1/markers/test-dataset" {
+			t.Errorf("path = %q, want /1/markers/test-dataset", r.URL.Path)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("unmarshal request: %v", err)
+		}
+		if req["type"] != "deploy" {
+			t.Errorf("type = %v, want deploy", req["type"])
+		}
+		if req["message"] != "v2.0.0" {
+			t.Errorf("message = %v, want v2.0.0", req["message"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":         "new123",
+			"type":       "deploy",
+			"message":    "v2.0.0",
+			"start_time": 1700000000,
+			"created_at": "2024-01-01T00:00:00Z",
+		})
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"create", "--dataset", "test-dataset", "--type", "deploy", "--message", "v2.0.0", "--start-time", "1700000000"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var item markerItem
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &item); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if item.ID != "new123" {
+		t.Errorf("ID = %q, want %q", item.ID, "new123")
+	}
+	if item.Type != "deploy" {
+		t.Errorf("Type = %q, want %q", item.Type, "deploy")
+	}
+}
+
+func TestCreate_DefaultStartTime(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("unmarshal request: %v", err)
+		}
+		st, ok := req["start_time"].(float64)
+		if !ok || st == 0 {
+			t.Errorf("start_time should be set to current time, got %v", req["start_time"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":         "new456",
+			"start_time": int(st),
+			"created_at": "2024-01-01T00:00:00Z",
+		})
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"create", "--dataset", "test-dataset", "--type", "deploy"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/marker/delete.go
+++ b/cmd/marker/delete.go
@@ -1,0 +1,94 @@
+package marker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/internal/api"
+	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/bendrucker/honeycomb-cli/internal/prompt"
+	"github.com/spf13/cobra"
+)
+
+func NewDeleteCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
+	var yes bool
+
+	cmd := &cobra.Command{
+		Use:   "delete <marker-id>",
+		Short: "Delete a marker",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runMarkerDelete(cmd.Context(), opts, *dataset, args[0], yes)
+		},
+	}
+
+	cmd.Flags().BoolVar(&yes, "yes", false, "Skip confirmation prompt")
+
+	return cmd
+}
+
+func runMarkerDelete(ctx context.Context, opts *options.RootOptions, dataset, markerID string, yes bool) error {
+	key, err := opts.RequireKey(config.KeyConfig)
+	if err != nil {
+		return err
+	}
+
+	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
+	if err != nil {
+		return fmt.Errorf("creating API client: %w", err)
+	}
+
+	if !yes {
+		if !opts.IOStreams.CanPrompt() {
+			return fmt.Errorf("--yes is required in non-interactive mode")
+		}
+
+		// Fetch marker for confirmation display
+		listResp, err := client.GetMarkerWithResponse(ctx, dataset, keyEditor(key))
+		if err != nil {
+			return fmt.Errorf("listing markers: %w", err)
+		}
+
+		if err := api.CheckResponse(listResp.StatusCode(), listResp.Body); err != nil {
+			return err
+		}
+
+		if listResp.JSON200 == nil {
+			return fmt.Errorf("unexpected response: %s", listResp.Status())
+		}
+
+		m, err := findMarker(*listResp.JSON200, markerID)
+		if err != nil {
+			return err
+		}
+
+		markerType := ""
+		if m.Type != nil {
+			markerType = *m.Type
+		}
+
+		answer, err := prompt.Choice(opts.IOStreams.Err, opts.IOStreams.In,
+			fmt.Sprintf("Delete marker %q (type: %s)? (y/N): ", markerID, markerType),
+			[]string{"y", "N"},
+		)
+		if err != nil {
+			return err
+		}
+		if answer != "y" {
+			return nil
+		}
+	}
+
+	resp, err := client.DeleteMarkerWithResponse(ctx, dataset, markerID, keyEditor(key))
+	if err != nil {
+		return fmt.Errorf("deleting marker: %w", err)
+	}
+
+	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(opts.IOStreams.Err, "Deleted marker %s\n", markerID)
+	return nil
+}

--- a/cmd/marker/list.go
+++ b/cmd/marker/list.go
@@ -1,0 +1,53 @@
+package marker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/internal/api"
+	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func NewListCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List markers",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runMarkerList(cmd.Context(), opts, *dataset)
+		},
+	}
+}
+
+func runMarkerList(ctx context.Context, opts *options.RootOptions, dataset string) error {
+	key, err := opts.RequireKey(config.KeyConfig)
+	if err != nil {
+		return err
+	}
+
+	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
+	if err != nil {
+		return fmt.Errorf("creating API client: %w", err)
+	}
+
+	resp, err := client.GetMarkerWithResponse(ctx, dataset, keyEditor(key))
+	if err != nil {
+		return fmt.Errorf("listing markers: %w", err)
+	}
+
+	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+		return err
+	}
+
+	if resp.JSON200 == nil {
+		return fmt.Errorf("unexpected response: %s", resp.Status())
+	}
+
+	items := make([]markerItem, len(*resp.JSON200))
+	for i, m := range *resp.JSON200 {
+		items[i] = markerToItem(m)
+	}
+
+	return opts.OutputWriter().Write(items, markerListTable)
+}

--- a/cmd/marker/list_test.go
+++ b/cmd/marker/list_test.go
@@ -1,0 +1,155 @@
+package marker
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/bendrucker/honeycomb-cli/internal/iostreams"
+	"github.com/zalando/go-keyring"
+)
+
+func init() {
+	keyring.MockInit()
+}
+
+func setupTest(t *testing.T, handler http.Handler) (*options.RootOptions, *iostreams.TestStreams) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	ts := iostreams.Test()
+	opts := &options.RootOptions{
+		IOStreams: ts.IOStreams,
+		Config:    &config.Config{},
+		APIUrl:    srv.URL,
+		Format:    "json",
+	}
+
+	if err := config.SetKey("default", config.KeyConfig, "test-key"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = config.DeleteKey("default", config.KeyConfig) })
+
+	return opts, ts
+}
+
+func TestList(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/1/markers/test-dataset" {
+			t.Errorf("path = %q, want /1/markers/test-dataset", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"id":         "abc123",
+				"type":       "deploy",
+				"message":    "v1.0.0",
+				"start_time": 1700000000,
+				"end_time":   1700000300,
+				"color":      "#ff0000",
+				"created_at": "2024-01-01T00:00:00Z",
+				"updated_at": "2024-01-01T00:00:00Z",
+			},
+			{
+				"id":         "def456",
+				"type":       "incident",
+				"message":    "outage",
+				"start_time": 1700001000,
+				"created_at": "2024-01-02T00:00:00Z",
+			},
+		})
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"list", "--dataset", "test-dataset"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var items []markerItem
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &items); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("got %d items, want 2", len(items))
+	}
+	if items[0].ID != "abc123" {
+		t.Errorf("items[0].ID = %q, want %q", items[0].ID, "abc123")
+	}
+	if items[0].Type != "deploy" {
+		t.Errorf("items[0].Type = %q, want %q", items[0].Type, "deploy")
+	}
+	if items[0].StartTime == nil || *items[0].StartTime != 1700000000 {
+		t.Errorf("items[0].StartTime = %v, want 1700000000", items[0].StartTime)
+	}
+	if items[1].EndTime != nil {
+		t.Errorf("items[1].EndTime = %v, want nil", items[1].EndTime)
+	}
+}
+
+func TestList_Empty(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"list", "--dataset", "test-dataset"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var items []markerItem
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &items); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if len(items) != 0 {
+		t.Errorf("got %d items, want 0", len(items))
+	}
+}
+
+func TestList_NoKey(t *testing.T) {
+	ts := iostreams.Test()
+	opts := &options.RootOptions{
+		IOStreams: ts.IOStreams,
+		Config:    &config.Config{},
+		APIUrl:    "http://localhost",
+		Format:    "json",
+	}
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"list", "--dataset", "test-dataset"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing key")
+	}
+	if !strings.Contains(err.Error(), "no config key configured") {
+		t.Errorf("error = %q, want missing key message", err.Error())
+	}
+}
+
+func TestList_Unauthorized(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unknown API key - check your credentials"}`))
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"list", "--dataset", "test-dataset"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for 401")
+	}
+	if !strings.Contains(err.Error(), "HTTP 401") {
+		t.Errorf("error = %q, want HTTP 401", err.Error())
+	}
+	if !strings.Contains(err.Error(), "unknown API key") {
+		t.Errorf("error = %q, want error message from body", err.Error())
+	}
+}

--- a/cmd/marker/marker.go
+++ b/cmd/marker/marker.go
@@ -1,0 +1,136 @@
+package marker
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"text/tabwriter"
+
+	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/internal/api"
+	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/bendrucker/honeycomb-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type markerItem struct {
+	ID        string `json:"id"                     yaml:"id"`
+	Type      string `json:"type,omitempty"          yaml:"type,omitempty"`
+	Message   string `json:"message,omitempty"       yaml:"message,omitempty"`
+	URL       string `json:"url,omitempty"           yaml:"url,omitempty"`
+	StartTime *int   `json:"start_time,omitempty"    yaml:"start_time,omitempty"`
+	EndTime   *int   `json:"end_time,omitempty"      yaml:"end_time,omitempty"`
+	Color     string `json:"color,omitempty"         yaml:"color,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"    yaml:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"    yaml:"updated_at,omitempty"`
+}
+
+var markerListTable = output.TableDef{
+	Columns: []output.Column{
+		{Header: "ID", Value: func(v any) string { return v.(markerItem).ID }},
+		{Header: "Type", Value: func(v any) string { return v.(markerItem).Type }},
+		{Header: "Message", Value: func(v any) string { return v.(markerItem).Message }},
+		{Header: "Start Time", Value: func(v any) string {
+			if st := v.(markerItem).StartTime; st != nil {
+				return fmt.Sprintf("%d", *st)
+			}
+			return ""
+		}},
+		{Header: "End Time", Value: func(v any) string {
+			if et := v.(markerItem).EndTime; et != nil {
+				return fmt.Sprintf("%d", *et)
+			}
+			return ""
+		}},
+		{Header: "Color", Value: func(v any) string { return v.(markerItem).Color }},
+	},
+}
+
+func markerToItem(m api.Marker) markerItem {
+	item := markerItem{
+		StartTime: m.StartTime,
+		EndTime:   m.EndTime,
+	}
+	if m.Id != nil {
+		item.ID = *m.Id
+	}
+	if m.Type != nil {
+		item.Type = *m.Type
+	}
+	if m.Message != nil {
+		item.Message = *m.Message
+	}
+	if m.Url != nil {
+		item.URL = *m.Url
+	}
+	if m.Color != nil {
+		item.Color = *m.Color
+	}
+	if m.CreatedAt != nil {
+		item.CreatedAt = *m.CreatedAt
+	}
+	if m.UpdatedAt != nil {
+		item.UpdatedAt = *m.UpdatedAt
+	}
+	return item
+}
+
+func writeDetail(opts *options.RootOptions, item markerItem) error {
+	format := opts.ResolveFormat()
+	if format != "table" {
+		return opts.OutputWriter().Write(item, output.TableDef{})
+	}
+
+	tw := tabwriter.NewWriter(opts.IOStreams.Out, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintf(tw, "ID:\t%s\n", item.ID)
+	_, _ = fmt.Fprintf(tw, "Type:\t%s\n", item.Type)
+	_, _ = fmt.Fprintf(tw, "Message:\t%s\n", item.Message)
+	_, _ = fmt.Fprintf(tw, "URL:\t%s\n", item.URL)
+	if item.StartTime != nil {
+		_, _ = fmt.Fprintf(tw, "Start Time:\t%d\n", *item.StartTime)
+	}
+	if item.EndTime != nil {
+		_, _ = fmt.Fprintf(tw, "End Time:\t%d\n", *item.EndTime)
+	}
+	_, _ = fmt.Fprintf(tw, "Color:\t%s\n", item.Color)
+	_, _ = fmt.Fprintf(tw, "Created At:\t%s\n", item.CreatedAt)
+	_, _ = fmt.Fprintf(tw, "Updated At:\t%s\n", item.UpdatedAt)
+	return tw.Flush()
+}
+
+func findMarker(markers []api.Marker, id string) (api.Marker, error) {
+	for _, m := range markers {
+		if m.Id != nil && *m.Id == id {
+			return m, nil
+		}
+	}
+	return api.Marker{}, fmt.Errorf("marker %q not found", id)
+}
+
+func keyEditor(key string) api.RequestEditorFn {
+	return func(_ context.Context, req *http.Request) error {
+		config.ApplyAuth(req, config.KeyConfig, key)
+		return nil
+	}
+}
+
+func NewCmd(opts *options.RootOptions) *cobra.Command {
+	var dataset string
+
+	cmd := &cobra.Command{
+		Use:     "marker",
+		Short:   "Manage markers",
+		Aliases: []string{"markers"},
+	}
+
+	cmd.PersistentFlags().StringVar(&dataset, "dataset", "", "Dataset slug (required)")
+	_ = cmd.MarkPersistentFlagRequired("dataset")
+
+	cmd.AddCommand(NewListCmd(opts, &dataset))
+	cmd.AddCommand(NewViewCmd(opts, &dataset))
+	cmd.AddCommand(NewCreateCmd(opts, &dataset))
+	cmd.AddCommand(NewUpdateCmd(opts, &dataset))
+	cmd.AddCommand(NewDeleteCmd(opts, &dataset))
+
+	return cmd
+}

--- a/cmd/marker/update.go
+++ b/cmd/marker/update.go
@@ -1,0 +1,107 @@
+package marker
+
+import (
+	"fmt"
+
+	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/internal/api"
+	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func NewUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
+	var (
+		markerType string
+		message    string
+		url        string
+		startTime  int
+		endTime    int
+		color      string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update <marker-id>",
+		Short: "Update a marker",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runMarkerUpdate(cmd, opts, *dataset, args[0], markerType, message, url, startTime, endTime, color)
+		},
+	}
+
+	cmd.Flags().StringVar(&markerType, "type", "", "Marker type")
+	cmd.Flags().StringVar(&message, "message", "", "Marker message")
+	cmd.Flags().StringVar(&url, "url", "", "URL associated with the marker")
+	cmd.Flags().IntVar(&startTime, "start-time", 0, "Start time as Unix timestamp")
+	cmd.Flags().IntVar(&endTime, "end-time", 0, "End time as Unix timestamp")
+	cmd.Flags().StringVar(&color, "color", "", "Marker color")
+
+	return cmd
+}
+
+func runMarkerUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, markerID, markerType, message, url string, startTime, endTime int, color string) error {
+	ctx := cmd.Context()
+
+	key, err := opts.RequireKey(config.KeyConfig)
+	if err != nil {
+		return err
+	}
+
+	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
+	if err != nil {
+		return fmt.Errorf("creating API client: %w", err)
+	}
+
+	// Fetch existing marker (no individual GET — list and filter)
+	listResp, err := client.GetMarkerWithResponse(ctx, dataset, keyEditor(key))
+	if err != nil {
+		return fmt.Errorf("listing markers: %w", err)
+	}
+
+	if err := api.CheckResponse(listResp.StatusCode(), listResp.Body); err != nil {
+		return err
+	}
+
+	if listResp.JSON200 == nil {
+		return fmt.Errorf("unexpected response: %s", listResp.Status())
+	}
+
+	existing, err := findMarker(*listResp.JSON200, markerID)
+	if err != nil {
+		return err
+	}
+
+	// Merge flag overrides into existing marker (API is full PUT)
+	if cmd.Flags().Changed("type") {
+		existing.Type = &markerType
+	}
+	if cmd.Flags().Changed("message") {
+		existing.Message = &message
+	}
+	if cmd.Flags().Changed("url") {
+		existing.Url = &url
+	}
+	if cmd.Flags().Changed("start-time") {
+		existing.StartTime = &startTime
+	}
+	if cmd.Flags().Changed("end-time") {
+		existing.EndTime = &endTime
+	}
+	if cmd.Flags().Changed("color") {
+		existing.Color = &color
+	}
+
+	resp, err := client.UpdateMarkerWithResponse(ctx, dataset, markerID, api.UpdateMarkerJSONRequestBody(existing), keyEditor(key))
+	if err != nil {
+		return fmt.Errorf("updating marker: %w", err)
+	}
+
+	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+		return err
+	}
+
+	if resp.JSON200 == nil {
+		return fmt.Errorf("unexpected response: %s", resp.Status())
+	}
+
+	return writeDetail(opts, markerToItem(*resp.JSON200))
+}

--- a/cmd/marker/update_test.go
+++ b/cmd/marker/update_test.go
@@ -1,0 +1,92 @@
+package marker
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestUpdate(t *testing.T) {
+	callCount := 0
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		callCount++
+
+		if callCount == 1 {
+			// List markers (GET)
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"id":         "abc123",
+					"type":       "deploy",
+					"message":    "v1.0.0",
+					"start_time": 1700000000,
+					"color":      "#ff0000",
+					"created_at": "2024-01-01T00:00:00Z",
+				},
+			})
+			return
+		}
+
+		// Update marker (PUT)
+		if r.Method != http.MethodPut {
+			t.Errorf("method = %q, want PUT", r.Method)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("unmarshal request: %v", err)
+		}
+		if req["message"] != "v2.0.0" {
+			t.Errorf("message = %v, want v2.0.0", req["message"])
+		}
+		// Unchanged fields should be preserved
+		if req["type"] != "deploy" {
+			t.Errorf("type = %v, want deploy (preserved)", req["type"])
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":         "abc123",
+			"type":       "deploy",
+			"message":    "v2.0.0",
+			"start_time": 1700000000,
+			"color":      "#ff0000",
+			"created_at": "2024-01-01T00:00:00Z",
+			"updated_at": "2024-01-02T00:00:00Z",
+		})
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"update", "--dataset", "test-dataset", "abc123", "--message", "v2.0.0"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var item markerItem
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &item); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if item.Message != "v2.0.0" {
+		t.Errorf("Message = %q, want %q", item.Message, "v2.0.0")
+	}
+	if item.Type != "deploy" {
+		t.Errorf("Type = %q, want %q (preserved)", item.Type, "deploy")
+	}
+}
+
+func TestUpdate_NotFound(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"id": "abc123", "type": "deploy"},
+		})
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"update", "--dataset", "test-dataset", "zzz999", "--message", "new"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+}

--- a/cmd/marker/view.go
+++ b/cmd/marker/view.go
@@ -1,0 +1,54 @@
+package marker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/internal/api"
+	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func NewViewCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "view <marker-id>",
+		Short: "View a marker",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runMarkerView(cmd.Context(), opts, *dataset, args[0])
+		},
+	}
+}
+
+func runMarkerView(ctx context.Context, opts *options.RootOptions, dataset, markerID string) error {
+	key, err := opts.RequireKey(config.KeyConfig)
+	if err != nil {
+		return err
+	}
+
+	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
+	if err != nil {
+		return fmt.Errorf("creating API client: %w", err)
+	}
+
+	resp, err := client.GetMarkerWithResponse(ctx, dataset, keyEditor(key))
+	if err != nil {
+		return fmt.Errorf("listing markers: %w", err)
+	}
+
+	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+		return err
+	}
+
+	if resp.JSON200 == nil {
+		return fmt.Errorf("unexpected response: %s", resp.Status())
+	}
+
+	m, err := findMarker(*resp.JSON200, markerID)
+	if err != nil {
+		return err
+	}
+
+	return writeDetail(opts, markerToItem(m))
+}

--- a/cmd/marker/view_test.go
+++ b/cmd/marker/view_test.go
@@ -1,0 +1,82 @@
+package marker
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestView(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"id":         "abc123",
+				"type":       "deploy",
+				"message":    "v1.0.0",
+				"url":        "https://example.com",
+				"start_time": 1700000000,
+				"end_time":   1700000300,
+				"color":      "#ff0000",
+				"created_at": "2024-01-01T00:00:00Z",
+				"updated_at": "2024-01-01T00:00:00Z",
+			},
+			{
+				"id":      "def456",
+				"type":    "incident",
+				"message": "outage",
+			},
+		})
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"view", "--dataset", "test-dataset", "abc123"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var item markerItem
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &item); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if item.ID != "abc123" {
+		t.Errorf("ID = %q, want %q", item.ID, "abc123")
+	}
+	if item.Type != "deploy" {
+		t.Errorf("Type = %q, want %q", item.Type, "deploy")
+	}
+	if item.URL != "https://example.com" {
+		t.Errorf("URL = %q, want %q", item.URL, "https://example.com")
+	}
+}
+
+func TestView_NotFound(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"id": "abc123", "type": "deploy"},
+		})
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"view", "--dataset", "test-dataset", "zzz999"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !strings.Contains(err.Error(), `marker "zzz999" not found`) {
+		t.Errorf("error = %q, want not found message", err.Error())
+	}
+}
+
+func TestView_MissingArg(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"view", "--dataset", "test-dataset"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing arg")
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/board"
 	"github.com/bendrucker/honeycomb-cli/cmd/column"
 	"github.com/bendrucker/honeycomb-cli/cmd/dataset"
+	"github.com/bendrucker/honeycomb-cli/cmd/marker"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/cmd/slo"
 	"github.com/bendrucker/honeycomb-cli/internal/agent"
@@ -56,6 +57,7 @@ func NewRootCmd(ios *iostreams.IOStreams) *cobra.Command {
 	cmd.AddCommand(board.NewCmd(opts))
 	cmd.AddCommand(column.NewCmd(opts))
 	cmd.AddCommand(dataset.NewCmd(opts))
+	cmd.AddCommand(marker.NewCmd(opts))
 	cmd.AddCommand(slo.NewCmd(opts))
 
 	return cmd


### PR DESCRIPTION
Add `cmd/marker` package with dataset-scoped CRUD commands: `list`, `view`, `create`, `update`, and `delete`.

## Changes

- `marker list` fetches all markers for a dataset via `GetMarkerWithResponse`
- `marker view` lists all markers and filters client-side by ID (no individual GET endpoint)
- `marker create` supports `--type`, `--message`, `--url`, `--start-time`, `--end-time`, `--color` flags with interactive prompts for type and message
- `marker update` uses fetch-merge-PUT pattern to preserve unmodified fields (API is full PUT)
- `marker delete` with `--yes` flag and interactive confirmation prompt
- Key-value table output for single-item responses (view/create/update)
- Registered in `cmd/root.go`

## Testing

Tests cover list (success, empty, no key, unauthorized), view (success, not found, missing arg), create (with flags, default start time), update (merge behavior, not found), and delete (`--yes`, non-interactive error).
