### PR TITLE
cmd/query: fix yaml panic in query view

### DIFF
--- a/cmd/query/view.go
+++ b/cmd/query/view.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -16,6 +17,18 @@ import (
 type annotationWithQuery struct {
 	annotationDetail
 	Query *api.Query `json:"query,omitempty" yaml:"query,omitempty"`
+}
+
+func (a annotationWithQuery) MarshalYAML() (any, error) {
+	data, err := json.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
 }
 
 func NewViewCmd(opts *options.RootOptions, dataset *string) *cobra.Command {


### PR DESCRIPTION
`query view --format yaml` panics because `annotationWithQuery` embeds `*api.Query`, which contains `nullable.Nullable[T]` fields from oapi-codegen. These fields have unexported struct members that `yaml.v3` cannot marshal via reflection.

## Issue

`yaml.v3` uses reflection to traverse struct fields. When it encounters an unexported field inside `nullable.Nullable[T]`, it panics. The generated API types can't be modified since they're produced by oapi-codegen.

## Changes

Add a `MarshalYAML` method on `annotationWithQuery` that round-trips through `encoding/json` (which the generated types fully support via custom marshalers) to produce a `map[string]any`. This gives `yaml.v3` a plain map with no unexported fields.

This is the same pattern needed anywhere a generated API type with `nullable` fields is serialized to YAML.
