### PR TITLE
cmd/column: fix zero timestamps in calculated column update

### DIFF
--- a/cmd/column/calculated_update.go
+++ b/cmd/column/calculated_update.go
@@ -128,6 +128,10 @@ func runCalculatedUpdate(ctx context.Context, opts *options.RootOptions, dataset
 		}
 	}
 
+	body.Id = nil
+	body.CreatedAt = nil
+	body.UpdatedAt = nil
+
 	resp, err := client.UpdateCalculatedFieldWithResponse(ctx, dataset, id, body, keyEditor(key))
 	if err != nil {
 		return fmt.Errorf("updating calculated column: %w", err)


### PR DESCRIPTION
When updating a calculated column via flags (not `--file`), the code fetches the existing field and copies the full struct as the update body. This includes read-only fields (`id`, `created_at`, `updated_at`) that the API echoes back as zero-value timestamps.

## Changes

Clear `Id`, `CreatedAt`, and `UpdatedAt` on the request body before sending the update request. These are server-managed fields that should not be included in PUT requests.
