### PR TITLE
cmd/column: add calculated field CRUD subcommands

### DIFF
--- a/cmd/column/calculated.go
+++ b/cmd/column/calculated.go
@@ -1,0 +1,101 @@
+package column
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/internal/api"
+	"github.com/bendrucker/honeycomb-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type calculatedItem struct {
+	ID          string `json:"id"                    yaml:"id"`
+	Alias       string `json:"alias"                 yaml:"alias"`
+	Expression  string `json:"expression"            yaml:"expression"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+}
+
+type calculatedDetail struct {
+	ID          string `json:"id"                    yaml:"id"`
+	Alias       string `json:"alias"                 yaml:"alias"`
+	Expression  string `json:"expression"            yaml:"expression"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	CreatedAt   string `json:"created_at,omitempty"  yaml:"created_at,omitempty"`
+	UpdatedAt   string `json:"updated_at,omitempty"  yaml:"updated_at,omitempty"`
+}
+
+var calculatedListTable = output.TableDef{
+	Columns: []output.Column{
+		{Header: "ID", Value: func(v any) string { return v.(calculatedItem).ID }},
+		{Header: "Alias", Value: func(v any) string { return v.(calculatedItem).Alias }},
+		{Header: "Expression", Value: func(v any) string { return v.(calculatedItem).Expression }},
+		{Header: "Description", Value: func(v any) string { return v.(calculatedItem).Description }},
+	},
+}
+
+func toCalculatedItem(f api.CalculatedField) calculatedItem {
+	item := calculatedItem{
+		Alias:      f.Alias,
+		Expression: f.Expression,
+	}
+	if f.Id != nil {
+		item.ID = *f.Id
+	}
+	if f.Description != nil {
+		item.Description = *f.Description
+	}
+	return item
+}
+
+func toCalculatedDetail(f api.CalculatedField) calculatedDetail {
+	d := calculatedDetail{
+		Alias:      f.Alias,
+		Expression: f.Expression,
+	}
+	if f.Id != nil {
+		d.ID = *f.Id
+	}
+	if f.Description != nil {
+		d.Description = *f.Description
+	}
+	if f.CreatedAt != nil {
+		d.CreatedAt = *f.CreatedAt
+	}
+	if f.UpdatedAt != nil {
+		d.UpdatedAt = *f.UpdatedAt
+	}
+	return d
+}
+
+func writeCalculatedDetail(opts *options.RootOptions, f api.CalculatedField) error {
+	d := toCalculatedDetail(f)
+	return opts.OutputWriter().WriteValue(d, func(w io.Writer) error {
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		_, _ = fmt.Fprintf(tw, "ID:\t%s\n", d.ID)
+		_, _ = fmt.Fprintf(tw, "Alias:\t%s\n", d.Alias)
+		_, _ = fmt.Fprintf(tw, "Expression:\t%s\n", d.Expression)
+		_, _ = fmt.Fprintf(tw, "Description:\t%s\n", d.Description)
+		_, _ = fmt.Fprintf(tw, "Created At:\t%s\n", d.CreatedAt)
+		_, _ = fmt.Fprintf(tw, "Updated At:\t%s\n", d.UpdatedAt)
+		return tw.Flush()
+	})
+}
+
+func NewCalculatedCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "calculated",
+		Short:   "Manage calculated fields",
+		Aliases: []string{"calc"},
+	}
+
+	cmd.AddCommand(NewCalculatedListCmd(opts, dataset))
+	cmd.AddCommand(NewCalculatedGetCmd(opts, dataset))
+	cmd.AddCommand(NewCalculatedCreateCmd(opts, dataset))
+	cmd.AddCommand(NewCalculatedUpdateCmd(opts, dataset))
+	cmd.AddCommand(NewCalculatedDeleteCmd(opts, dataset))
+
+	return cmd
+}

--- a/cmd/column/calculated_create.go
+++ b/cmd/column/calculated_create.go
@@ -1,0 +1,90 @@
+package column
+
+import (
+	"fmt"
+
+	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/internal/api"
+	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/bendrucker/honeycomb-cli/internal/prompt"
+	"github.com/spf13/cobra"
+)
+
+func NewCalculatedCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
+	var (
+		alias       string
+		expression  string
+		description string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a calculated field",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if alias == "" {
+				if !opts.IOStreams.CanPrompt() {
+					return fmt.Errorf("--alias is required in non-interactive mode")
+				}
+				var err error
+				alias, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Alias: ")
+				if err != nil {
+					return err
+				}
+			}
+
+			if expression == "" {
+				if !opts.IOStreams.CanPrompt() {
+					return fmt.Errorf("--expression is required in non-interactive mode")
+				}
+				var err error
+				expression, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Expression: ")
+				if err != nil {
+					return err
+				}
+			}
+
+			return runCalculatedCreate(cmd, opts, *dataset, alias, expression, description)
+		},
+	}
+
+	cmd.Flags().StringVar(&alias, "alias", "", "Human-readable name (required)")
+	cmd.Flags().StringVar(&expression, "expression", "", "Formula expression (required)")
+	cmd.Flags().StringVar(&description, "description", "", "Description")
+
+	return cmd
+}
+
+func runCalculatedCreate(cmd *cobra.Command, opts *options.RootOptions, dataset, alias, expression, description string) error {
+	key, err := opts.RequireKey(config.KeyConfig)
+	if err != nil {
+		return err
+	}
+
+	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
+	if err != nil {
+		return fmt.Errorf("creating API client: %w", err)
+	}
+
+	body := api.CreateCalculatedFieldJSONRequestBody{
+		Alias:      alias,
+		Expression: expression,
+	}
+	if cmd.Flags().Changed("description") {
+		body.Description = &description
+	}
+
+	resp, err := client.CreateCalculatedFieldWithResponse(cmd.Context(), api.DatasetSlugOrAll(dataset), body, keyEditor(key))
+	if err != nil {
+		return fmt.Errorf("creating calculated field: %w", err)
+	}
+
+	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+		return err
+	}
+
+	if resp.JSON201 == nil {
+		return fmt.Errorf("unexpected response: %s", resp.Status())
+	}
+
+	return writeCalculatedDetail(opts, *resp.JSON201)
+}

--- a/cmd/column/calculated_delete.go
+++ b/cmd/column/calculated_delete.go
@@ -1,0 +1,82 @@
+package column
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/internal/api"
+	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/bendrucker/honeycomb-cli/internal/prompt"
+	"github.com/spf13/cobra"
+)
+
+func NewCalculatedDeleteCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
+	var yes bool
+
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a calculated field",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCalculatedDelete(cmd.Context(), opts, *dataset, args[0], yes)
+		},
+	}
+
+	cmd.Flags().BoolVar(&yes, "yes", false, "Skip confirmation prompt")
+
+	return cmd
+}
+
+func runCalculatedDelete(ctx context.Context, opts *options.RootOptions, dataset, fieldID string, yes bool) error {
+	key, err := opts.RequireKey(config.KeyConfig)
+	if err != nil {
+		return err
+	}
+
+	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
+	if err != nil {
+		return fmt.Errorf("creating API client: %w", err)
+	}
+
+	slug := api.DatasetSlugOrAll(dataset)
+
+	if !yes {
+		if !opts.IOStreams.CanPrompt() {
+			return fmt.Errorf("--yes is required in non-interactive mode")
+		}
+
+		getResp, err := client.GetCalculatedFieldWithResponse(ctx, slug, fieldID, keyEditor(key))
+		if err != nil {
+			return fmt.Errorf("getting calculated field: %w", err)
+		}
+
+		if err := api.CheckResponse(getResp.StatusCode(), getResp.Body); err != nil {
+			return err
+		}
+
+		if getResp.JSON200 == nil {
+			return fmt.Errorf("unexpected response: %s", getResp.Status())
+		}
+
+		answer, err := prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, fmt.Sprintf("Delete calculated field %q? (y/N): ", getResp.JSON200.Alias))
+		if err != nil {
+			return err
+		}
+		if answer != "y" && answer != "Y" {
+			return fmt.Errorf("aborted")
+		}
+	}
+
+	resp, err := client.DeleteCalculatedFieldWithResponse(ctx, slug, fieldID, keyEditor(key))
+	if err != nil {
+		return fmt.Errorf("deleting calculated field: %w", err)
+	}
+
+	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(opts.IOStreams.Err, "Calculated field %s deleted\n", fieldID)
+	return nil
+}

--- a/cmd/column/calculated_get.go
+++ b/cmd/column/calculated_get.go
@@ -1,0 +1,49 @@
+package column
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/internal/api"
+	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func NewCalculatedGetCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a calculated field",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCalculatedGet(cmd.Context(), opts, *dataset, args[0])
+		},
+	}
+}
+
+func runCalculatedGet(ctx context.Context, opts *options.RootOptions, dataset, fieldID string) error {
+	key, err := opts.RequireKey(config.KeyConfig)
+	if err != nil {
+		return err
+	}
+
+	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
+	if err != nil {
+		return fmt.Errorf("creating API client: %w", err)
+	}
+
+	resp, err := client.GetCalculatedFieldWithResponse(ctx, api.DatasetSlugOrAll(dataset), fieldID, keyEditor(key))
+	if err != nil {
+		return fmt.Errorf("getting calculated field: %w", err)
+	}
+
+	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+		return err
+	}
+
+	if resp.JSON200 == nil {
+		return fmt.Errorf("unexpected response: %s", resp.Status())
+	}
+
+	return writeCalculatedDetail(opts, *resp.JSON200)
+}

--- a/cmd/column/calculated_list.go
+++ b/cmd/column/calculated_list.go
@@ -1,0 +1,62 @@
+package column
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/internal/api"
+	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func NewCalculatedListCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List calculated fields in a dataset",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runCalculatedList(cmd.Context(), opts, *dataset)
+		},
+	}
+}
+
+func runCalculatedList(ctx context.Context, opts *options.RootOptions, dataset string) error {
+	key, err := opts.RequireKey(config.KeyConfig)
+	if err != nil {
+		return err
+	}
+
+	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
+	if err != nil {
+		return fmt.Errorf("creating API client: %w", err)
+	}
+
+	resp, err := client.ListCalculatedFields(ctx, api.DatasetSlugOrAll(dataset), nil, keyEditor(key))
+	if err != nil {
+		return fmt.Errorf("listing calculated fields: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("reading response: %w", err)
+	}
+
+	if err := api.CheckResponse(resp.StatusCode, body); err != nil {
+		return err
+	}
+
+	var fields []api.CalculatedField
+	if err := json.Unmarshal(body, &fields); err != nil {
+		return fmt.Errorf("parsing response: %w", err)
+	}
+
+	items := make([]calculatedItem, len(fields))
+	for i, f := range fields {
+		items[i] = toCalculatedItem(f)
+	}
+
+	return opts.OutputWriter().Write(items, calculatedListTable)
+}

--- a/cmd/column/calculated_test.go
+++ b/cmd/column/calculated_test.go
@@ -1,0 +1,277 @@
+package column
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestCalculatedList(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/1/derived_columns/test" {
+			t.Errorf("path = %q, want /1/derived_columns/test", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"id":          "dc1",
+				"alias":       "latency_p99",
+				"expression":  "HEATMAP(duration_ms)",
+				"description": "P99 latency heatmap",
+			},
+			{
+				"id":         "dc2",
+				"alias":      "error_rate",
+				"expression": "COUNT(status_code = 500) / COUNT()",
+			},
+		})
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"--dataset", "test", "calculated", "list"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var items []calculatedItem
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &items); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("got %d items, want 2", len(items))
+	}
+	if items[0].Alias != "latency_p99" {
+		t.Errorf("items[0].Alias = %q, want %q", items[0].Alias, "latency_p99")
+	}
+	if items[0].Expression != "HEATMAP(duration_ms)" {
+		t.Errorf("items[0].Expression = %q, want %q", items[0].Expression, "HEATMAP(duration_ms)")
+	}
+	if items[1].Description != "" {
+		t.Errorf("items[1].Description = %q, want empty", items[1].Description)
+	}
+}
+
+func TestCalculatedList_Empty(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"--dataset", "test", "calculated", "list"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var items []calculatedItem
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &items); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if len(items) != 0 {
+		t.Errorf("got %d items, want 0", len(items))
+	}
+}
+
+func TestCalculatedGet(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/1/derived_columns/test/dc1" {
+			t.Errorf("path = %q, want /1/derived_columns/test/dc1", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":          "dc1",
+			"alias":       "latency_p99",
+			"expression":  "HEATMAP(duration_ms)",
+			"description": "P99 latency heatmap",
+			"created_at":  "2025-01-01T00:00:00Z",
+			"updated_at":  "2025-01-02T00:00:00Z",
+		})
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"--dataset", "test", "calculated", "get", "dc1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var detail calculatedDetail
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &detail); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if detail.ID != "dc1" {
+		t.Errorf("ID = %q, want %q", detail.ID, "dc1")
+	}
+	if detail.Alias != "latency_p99" {
+		t.Errorf("Alias = %q, want %q", detail.Alias, "latency_p99")
+	}
+	if detail.CreatedAt != "2025-01-01T00:00:00Z" {
+		t.Errorf("CreatedAt = %q, want %q", detail.CreatedAt, "2025-01-01T00:00:00Z")
+	}
+}
+
+func TestCalculatedGet_NotFound(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"not found"}`))
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"--dataset", "test", "calculated", "get", "nonexistent"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	if !strings.Contains(err.Error(), "HTTP 404") {
+		t.Errorf("error = %q, want HTTP 404", err.Error())
+	}
+}
+
+func TestCalculatedCreate(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		if r.URL.Path != "/1/derived_columns/test" {
+			t.Errorf("path = %q, want /1/derived_columns/test", r.URL.Path)
+		}
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		if body["alias"] != "latency_p99" {
+			t.Errorf("alias = %q, want %q", body["alias"], "latency_p99")
+		}
+		if body["expression"] != "HEATMAP(duration_ms)" {
+			t.Errorf("expression = %q, want %q", body["expression"], "HEATMAP(duration_ms)")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":         "dc1",
+			"alias":      "latency_p99",
+			"expression": "HEATMAP(duration_ms)",
+			"created_at": "2025-01-01T00:00:00Z",
+			"updated_at": "2025-01-01T00:00:00Z",
+		})
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"--dataset", "test", "calculated", "create", "--alias", "latency_p99", "--expression", "HEATMAP(duration_ms)"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var detail calculatedDetail
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &detail); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if detail.ID != "dc1" {
+		t.Errorf("ID = %q, want %q", detail.ID, "dc1")
+	}
+	if detail.Alias != "latency_p99" {
+		t.Errorf("Alias = %q, want %q", detail.Alias, "latency_p99")
+	}
+}
+
+func TestCalculatedUpdate(t *testing.T) {
+	calls := 0
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet:
+			calls++
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":         "dc1",
+				"alias":      "latency_p99",
+				"expression": "HEATMAP(duration_ms)",
+			})
+		case r.Method == http.MethodPut:
+			calls++
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			if body["alias"] != "latency_p99_updated" {
+				t.Errorf("alias = %q, want %q", body["alias"], "latency_p99_updated")
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":         "dc1",
+				"alias":      "latency_p99_updated",
+				"expression": "HEATMAP(duration_ms)",
+				"updated_at": "2025-01-02T00:00:00Z",
+			})
+		}
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"--dataset", "test", "calculated", "update", "dc1", "--alias", "latency_p99_updated"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if calls != 2 {
+		t.Errorf("API calls = %d, want 2 (GET + PUT)", calls)
+	}
+
+	var detail calculatedDetail
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &detail); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if detail.Alias != "latency_p99_updated" {
+		t.Errorf("Alias = %q, want %q", detail.Alias, "latency_p99_updated")
+	}
+}
+
+func TestCalculatedUpdate_NoFlags(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"--dataset", "test", "calculated", "update", "dc1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for no flags")
+	}
+	if !strings.Contains(err.Error(), "at least one") {
+		t.Errorf("error = %q, want 'at least one' message", err.Error())
+	}
+}
+
+func TestCalculatedDelete_WithYes(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("method = %q, want DELETE", r.Method)
+		}
+		if r.URL.Path != "/1/derived_columns/test/dc1" {
+			t.Errorf("path = %q, want /1/derived_columns/test/dc1", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"--dataset", "test", "calculated", "delete", "dc1", "--yes"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(ts.ErrBuf.String(), "Calculated field dc1 deleted") {
+		t.Errorf("stderr = %q, want deletion message", ts.ErrBuf.String())
+	}
+}
+
+func TestCalculatedDelete_NoYesNonInteractive(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"--dataset", "test", "calculated", "delete", "dc1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing --yes")
+	}
+	if !strings.Contains(err.Error(), "--yes is required") {
+		t.Errorf("error = %q, want '--yes is required' message", err.Error())
+	}
+}

--- a/cmd/column/calculated_update.go
+++ b/cmd/column/calculated_update.go
@@ -1,0 +1,91 @@
+package column
+
+import (
+	"fmt"
+
+	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/internal/api"
+	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func NewCalculatedUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
+	var (
+		alias       string
+		expression  string
+		description string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a calculated field",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !cmd.Flags().Changed("alias") && !cmd.Flags().Changed("expression") && !cmd.Flags().Changed("description") {
+				return fmt.Errorf("at least one of --alias, --expression, or --description is required")
+			}
+			return runCalculatedUpdate(cmd, opts, *dataset, args[0], alias, expression, description)
+		},
+	}
+
+	cmd.Flags().StringVar(&alias, "alias", "", "Human-readable name")
+	cmd.Flags().StringVar(&expression, "expression", "", "Formula expression")
+	cmd.Flags().StringVar(&description, "description", "", "Description")
+
+	return cmd
+}
+
+func runCalculatedUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, fieldID, alias, expression, description string) error {
+	key, err := opts.RequireKey(config.KeyConfig)
+	if err != nil {
+		return err
+	}
+
+	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
+	if err != nil {
+		return fmt.Errorf("creating API client: %w", err)
+	}
+
+	ctx := cmd.Context()
+	slug := api.DatasetSlugOrAll(dataset)
+
+	getResp, err := client.GetCalculatedFieldWithResponse(ctx, slug, fieldID, keyEditor(key))
+	if err != nil {
+		return fmt.Errorf("getting calculated field: %w", err)
+	}
+
+	if err := api.CheckResponse(getResp.StatusCode(), getResp.Body); err != nil {
+		return err
+	}
+
+	if getResp.JSON200 == nil {
+		return fmt.Errorf("unexpected response: %s", getResp.Status())
+	}
+
+	field := *getResp.JSON200
+
+	if cmd.Flags().Changed("alias") {
+		field.Alias = alias
+	}
+	if cmd.Flags().Changed("expression") {
+		field.Expression = expression
+	}
+	if cmd.Flags().Changed("description") {
+		field.Description = &description
+	}
+
+	resp, err := client.UpdateCalculatedFieldWithResponse(ctx, slug, fieldID, field, keyEditor(key))
+	if err != nil {
+		return fmt.Errorf("updating calculated field: %w", err)
+	}
+
+	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+		return err
+	}
+
+	if resp.JSON200 == nil {
+		return fmt.Errorf("unexpected response: %s", resp.Status())
+	}
+
+	return writeCalculatedDetail(opts, *resp.JSON200)
+}

--- a/cmd/column/column.go
+++ b/cmd/column/column.go
@@ -111,6 +111,7 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 	cmd.AddCommand(NewCreateCmd(opts, &dataset))
 	cmd.AddCommand(NewUpdateCmd(opts, &dataset))
 	cmd.AddCommand(NewDeleteCmd(opts, &dataset))
+	cmd.AddCommand(NewCalculatedCmd(opts, &dataset))
 
 	return cmd
 }


### PR DESCRIPTION
Add `column calculated` CRUD subcommands (list, get, create, update, delete) for managing calculated fields within a dataset.

## Changes

- `cmd/column/calculated.go` — parent command with display types, table def, and helpers
- `cmd/column/calculated_list.go` — list using raw body decode (union type workaround)
- `cmd/column/calculated_get.go` — get by ID
- `cmd/column/calculated_create.go` — create with `--alias`, `--expression`, `--description` flags and interactive prompts
- `cmd/column/calculated_update.go` — fetch-merge-put pattern
- `cmd/column/calculated_delete.go` — delete with `--yes` and interactive confirmation
- `cmd/column/calculated_test.go` — 9 test cases covering all subcommands

The `--dataset` persistent flag from the parent `column` command is inherited.

Closes #28
