### PR TITLE
cmd/query: add CRUD commands for query annotations

### DIFF
--- a/cmd/query/create.go
+++ b/cmd/query/create.go
@@ -1,0 +1,76 @@
+package query
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/internal/api"
+	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/bendrucker/honeycomb-cli/internal/prompt"
+	"github.com/spf13/cobra"
+)
+
+func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
+	var file string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a query annotation",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runAnnotationCreate(cmd.Context(), opts, *dataset, file)
+		},
+	}
+
+	cmd.Flags().StringVarP(&file, "file", "f", "", "Path to JSON file (- for stdin)")
+
+	return cmd
+}
+
+func runAnnotationCreate(ctx context.Context, opts *options.RootOptions, dataset, file string) error {
+	key, err := opts.RequireKey(config.KeyConfig)
+	if err != nil {
+		return err
+	}
+
+	if file == "" {
+		if !opts.IOStreams.CanPrompt() {
+			return fmt.Errorf("--file is required in non-interactive mode")
+		}
+		file, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Path to query annotation JSON file: ")
+		if err != nil {
+			return err
+		}
+		if file == "" {
+			return fmt.Errorf("file path is required")
+		}
+	}
+
+	data, err := readFile(opts, file)
+	if err != nil {
+		return err
+	}
+
+	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
+	if err != nil {
+		return fmt.Errorf("creating API client: %w", err)
+	}
+
+	resp, err := client.CreateQueryAnnotationWithBodyWithResponse(ctx, dataset, "application/json", bytes.NewReader(data), keyEditor(key))
+	if err != nil {
+		return fmt.Errorf("creating query annotation: %w", err)
+	}
+
+	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+		return err
+	}
+
+	var annotation api.QueryAnnotation
+	if err := json.Unmarshal(resp.Body, &annotation); err != nil {
+		return fmt.Errorf("parsing response: %w", err)
+	}
+
+	return writeAnnotationDetail(opts, annotationToDetail(annotation))
+}

--- a/cmd/query/create_test.go
+++ b/cmd/query/create_test.go
@@ -1,0 +1,68 @@
+package query
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestCreate_File(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/1/query_annotations/test-dataset" {
+			t.Errorf("path = %q, want /1/query_annotations/test-dataset", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		if body["name"] != "Latency Query" {
+			t.Errorf("body.name = %q, want %q", body["name"], "Latency Query")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":       "ann-new",
+			"name":     "Latency Query",
+			"query_id": "q-abc",
+		})
+	}))
+
+	ts.InBuf.WriteString(`{"name":"Latency Query","query_id":"q-abc"}`)
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"create", "--dataset", "test-dataset", "--file", "-"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var detail annotationDetail
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &detail); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if detail.ID != "ann-new" {
+		t.Errorf("ID = %q, want %q", detail.ID, "ann-new")
+	}
+	if detail.Name != "Latency Query" {
+		t.Errorf("Name = %q, want %q", detail.Name, "Latency Query")
+	}
+}
+
+func TestCreate_NoFile_NonInteractive(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"create", "--dataset", "test-dataset"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing --file")
+	}
+	if !strings.Contains(err.Error(), "--file is required") {
+		t.Errorf("error = %q, want --file required message", err.Error())
+	}
+}

--- a/cmd/query/delete.go
+++ b/cmd/query/delete.go
@@ -1,0 +1,73 @@
+package query
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/internal/api"
+	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/bendrucker/honeycomb-cli/internal/prompt"
+	"github.com/spf13/cobra"
+)
+
+func NewDeleteCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
+	var yes bool
+
+	cmd := &cobra.Command{
+		Use:   "delete <annotation-id>",
+		Short: "Delete a query annotation",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAnnotationDelete(cmd.Context(), opts, *dataset, args[0], yes)
+		},
+	}
+
+	cmd.Flags().BoolVar(&yes, "yes", false, "Skip confirmation prompt")
+
+	return cmd
+}
+
+func runAnnotationDelete(ctx context.Context, opts *options.RootOptions, dataset, annotationID string, yes bool) error {
+	key, err := opts.RequireKey(config.KeyConfig)
+	if err != nil {
+		return err
+	}
+
+	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
+	if err != nil {
+		return fmt.Errorf("creating API client: %w", err)
+	}
+
+	if !yes {
+		if !opts.IOStreams.CanPrompt() {
+			return fmt.Errorf("--yes is required in non-interactive mode")
+		}
+
+		a, err := getAnnotation(ctx, client, key, dataset, annotationID)
+		if err != nil {
+			return err
+		}
+
+		answer, err := prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, fmt.Sprintf("Delete query annotation %q? (y/N): ", a.Name))
+		if err != nil {
+			return err
+		}
+		if !strings.EqualFold(answer, "y") {
+			return fmt.Errorf("aborted")
+		}
+	}
+
+	resp, err := client.DeleteQueryAnnotationWithResponse(ctx, dataset, annotationID, keyEditor(key))
+	if err != nil {
+		return fmt.Errorf("deleting query annotation: %w", err)
+	}
+
+	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(opts.IOStreams.Err, "Query annotation %s deleted\n", annotationID)
+	return nil
+}

--- a/cmd/query/delete_test.go
+++ b/cmd/query/delete_test.go
@@ -1,0 +1,61 @@
+package query
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestDelete_Yes(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/1/query_annotations/test-dataset/ann-1" {
+			t.Errorf("path = %q, want /1/query_annotations/test-dataset/ann-1", r.URL.Path)
+		}
+		if r.Method != http.MethodDelete {
+			t.Errorf("method = %q, want DELETE", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"delete", "--dataset", "test-dataset", "--yes", "ann-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(ts.ErrBuf.String(), "Query annotation ann-1 deleted") {
+		t.Errorf("stderr = %q, want deletion confirmation", ts.ErrBuf.String())
+	}
+}
+
+func TestDelete_NoYes_NonInteractive(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"delete", "--dataset", "test-dataset", "ann-1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing --yes")
+	}
+	if !strings.Contains(err.Error(), "--yes is required") {
+		t.Errorf("error = %q, want --yes required message", err.Error())
+	}
+}
+
+func TestDelete_NotFound(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"Query Annotation not found"}`))
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"delete", "--dataset", "test-dataset", "--yes", "nonexistent"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	if !strings.Contains(err.Error(), "HTTP 404") {
+		t.Errorf("error = %q, want HTTP 404", err.Error())
+	}
+}

--- a/cmd/query/format.go
+++ b/cmd/query/format.go
@@ -1,0 +1,71 @@
+package query
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/internal/api"
+)
+
+type annotationItem struct {
+	ID      string `json:"id"              yaml:"id"`
+	Name    string `json:"name"            yaml:"name"`
+	QueryID string `json:"query_id"        yaml:"query_id"`
+	Source  string `json:"source,omitempty" yaml:"source,omitempty"`
+}
+
+type annotationDetail struct {
+	ID          string `json:"id"                    yaml:"id"`
+	Name        string `json:"name"                  yaml:"name"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	QueryID     string `json:"query_id"              yaml:"query_id"`
+	Source      string `json:"source,omitempty"       yaml:"source,omitempty"`
+	CreatedAt   string `json:"created_at,omitempty"  yaml:"created_at,omitempty"`
+	UpdatedAt   string `json:"updated_at,omitempty"  yaml:"updated_at,omitempty"`
+}
+
+func annotationToDetail(a api.QueryAnnotation) annotationDetail {
+	d := annotationDetail{
+		Name:    a.Name,
+		QueryID: a.QueryId,
+	}
+	if a.Id != nil {
+		d.ID = *a.Id
+	}
+	if a.Description != nil {
+		d.Description = *a.Description
+	}
+	if a.Source != nil {
+		d.Source = string(*a.Source)
+	}
+	if a.CreatedAt != nil {
+		d.CreatedAt = a.CreatedAt.Format(time.RFC3339)
+	}
+	if a.UpdatedAt != nil {
+		d.UpdatedAt = a.UpdatedAt.Format(time.RFC3339)
+	}
+	return d
+}
+
+func writeAnnotationDetail(opts *options.RootOptions, detail annotationDetail) error {
+	return opts.OutputWriter().WriteValue(detail, func(w io.Writer) error {
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		_, _ = fmt.Fprintf(tw, "ID:\t%s\n", detail.ID)
+		_, _ = fmt.Fprintf(tw, "Name:\t%s\n", detail.Name)
+		_, _ = fmt.Fprintf(tw, "Description:\t%s\n", detail.Description)
+		_, _ = fmt.Fprintf(tw, "Query ID:\t%s\n", detail.QueryID)
+		if detail.Source != "" {
+			_, _ = fmt.Fprintf(tw, "Source:\t%s\n", detail.Source)
+		}
+		if detail.CreatedAt != "" {
+			_, _ = fmt.Fprintf(tw, "Created At:\t%s\n", detail.CreatedAt)
+		}
+		if detail.UpdatedAt != "" {
+			_, _ = fmt.Fprintf(tw, "Updated At:\t%s\n", detail.UpdatedAt)
+		}
+		return tw.Flush()
+	})
+}

--- a/cmd/query/list.go
+++ b/cmd/query/list.go
@@ -1,0 +1,88 @@
+package query
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/internal/api"
+	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/bendrucker/honeycomb-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var annotationListTable = output.TableDef{
+	Columns: []output.Column{
+		{Header: "ID", Value: func(v any) string { return v.(annotationItem).ID }},
+		{Header: "Name", Value: func(v any) string { return v.(annotationItem).Name }},
+		{Header: "Query ID", Value: func(v any) string { return v.(annotationItem).QueryID }},
+		{Header: "Source", Value: func(v any) string { return v.(annotationItem).Source }},
+	},
+}
+
+func NewListCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
+	var includeBoardAnnotations bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List query annotations",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runAnnotationList(cmd.Context(), opts, *dataset, includeBoardAnnotations)
+		},
+	}
+
+	cmd.Flags().BoolVar(&includeBoardAnnotations, "include-board-annotations", false, "Include annotations created from boards")
+
+	return cmd
+}
+
+func runAnnotationList(ctx context.Context, opts *options.RootOptions, dataset string, includeBoardAnnotations bool) error {
+	key, err := opts.RequireKey(config.KeyConfig)
+	if err != nil {
+		return err
+	}
+
+	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
+	if err != nil {
+		return fmt.Errorf("creating API client: %w", err)
+	}
+
+	params := &api.ListQueryAnnotationsParams{}
+	if includeBoardAnnotations {
+		params.IncludeBoardAnnotations = ptr(true)
+	}
+
+	resp, err := client.ListQueryAnnotationsWithResponse(ctx, dataset, params, keyEditor(key))
+	if err != nil {
+		return fmt.Errorf("listing query annotations: %w", err)
+	}
+
+	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+		return err
+	}
+
+	if resp.JSON200 == nil {
+		return fmt.Errorf("unexpected response: %s", resp.Status())
+	}
+
+	items := make([]annotationItem, len(*resp.JSON200))
+	for i, a := range *resp.JSON200 {
+		item := annotationItem{
+			Name:    a.Name,
+			QueryID: a.QueryId,
+		}
+		if a.Id != nil {
+			item.ID = *a.Id
+		}
+		if a.Source != nil {
+			item.Source = string(*a.Source)
+		}
+		items[i] = item
+	}
+
+	return opts.OutputWriter().Write(items, annotationListTable)
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/cmd/query/list_test.go
+++ b/cmd/query/list_test.go
@@ -1,0 +1,166 @@
+package query
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/bendrucker/honeycomb-cli/internal/iostreams"
+	"github.com/bendrucker/honeycomb-cli/internal/output"
+	"github.com/zalando/go-keyring"
+)
+
+func init() {
+	keyring.MockInit()
+}
+
+func setupTest(t *testing.T, handler http.Handler) (*options.RootOptions, *iostreams.TestStreams) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	ts := iostreams.Test()
+	opts := &options.RootOptions{
+		IOStreams: ts.IOStreams,
+		Config:    &config.Config{},
+		APIUrl:    srv.URL,
+		Format:    output.FormatJSON,
+	}
+
+	if err := config.SetKey("default", config.KeyConfig, "test-key"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = config.DeleteKey("default", config.KeyConfig) })
+
+	return opts, ts
+}
+
+func TestList(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/1/query_annotations/test-dataset" {
+			t.Errorf("path = %q, want /1/query_annotations/test-dataset", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"id":       "ann-1",
+				"name":     "Latency Query",
+				"query_id": "q-abc",
+				"source":   "query",
+			},
+			{
+				"id":       "ann-2",
+				"name":     "Error Rate",
+				"query_id": "q-def",
+			},
+		})
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"list", "--dataset", "test-dataset"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var items []annotationItem
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &items); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("got %d items, want 2", len(items))
+	}
+	if items[0].Name != "Latency Query" {
+		t.Errorf("items[0].Name = %q, want %q", items[0].Name, "Latency Query")
+	}
+	if items[0].QueryID != "q-abc" {
+		t.Errorf("items[0].QueryID = %q, want %q", items[0].QueryID, "q-abc")
+	}
+	if items[0].Source != "query" {
+		t.Errorf("items[0].Source = %q, want %q", items[0].Source, "query")
+	}
+	if items[1].Source != "" {
+		t.Errorf("items[1].Source = %q, want empty", items[1].Source)
+	}
+}
+
+func TestList_Empty(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"list", "--dataset", "test-dataset"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var items []annotationItem
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &items); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if len(items) != 0 {
+		t.Errorf("got %d items, want 0", len(items))
+	}
+}
+
+func TestList_NoKey(t *testing.T) {
+	ts := iostreams.Test()
+	opts := &options.RootOptions{
+		IOStreams: ts.IOStreams,
+		Config:    &config.Config{},
+		APIUrl:    "http://localhost",
+		Format:    output.FormatJSON,
+	}
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"list", "--dataset", "test-dataset"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing key")
+	}
+	if !strings.Contains(err.Error(), "no config key configured") {
+		t.Errorf("error = %q, want missing key message", err.Error())
+	}
+}
+
+func TestList_Unauthorized(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unknown API key - check your credentials"}`))
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"list", "--dataset", "test-dataset"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for 401")
+	}
+	if !strings.Contains(err.Error(), "HTTP 401") {
+		t.Errorf("error = %q, want HTTP 401", err.Error())
+	}
+	if !strings.Contains(err.Error(), "unknown API key") {
+		t.Errorf("error = %q, want error message from body", err.Error())
+	}
+}
+
+func TestList_IncludeBoardAnnotations(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("include_board_annotations") != "true" {
+			t.Errorf("include_board_annotations param = %q, want %q", r.URL.Query().Get("include_board_annotations"), "true")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"list", "--dataset", "test-dataset", "--include-board-annotations"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/query/query.go
+++ b/cmd/query/query.go
@@ -1,0 +1,69 @@
+package query
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/internal/api"
+	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func NewCmd(opts *options.RootOptions) *cobra.Command {
+	var dataset string
+
+	cmd := &cobra.Command{
+		Use:     "query",
+		Short:   "Manage queries and saved queries",
+		Aliases: []string{"queries"},
+	}
+
+	cmd.PersistentFlags().StringVar(&dataset, "dataset", "", "Dataset slug (required)")
+	_ = cmd.MarkPersistentFlagRequired("dataset")
+
+	cmd.AddCommand(NewListCmd(opts, &dataset))
+	cmd.AddCommand(NewViewCmd(opts, &dataset))
+	cmd.AddCommand(NewCreateCmd(opts, &dataset))
+	cmd.AddCommand(NewUpdateCmd(opts, &dataset))
+	cmd.AddCommand(NewDeleteCmd(opts, &dataset))
+
+	return cmd
+}
+
+func keyEditor(key string) api.RequestEditorFn {
+	return func(_ context.Context, req *http.Request) error {
+		config.ApplyAuth(req, config.KeyConfig, key)
+		return nil
+	}
+}
+
+func readFile(opts *options.RootOptions, file string) ([]byte, error) {
+	var r io.Reader
+	if file == "-" {
+		r = opts.IOStreams.In
+	} else {
+		f, err := os.Open(file)
+		if err != nil {
+			return nil, fmt.Errorf("opening file: %w", err)
+		}
+		defer f.Close() //nolint:errcheck // best-effort close on read-only file
+		r = f
+	}
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("reading file: %w", err)
+	}
+
+	var js json.RawMessage
+	if err := json.Unmarshal(data, &js); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+
+	return data, nil
+}

--- a/cmd/query/update.go
+++ b/cmd/query/update.go
@@ -1,0 +1,126 @@
+package query
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/internal/api"
+	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func NewUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
+	var (
+		file string
+		name string
+		desc string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update <annotation-id>",
+		Short: "Update a query annotation",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAnnotationUpdate(cmd, opts, *dataset, args[0], file, name, desc)
+		},
+	}
+
+	cmd.Flags().StringVarP(&file, "file", "f", "", "Path to JSON file (- for stdin)")
+	cmd.Flags().StringVar(&name, "name", "", "Annotation name")
+	cmd.Flags().StringVar(&desc, "description", "", "Annotation description")
+
+	cmd.MarkFlagsMutuallyExclusive("file", "name")
+	cmd.MarkFlagsMutuallyExclusive("file", "description")
+
+	return cmd
+}
+
+func runAnnotationUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, annotationID, file, name, desc string) error {
+	key, err := opts.RequireKey(config.KeyConfig)
+	if err != nil {
+		return err
+	}
+
+	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
+	if err != nil {
+		return fmt.Errorf("creating API client: %w", err)
+	}
+
+	ctx := cmd.Context()
+
+	if file != "" {
+		return updateAnnotationFromFile(ctx, client, opts, key, dataset, annotationID, file)
+	}
+
+	if !cmd.Flags().Changed("name") && !cmd.Flags().Changed("description") {
+		return fmt.Errorf("--file, --name, or --description is required")
+	}
+
+	current, err := getAnnotation(ctx, client, key, dataset, annotationID)
+	if err != nil {
+		return err
+	}
+
+	if cmd.Flags().Changed("name") {
+		current.Name = name
+	}
+	if cmd.Flags().Changed("description") {
+		current.Description = &desc
+	}
+
+	resp, err := client.UpdateQueryAnnotationWithResponse(ctx, dataset, annotationID, *current, keyEditor(key))
+	if err != nil {
+		return fmt.Errorf("updating query annotation: %w", err)
+	}
+
+	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+		return err
+	}
+
+	if resp.JSON200 == nil {
+		return fmt.Errorf("unexpected response: %s", resp.Status())
+	}
+
+	return writeAnnotationDetail(opts, annotationToDetail(*resp.JSON200))
+}
+
+func updateAnnotationFromFile(ctx context.Context, client *api.ClientWithResponses, opts *options.RootOptions, key, dataset, annotationID, file string) error {
+	data, err := readFile(opts, file)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.UpdateQueryAnnotationWithBodyWithResponse(ctx, dataset, annotationID, "application/json", bytes.NewReader(data), keyEditor(key))
+	if err != nil {
+		return fmt.Errorf("updating query annotation: %w", err)
+	}
+
+	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+		return err
+	}
+
+	if resp.JSON200 == nil {
+		return fmt.Errorf("unexpected response: %s", resp.Status())
+	}
+
+	return writeAnnotationDetail(opts, annotationToDetail(*resp.JSON200))
+}
+
+func getAnnotation(ctx context.Context, client *api.ClientWithResponses, key, dataset, annotationID string) (*api.QueryAnnotation, error) {
+	resp, err := client.GetQueryAnnotationWithResponse(ctx, dataset, annotationID, keyEditor(key))
+	if err != nil {
+		return nil, fmt.Errorf("getting query annotation: %w", err)
+	}
+
+	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response: %s", resp.Status())
+	}
+
+	return resp.JSON200, nil
+}

--- a/cmd/query/update_test.go
+++ b/cmd/query/update_test.go
@@ -1,0 +1,104 @@
+package query
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestUpdate_Flags(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/1/query_annotations/test-dataset/ann-1" {
+			t.Errorf("path = %q, want /1/query_annotations/test-dataset/ann-1", r.URL.Path)
+		}
+
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "ann-1",
+				"name":     "Latency Query",
+				"query_id": "q-abc",
+			})
+		case http.MethodPut:
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			if body["name"] != "Updated Query" {
+				t.Errorf("body.name = %q, want %q", body["name"], "Updated Query")
+			}
+			if body["query_id"] != "q-abc" {
+				t.Errorf("body.query_id = %q, want %q (should be preserved)", body["query_id"], "q-abc")
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "ann-1",
+				"name":     "Updated Query",
+				"query_id": "q-abc",
+			})
+		default:
+			t.Errorf("unexpected method %q", r.Method)
+		}
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"update", "--dataset", "test-dataset", "ann-1", "--name", "Updated Query"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var detail annotationDetail
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &detail); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if detail.Name != "Updated Query" {
+		t.Errorf("Name = %q, want %q", detail.Name, "Updated Query")
+	}
+}
+
+func TestUpdate_File(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("method = %q, want PUT", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":       "ann-1",
+			"name":     "From File",
+			"query_id": "q-abc",
+		})
+	}))
+
+	ts.InBuf.WriteString(`{"name":"From File","query_id":"q-abc"}`)
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"update", "--dataset", "test-dataset", "ann-1", "--file", "-"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var detail annotationDetail
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &detail); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if detail.Name != "From File" {
+		t.Errorf("Name = %q, want %q", detail.Name, "From File")
+	}
+}
+
+func TestUpdate_NoFlags(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"update", "--dataset", "test-dataset", "ann-1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for no flags")
+	}
+	if !strings.Contains(err.Error(), "--file") {
+		t.Errorf("error = %q, want message about required flags", err.Error())
+	}
+}

--- a/cmd/query/view.go
+++ b/cmd/query/view.go
@@ -1,0 +1,127 @@
+package query
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/internal/api"
+	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+type annotationWithQuery struct {
+	annotationDetail
+	Query *api.Query `json:"query,omitempty" yaml:"query,omitempty"`
+}
+
+func NewViewCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "view <annotation-id>",
+		Short: "View a query annotation",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAnnotationView(cmd.Context(), opts, *dataset, args[0])
+		},
+	}
+}
+
+func runAnnotationView(ctx context.Context, opts *options.RootOptions, dataset, annotationID string) error {
+	key, err := opts.RequireKey(config.KeyConfig)
+	if err != nil {
+		return err
+	}
+
+	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
+	if err != nil {
+		return fmt.Errorf("creating API client: %w", err)
+	}
+
+	resp, err := client.GetQueryAnnotationWithResponse(ctx, dataset, annotationID, keyEditor(key))
+	if err != nil {
+		return fmt.Errorf("getting query annotation: %w", err)
+	}
+
+	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+		return err
+	}
+
+	if resp.JSON200 == nil {
+		return fmt.Errorf("unexpected response: %s", resp.Status())
+	}
+
+	annotation := resp.JSON200
+
+	queryResp, err := client.GetQueryWithResponse(ctx, dataset, annotation.QueryId, keyEditor(key))
+	if err != nil {
+		return fmt.Errorf("getting query: %w", err)
+	}
+
+	if err := api.CheckResponse(queryResp.StatusCode(), queryResp.Body); err != nil {
+		return err
+	}
+
+	combined := annotationWithQuery{
+		annotationDetail: annotationToDetail(*annotation),
+		Query:            queryResp.JSON200,
+	}
+
+	return opts.OutputWriter().WriteValue(combined, func(w io.Writer) error {
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		_, _ = fmt.Fprintf(tw, "ID:\t%s\n", combined.ID)
+		_, _ = fmt.Fprintf(tw, "Name:\t%s\n", combined.Name)
+		_, _ = fmt.Fprintf(tw, "Description:\t%s\n", combined.Description)
+		_, _ = fmt.Fprintf(tw, "Query ID:\t%s\n", combined.QueryID)
+		if combined.Source != "" {
+			_, _ = fmt.Fprintf(tw, "Source:\t%s\n", combined.Source)
+		}
+		if combined.CreatedAt != "" {
+			_, _ = fmt.Fprintf(tw, "Created At:\t%s\n", combined.CreatedAt)
+		}
+		if combined.UpdatedAt != "" {
+			_, _ = fmt.Fprintf(tw, "Updated At:\t%s\n", combined.UpdatedAt)
+		}
+
+		if q := combined.Query; q != nil {
+			_, _ = fmt.Fprintln(tw)
+			_, _ = fmt.Fprintln(tw, "Query:")
+			if q.TimeRange != nil {
+				_, _ = fmt.Fprintf(tw, "  Time Range:\t%ds\n", *q.TimeRange)
+			}
+			if q.Breakdowns != nil && len(*q.Breakdowns) > 0 {
+				_, _ = fmt.Fprintf(tw, "  Breakdowns:\t%s\n", strings.Join(*q.Breakdowns, ", "))
+			}
+			if q.Calculations != nil {
+				for _, calc := range *q.Calculations {
+					col := ""
+					if calc.Column.IsSpecified() && !calc.Column.IsNull() {
+						col = calc.Column.MustGet()
+					}
+					if col != "" {
+						_, _ = fmt.Fprintf(tw, "  Calculation:\t%s(%s)\n", calc.Op, col)
+					} else {
+						_, _ = fmt.Fprintf(tw, "  Calculation:\t%s\n", calc.Op)
+					}
+				}
+			}
+			if q.Filters != nil {
+				for _, f := range *q.Filters {
+					col := ""
+					if f.Column.IsSpecified() && !f.Column.IsNull() {
+						col = f.Column.MustGet()
+					}
+					val := ""
+					if f.Value != nil {
+						val = fmt.Sprintf("%v", f.Value)
+					}
+					_, _ = fmt.Fprintf(tw, "  Filter:\t%s %s %s\n", col, f.Op, val)
+				}
+			}
+		}
+
+		return tw.Flush()
+	})
+}

--- a/cmd/query/view_test.go
+++ b/cmd/query/view_test.go
@@ -1,0 +1,92 @@
+package query
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestView(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/1/query_annotations/test-dataset/ann-1":
+			_, _ = w.Write([]byte(`{
+				"id": "ann-1",
+				"name": "Latency Query",
+				"description": "P99 latency query",
+				"query_id": "q-abc",
+				"source": "query",
+				"created_at": "2025-01-15T10:30:00Z",
+				"updated_at": "2025-02-01T12:00:00Z"
+			}`))
+		case "/1/queries/test-dataset/q-abc":
+			_, _ = w.Write([]byte(`{
+				"id": "q-abc",
+				"time_range": 7200,
+				"breakdowns": ["service.name"],
+				"calculations": [{"op": "P99", "column": "duration_ms"}],
+				"filters": [{"column": "status", "op": "=", "value": "error"}]
+			}`))
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"view", "--dataset", "test-dataset", "ann-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var result annotationWithQuery
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if result.ID != "ann-1" {
+		t.Errorf("ID = %q, want %q", result.ID, "ann-1")
+	}
+	if result.Name != "Latency Query" {
+		t.Errorf("Name = %q, want %q", result.Name, "Latency Query")
+	}
+	if result.QueryID != "q-abc" {
+		t.Errorf("QueryID = %q, want %q", result.QueryID, "q-abc")
+	}
+	if result.Query == nil {
+		t.Fatal("Query is nil")
+	}
+	if result.Query.TimeRange == nil || *result.Query.TimeRange != 7200 {
+		t.Errorf("Query.TimeRange = %v, want 7200", result.Query.TimeRange)
+	}
+}
+
+func TestView_NotFound(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"Query Annotation not found"}`))
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"view", "--dataset", "test-dataset", "nonexistent"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	if !strings.Contains(err.Error(), "HTTP 404") {
+		t.Errorf("error = %q, want HTTP 404", err.Error())
+	}
+}
+
+func TestView_MissingArg(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"view", "--dataset", "test-dataset"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing arg")
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/dataset"
 	"github.com/bendrucker/honeycomb-cli/cmd/marker"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/cmd/query"
 	"github.com/bendrucker/honeycomb-cli/cmd/slo"
 	"github.com/bendrucker/honeycomb-cli/cmd/trigger"
 	"github.com/bendrucker/honeycomb-cli/internal/agent"
@@ -59,6 +60,7 @@ func NewRootCmd(ios *iostreams.IOStreams) *cobra.Command {
 	cmd.AddCommand(column.NewCmd(opts))
 	cmd.AddCommand(dataset.NewCmd(opts))
 	cmd.AddCommand(marker.NewCmd(opts))
+	cmd.AddCommand(query.NewCmd(opts))
 	cmd.AddCommand(slo.NewCmd(opts))
 	cmd.AddCommand(trigger.NewCmd(opts))
 


### PR DESCRIPTION
Adds `cmd/query/` with CRUD subcommands for query annotations (saved queries): `list`, `view`, `create`, `update`, `delete`. Follows the same patterns as `cmd/slo/`.

## Changes

- `cmd/query/query.go` — parent command with `--dataset` persistent flag, `keyEditor`, `readFile` helpers
- `cmd/query/format.go` — `annotationItem`/`annotationDetail` types, mapping function, tabwriter formatter
- `cmd/query/list.go` — list annotations with `--include-board-annotations` flag
- `cmd/query/view.go` — view annotation + fetches associated query spec (two API calls), combined output with query details
- `cmd/query/create.go` — create from `--file` / stdin JSON
- `cmd/query/update.go` — update via `--file` or `--name`/`--description` flags (mutually exclusive)
- `cmd/query/delete.go` — delete with `--yes` confirmation skip
- `cmd/root.go` — register `query.NewCmd(opts)`

## Testing

Each subcommand has table-driven tests with `httptest.NewServer` stubs covering happy paths, error cases (missing key, unauthorized, not found), and non-interactive mode validation.
