### PR TITLE
internal: extract fields and jq packages from cmd/api

### DIFF
--- a/internal/fields/fields.go
+++ b/internal/fields/fields.go
@@ -1,4 +1,4 @@
-package api
+package fields
 
 import (
 	"fmt"
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-func parseFields(raw, typed []string, stdin io.Reader) (map[string]any, error) {
+func Parse(raw, typed []string, stdin io.Reader) (map[string]any, error) {
 	result := make(map[string]any)
 
 	for _, f := range raw {
@@ -16,7 +16,7 @@ func parseFields(raw, typed []string, stdin io.Reader) (map[string]any, error) {
 		if !ok {
 			return nil, fmt.Errorf("invalid field %q (must be key=value)", f)
 		}
-		setField(result, key, val)
+		SetField(result, key, val)
 	}
 
 	for _, f := range typed {
@@ -24,17 +24,17 @@ func parseFields(raw, typed []string, stdin io.Reader) (map[string]any, error) {
 		if !ok {
 			return nil, fmt.Errorf("invalid field %q (must be key=value)", f)
 		}
-		coerced, err := coerceValue(val, stdin)
+		coerced, err := CoerceValue(val, stdin)
 		if err != nil {
 			return nil, fmt.Errorf("field %q: %w", key, err)
 		}
-		setField(result, key, coerced)
+		SetField(result, key, coerced)
 	}
 
 	return result, nil
 }
 
-func setField(m map[string]any, key string, val any) {
+func SetField(m map[string]any, key string, val any) {
 	bracket := strings.IndexByte(key, '[')
 	if bracket < 0 {
 		m[key] = val
@@ -65,10 +65,10 @@ func setField(m map[string]any, key string, val any) {
 	}
 
 	suffix := rest[close+1:]
-	setField(nested, inner+suffix, val)
+	SetField(nested, inner+suffix, val)
 }
 
-func coerceValue(s string, stdin io.Reader) (any, error) {
+func CoerceValue(s string, stdin io.Reader) (any, error) {
 	switch s {
 	case "true":
 		return true, nil

--- a/internal/fields/fields_test.go
+++ b/internal/fields/fields_test.go
@@ -1,4 +1,4 @@
-package api
+package fields
 
 import (
 	"encoding/json"
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestParseFields(t *testing.T) {
+func TestParse(t *testing.T) {
 	tests := []struct {
 		name    string
 		raw     []string
@@ -80,9 +80,9 @@ func TestParseFields(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseFields(tt.raw, tt.typed, strings.NewReader(""))
+			got, err := Parse(tt.raw, tt.typed, strings.NewReader(""))
 			if (err != nil) != tt.wantErr {
-				t.Errorf("parseFields() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if tt.wantErr {
@@ -94,19 +94,19 @@ func TestParseFields(t *testing.T) {
 				t.Fatal(err)
 			}
 			if string(b) != tt.want {
-				t.Errorf("parseFields() = %s, want %s", b, tt.want)
+				t.Errorf("Parse() = %s, want %s", b, tt.want)
 			}
 		})
 	}
 }
 
-func TestParseFields_AtFile(t *testing.T) {
+func TestParse_AtFile(t *testing.T) {
 	tmp := t.TempDir() + "/data.txt"
 	if err := os.WriteFile(tmp, []byte("file-content"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	got, err := parseFields(nil, []string{"data=@" + tmp}, strings.NewReader(""))
+	got, err := Parse(nil, []string{"data=@" + tmp}, strings.NewReader(""))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,9 +116,9 @@ func TestParseFields_AtFile(t *testing.T) {
 	}
 }
 
-func TestParseFields_AtStdin(t *testing.T) {
+func TestParse_AtStdin(t *testing.T) {
 	stdin := strings.NewReader("stdin-content")
-	got, err := parseFields(nil, []string{"data=@-"}, stdin)
+	got, err := Parse(nil, []string{"data=@-"}, stdin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,8 +128,8 @@ func TestParseFields_AtStdin(t *testing.T) {
 	}
 }
 
-func TestParseFields_AtFileMissing(t *testing.T) {
-	_, err := parseFields(nil, []string{"data=@/nonexistent/file.txt"}, strings.NewReader(""))
+func TestParse_AtFileMissing(t *testing.T) {
+	_, err := Parse(nil, []string{"data=@/nonexistent/file.txt"}, strings.NewReader(""))
 	if err == nil {
 		t.Fatal("expected error for missing file")
 	}

--- a/internal/jq/jq.go
+++ b/internal/jq/jq.go
@@ -1,4 +1,4 @@
-package api
+package jq
 
 import (
 	"encoding/json"
@@ -8,7 +8,7 @@ import (
 	"github.com/itchyny/gojq"
 )
 
-func filterJQ(input io.Reader, output io.Writer, expr string) error {
+func Filter(input io.Reader, output io.Writer, expr string) error {
 	query, err := gojq.Parse(expr)
 	if err != nil {
 		return fmt.Errorf("parsing jq expression: %w", err)

--- a/internal/jq/jq_test.go
+++ b/internal/jq/jq_test.go
@@ -1,4 +1,4 @@
-package api
+package jq
 
 import (
 	"bytes"
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestFilterJQ(t *testing.T) {
+func TestFilter(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string
@@ -67,13 +67,13 @@ func TestFilterJQ(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var out bytes.Buffer
-			err := filterJQ(strings.NewReader(tt.input), &out, tt.expr)
+			err := Filter(strings.NewReader(tt.input), &out, tt.expr)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("filterJQ() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Filter() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !tt.wantErr && out.String() != tt.want {
-				t.Errorf("filterJQ() = %q, want %q", out.String(), tt.want)
+				t.Errorf("Filter() = %q, want %q", out.String(), tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Extract `fields.Parse`, `fields.SetField`, `fields.CoerceValue` into `internal/fields` and `jq.Filter` into `internal/jq` so both `cmd/api` and the upcoming `cmd/mcp` can reuse them.
