### PR TITLE
cmd/recipient: fix double-nested details in JSON output

### DIFF
--- a/cmd/recipient/recipient_test.go
+++ b/cmd/recipient/recipient_test.go
@@ -236,12 +236,8 @@ func TestDelete_WithYes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var result map[string]string
-	if err := json.Unmarshal(ts.OutBuf.Bytes(), &result); err != nil {
-		t.Fatalf("unmarshal output: %v", err)
-	}
-	if result["id"] != "r1" {
-		t.Errorf("id = %q, want %q", result["id"], "r1")
+	if !strings.Contains(ts.ErrBuf.String(), "Recipient r1 deleted") {
+		t.Errorf("stderr = %q, want deletion confirmation", ts.ErrBuf.String())
 	}
 }
 


### PR DESCRIPTION
The Honeycomb API returns recipient data with a top-level `details` key containing type-specific fields (`address`, `channel`, `url`, etc.). `mapToDetail()` was treating `details` like any other unknown key and collecting it into a new details map, producing `details.details` double nesting in the output.

## Changes

- Check for the `details` key explicitly in `mapToDetail()` and use its contents directly instead of wrapping it in another map
- Update `extractTarget()` to look in `d.Details` for target fields instead of navigating through the old `details.details` nested path
- Add `email_address` to the target field list (used by email recipients)
