### PR TITLE
output: remove YAML format support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ internal/
   iostreams/iostreams.go         IO abstraction with TTY detection
   agent/agent.go                 AI coding agent detection
   config/
-    config.go                    YAML config (~/.config/honeycomb/config.yaml)
+    config.go                    JSON config (~/.config/honeycomb/config.json)
     keyring.go                   OS keyring with timeout wrapper
 api.json                         Honeycomb OpenAPI 3.1 source spec
 overlay.yaml                     OpenAPI overlay for 3.1→3.0 compatibility
@@ -54,14 +54,14 @@ Run `go generate ./internal/api/...` to regenerate. The generated file is commit
 - **Error handling** — return errors, don't panic. Wrap with `fmt.Errorf("context: %w", err)`.
 - **Naming** — `NewXxx` constructors, unexported fields, `opts` for option structs.
 - **Testing** — table-driven tests with `t.Run`. Use `t.Setenv` for env vars. No testify.
-- **No Viper** — config is parsed with `gopkg.in/yaml.v3` directly.
+- **No Viper** — config is parsed with `encoding/json` directly.
 
 ## Dependencies
 
 | Package | Purpose |
 |---------|---------|
 | `spf13/cobra` | CLI framework |
-| `gopkg.in/yaml.v3` | Config parsing |
+| `encoding/json` | Config parsing (stdlib) |
 | `zalando/go-keyring` | OS keyring for secrets |
 | `mattn/go-isatty` | TTY detection |
 | `oapi-codegen/runtime` | Generated client runtime |
@@ -99,7 +99,7 @@ A Honeycomb MCP server is configured and available as a reference implementation
 
 ## Output Formats
 
-The `--format` flag supports `json`, `table`, and `yaml`. Commands should implement all three. Default is `table` in TTY, `json` otherwise.
+The `--format` flag supports `json` and `table`. Default is `table` in TTY, `json` otherwise.
 
 ## Command Design
 

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -12,16 +12,15 @@ import (
 	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 type loginResult struct {
-	Type        string `json:"type" yaml:"type"`
-	Team        string `json:"team,omitempty" yaml:"team,omitempty"`
-	Environment string `json:"environment,omitempty" yaml:"environment,omitempty"`
-	KeyID       string `json:"key_id,omitempty" yaml:"key_id,omitempty"`
-	Name        string `json:"name,omitempty" yaml:"name,omitempty"`
-	Verified    bool   `json:"verified" yaml:"verified"`
+	Type        string `json:"type"`
+	Team        string `json:"team,omitempty"`
+	Environment string `json:"environment,omitempty"`
+	KeyID       string `json:"key_id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Verified    bool   `json:"verified"`
 }
 
 func NewLoginCmd(opts *options.RootOptions) *cobra.Command {
@@ -156,8 +155,6 @@ func writeLoginResult(opts *options.RootOptions, result loginResult) error {
 		enc := json.NewEncoder(out)
 		enc.SetIndent("", "  ")
 		return enc.Encode(result)
-	case output.FormatYAML:
-		return yaml.NewEncoder(out).Encode(result)
 	case output.FormatTable:
 		if result.Verified {
 			if result.Team != "" {

--- a/cmd/auth/logout.go
+++ b/cmd/auth/logout.go
@@ -11,7 +11,7 @@ import (
 )
 
 type logoutResult struct {
-	Type string `json:"type" yaml:"type"`
+	Type string `json:"type"`
 }
 
 func NewLogoutCmd(opts *options.RootOptions) *cobra.Command {

--- a/cmd/auth/status.go
+++ b/cmd/auth/status.go
@@ -14,13 +14,13 @@ import (
 )
 
 type KeyStatus struct {
-	Type        string `json:"type" yaml:"type"`
-	Status      string `json:"status" yaml:"status"`
-	Team        string `json:"team,omitempty" yaml:"team,omitempty"`
-	Environment string `json:"environment,omitempty" yaml:"environment,omitempty"`
-	KeyID       string `json:"key_id,omitempty" yaml:"key_id,omitempty"`
-	Name        string `json:"name,omitempty" yaml:"name,omitempty"`
-	Error       string `json:"error,omitempty" yaml:"error,omitempty"`
+	Type        string `json:"type"`
+	Status      string `json:"status"`
+	Team        string `json:"team,omitempty"`
+	Environment string `json:"environment,omitempty"`
+	KeyID       string `json:"key_id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Error       string `json:"error,omitempty"`
 }
 
 var statusTable = output.TableDef{

--- a/cmd/board/board.go
+++ b/cmd/board/board.go
@@ -39,22 +39,21 @@ func keyEditor(key string) api.RequestEditorFn {
 }
 
 type boardListItem struct {
-	ID           string `json:"id"                      yaml:"id"`
-	Name         string `json:"name"                    yaml:"name"`
-	Description  string `json:"description,omitempty"    yaml:"description,omitempty"`
-	ColumnLayout string `json:"column_layout,omitempty"  yaml:"column_layout,omitempty"`
-	URL          string `json:"url,omitempty"            yaml:"url,omitempty"`
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Description  string `json:"description,omitempty"`
+	ColumnLayout string `json:"column_layout,omitempty"`
+	URL          string `json:"url,omitempty"`
 }
 
 type boardDetail struct {
-	ID           string          `json:"id"                        yaml:"id"`
-	Name         string          `json:"name"                      yaml:"name"`
-	Description  string          `json:"description,omitempty"     yaml:"description,omitempty"`
-	Type         string          `json:"type"                      yaml:"type"`
-	ColumnLayout string          `json:"column_layout,omitempty"   yaml:"column_layout,omitempty"`
-	URL          string          `json:"url,omitempty"             yaml:"url,omitempty"`
-	Panels       json.RawMessage `json:"panels,omitempty"          yaml:"-"`
-	PanelsAny    any             `json:"-"                         yaml:"panels,omitempty"`
+	ID           string          `json:"id"`
+	Name         string          `json:"name"`
+	Description  string          `json:"description,omitempty"`
+	Type         string          `json:"type"`
+	ColumnLayout string          `json:"column_layout,omitempty"`
+	URL          string          `json:"url,omitempty"`
+	Panels       json.RawMessage `json:"panels,omitempty"`
 }
 
 func writeBoardDetail(opts *options.RootOptions, detail boardDetail) error {
@@ -103,9 +102,6 @@ func boardToDetail(b api.Board) boardDetail {
 	if b.Panels != nil {
 		raw, _ := json.Marshal(b.Panels)
 		d.Panels = raw
-		var panels any
-		_ = json.Unmarshal(raw, &panels)
-		d.PanelsAny = panels
 	}
 	return d
 }

--- a/cmd/board/view.go
+++ b/cmd/board/view.go
@@ -13,15 +13,14 @@ import (
 )
 
 type viewItem struct {
-	ID   string `json:"id"   yaml:"id"`
-	Name string `json:"name" yaml:"name"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 type viewDetail struct {
-	ID         string          `json:"id"                    yaml:"id"`
-	Name       string          `json:"name"                  yaml:"name"`
-	Filters    json.RawMessage `json:"filters,omitempty"     yaml:"-"`
-	FiltersAny any             `json:"-"                     yaml:"filters,omitempty"`
+	ID      string          `json:"id"`
+	Name    string          `json:"name"`
+	Filters json.RawMessage `json:"filters,omitempty"`
 }
 
 var viewListTable = output.TableDef{
@@ -53,9 +52,6 @@ func viewResponseToDetail(v api.BoardViewResponse) viewDetail {
 	if v.Filters != nil {
 		raw, _ := json.Marshal(v.Filters)
 		d.Filters = raw
-		var filters any
-		_ = json.Unmarshal(raw, &filters)
-		d.FiltersAny = filters
 	}
 	return d
 }

--- a/cmd/column/calculated.go
+++ b/cmd/column/calculated.go
@@ -11,19 +11,19 @@ import (
 )
 
 type calculatedItem struct {
-	ID          string `json:"id"                     yaml:"id"`
-	Alias       string `json:"alias"                  yaml:"alias"`
-	Expression  string `json:"expression"             yaml:"expression"`
-	Description string `json:"description,omitempty"   yaml:"description,omitempty"`
+	ID          string `json:"id"`
+	Alias       string `json:"alias"`
+	Expression  string `json:"expression"`
+	Description string `json:"description,omitempty"`
 }
 
 type calculatedDetail struct {
-	ID          string `json:"id"                     yaml:"id"`
-	Alias       string `json:"alias"                  yaml:"alias"`
-	Expression  string `json:"expression"             yaml:"expression"`
-	Description string `json:"description,omitempty"   yaml:"description,omitempty"`
-	CreatedAt   string `json:"created_at,omitempty"    yaml:"created_at,omitempty"`
-	UpdatedAt   string `json:"updated_at,omitempty"    yaml:"updated_at,omitempty"`
+	ID          string `json:"id"`
+	Alias       string `json:"alias"`
+	Expression  string `json:"expression"`
+	Description string `json:"description,omitempty"`
+	CreatedAt   string `json:"created_at,omitempty"`
+	UpdatedAt   string `json:"updated_at,omitempty"`
 }
 
 var calculatedListTable = output.TableDef{

--- a/cmd/column/column.go
+++ b/cmd/column/column.go
@@ -15,23 +15,23 @@ import (
 )
 
 type columnItem struct {
-	ID          string `json:"id"                     yaml:"id"`
-	KeyName     string `json:"key_name"               yaml:"key_name"`
-	Type        string `json:"type,omitempty"          yaml:"type,omitempty"`
-	Description string `json:"description,omitempty"   yaml:"description,omitempty"`
-	Hidden      bool   `json:"hidden"                  yaml:"hidden"`
-	LastWritten string `json:"last_written,omitempty"  yaml:"last_written,omitempty"`
+	ID          string `json:"id"`
+	KeyName     string `json:"key_name"`
+	Type        string `json:"type,omitempty"`
+	Description string `json:"description,omitempty"`
+	Hidden      bool   `json:"hidden"`
+	LastWritten string `json:"last_written,omitempty"`
 }
 
 type columnDetail struct {
-	ID          string `json:"id"                     yaml:"id"`
-	KeyName     string `json:"key_name"               yaml:"key_name"`
-	Type        string `json:"type,omitempty"          yaml:"type,omitempty"`
-	Description string `json:"description,omitempty"   yaml:"description,omitempty"`
-	Hidden      bool   `json:"hidden"                  yaml:"hidden"`
-	LastWritten string `json:"last_written,omitempty"  yaml:"last_written,omitempty"`
-	CreatedAt   string `json:"created_at,omitempty"    yaml:"created_at,omitempty"`
-	UpdatedAt   string `json:"updated_at,omitempty"    yaml:"updated_at,omitempty"`
+	ID          string `json:"id"`
+	KeyName     string `json:"key_name"`
+	Type        string `json:"type,omitempty"`
+	Description string `json:"description,omitempty"`
+	Hidden      bool   `json:"hidden"`
+	LastWritten string `json:"last_written,omitempty"`
+	CreatedAt   string `json:"created_at,omitempty"`
+	UpdatedAt   string `json:"updated_at,omitempty"`
 }
 
 var columnListTable = output.TableDef{

--- a/cmd/dataset/get.go
+++ b/cmd/dataset/get.go
@@ -13,14 +13,14 @@ import (
 )
 
 type datasetDetail struct {
-	Name            string  `json:"name"                          yaml:"name"`
-	Slug            string  `json:"slug"                          yaml:"slug"`
-	Description     string  `json:"description,omitempty"         yaml:"description,omitempty"`
-	ExpandJsonDepth *int    `json:"expand_json_depth,omitempty"   yaml:"expand_json_depth,omitempty"`
-	Columns         *int    `json:"columns,omitempty"             yaml:"columns,omitempty"`
-	LastWritten     *string `json:"last_written,omitempty"        yaml:"last_written,omitempty"`
-	DeleteProtected bool    `json:"delete_protected"              yaml:"delete_protected"`
-	CreatedAt       string  `json:"created_at"                    yaml:"created_at"`
+	Name            string  `json:"name"`
+	Slug            string  `json:"slug"`
+	Description     string  `json:"description,omitempty"`
+	ExpandJsonDepth *int    `json:"expand_json_depth,omitempty"`
+	Columns         *int    `json:"columns,omitempty"`
+	LastWritten     *string `json:"last_written,omitempty"`
+	DeleteProtected bool    `json:"delete_protected"`
+	CreatedAt       string  `json:"created_at"`
 }
 
 func mapDatasetDetail(d *api.Dataset) datasetDetail {

--- a/cmd/dataset/list.go
+++ b/cmd/dataset/list.go
@@ -13,12 +13,12 @@ import (
 )
 
 type datasetItem struct {
-	Name        string  `json:"name"                    yaml:"name"`
-	Slug        string  `json:"slug"                    yaml:"slug"`
-	Description string  `json:"description,omitempty"   yaml:"description,omitempty"`
-	Columns     *int    `json:"columns,omitempty"       yaml:"columns,omitempty"`
-	LastWritten *string `json:"last_written,omitempty"  yaml:"last_written,omitempty"`
-	CreatedAt   string  `json:"created_at"              yaml:"created_at"`
+	Name        string  `json:"name"`
+	Slug        string  `json:"slug"`
+	Description string  `json:"description,omitempty"`
+	Columns     *int    `json:"columns,omitempty"`
+	LastWritten *string `json:"last_written,omitempty"`
+	CreatedAt   string  `json:"created_at"`
 }
 
 var datasetListTable = output.TableDef{

--- a/cmd/environment/environment.go
+++ b/cmd/environment/environment.go
@@ -43,20 +43,20 @@ func keyEditor(key string) api.RequestEditorFn {
 }
 
 type environmentItem struct {
-	ID          string `json:"id"                     yaml:"id"`
-	Name        string `json:"name"                   yaml:"name"`
-	Slug        string `json:"slug"                   yaml:"slug"`
-	Description string `json:"description,omitempty"   yaml:"description,omitempty"`
-	Color       string `json:"color,omitempty"         yaml:"color,omitempty"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Slug        string `json:"slug"`
+	Description string `json:"description,omitempty"`
+	Color       string `json:"color,omitempty"`
 }
 
 type environmentDetail struct {
-	ID              string `json:"id"                      yaml:"id"`
-	Name            string `json:"name"                    yaml:"name"`
-	Slug            string `json:"slug"                    yaml:"slug"`
-	Description     string `json:"description,omitempty"   yaml:"description,omitempty"`
-	Color           string `json:"color,omitempty"         yaml:"color,omitempty"`
-	DeleteProtected bool   `json:"delete_protected"        yaml:"delete_protected"`
+	ID              string `json:"id"`
+	Name            string `json:"name"`
+	Slug            string `json:"slug"`
+	Description     string `json:"description,omitempty"`
+	Color           string `json:"color,omitempty"`
+	DeleteProtected bool   `json:"delete_protected"`
 }
 
 func colorString(c api.Environment_Attributes_Color) string {

--- a/cmd/key/key.go
+++ b/cmd/key/key.go
@@ -43,18 +43,18 @@ func keyEditor(key string) api.RequestEditorFn {
 }
 
 type keyItem struct {
-	ID       string `json:"id"                    yaml:"id"`
-	Name     string `json:"name"                  yaml:"name"`
-	KeyType  string `json:"key_type"              yaml:"key_type"`
-	Disabled bool   `json:"disabled"              yaml:"disabled"`
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	KeyType  string `json:"key_type"`
+	Disabled bool   `json:"disabled"`
 }
 
 type keyDetail struct {
-	ID       string `json:"id"                     yaml:"id"`
-	Name     string `json:"name"                   yaml:"name"`
-	KeyType  string `json:"key_type"               yaml:"key_type"`
-	Disabled bool   `json:"disabled"               yaml:"disabled"`
-	Secret   string `json:"secret,omitempty"        yaml:"secret,omitempty"`
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	KeyType  string `json:"key_type"`
+	Disabled bool   `json:"disabled"`
+	Secret   string `json:"secret,omitempty"`
 }
 
 var keyListTable = output.TableDef{

--- a/cmd/marker/marker.go
+++ b/cmd/marker/marker.go
@@ -14,15 +14,15 @@ import (
 )
 
 type markerItem struct {
-	ID        string `json:"id"                     yaml:"id"`
-	Type      string `json:"type,omitempty"          yaml:"type,omitempty"`
-	Message   string `json:"message,omitempty"       yaml:"message,omitempty"`
-	URL       string `json:"url,omitempty"           yaml:"url,omitempty"`
-	StartTime *int   `json:"start_time,omitempty"    yaml:"start_time,omitempty"`
-	EndTime   *int   `json:"end_time,omitempty"      yaml:"end_time,omitempty"`
-	Color     string `json:"color,omitempty"         yaml:"color,omitempty"`
-	CreatedAt string `json:"created_at,omitempty"    yaml:"created_at,omitempty"`
-	UpdatedAt string `json:"updated_at,omitempty"    yaml:"updated_at,omitempty"`
+	ID        string `json:"id"`
+	Type      string `json:"type,omitempty"`
+	Message   string `json:"message,omitempty"`
+	URL       string `json:"url,omitempty"`
+	StartTime *int   `json:"start_time,omitempty"`
+	EndTime   *int   `json:"end_time,omitempty"`
+	Color     string `json:"color,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
 }
 
 var markerListTable = output.TableDef{

--- a/cmd/marker/setting.go
+++ b/cmd/marker/setting.go
@@ -11,11 +11,11 @@ import (
 )
 
 type settingItem struct {
-	ID        string `json:"id"                     yaml:"id"`
-	Type      string `json:"type"                   yaml:"type"`
-	Color     string `json:"color"                  yaml:"color"`
-	CreatedAt string `json:"created_at,omitempty"    yaml:"created_at,omitempty"`
-	UpdatedAt string `json:"updated_at,omitempty"    yaml:"updated_at,omitempty"`
+	ID        string `json:"id"`
+	Type      string `json:"type"`
+	Color     string `json:"color"`
+	CreatedAt string `json:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
 }
 
 var settingListTable = output.TableDef{

--- a/cmd/mcp/call.go
+++ b/cmd/mcp/call.go
@@ -134,14 +134,14 @@ func writeCallResult(o *callOptions, result *mcp.CallToolResult) error {
 	ios := o.root.IOStreams
 	format := o.root.ResolveFormat()
 
-	if format == "json" || format == "yaml" || o.jqExpr != "" {
+	if format == "json" || o.jqExpr != "" {
 		type contentItem struct {
-			Type string `json:"type"           yaml:"type"`
-			Text string `json:"text,omitempty" yaml:"text,omitempty"`
+			Type string `json:"type"`
+			Text string `json:"text,omitempty"`
 		}
 		type callResult struct {
-			Content []contentItem `json:"content" yaml:"content"`
-			IsError bool          `json:"isError" yaml:"isError"`
+			Content []contentItem `json:"content"`
+			IsError bool          `json:"isError"`
 		}
 
 		out := callResult{IsError: result.IsError}

--- a/cmd/query/format.go
+++ b/cmd/query/format.go
@@ -11,20 +11,20 @@ import (
 )
 
 type annotationItem struct {
-	ID      string `json:"id"              yaml:"id"`
-	Name    string `json:"name"            yaml:"name"`
-	QueryID string `json:"query_id"        yaml:"query_id"`
-	Source  string `json:"source,omitempty" yaml:"source,omitempty"`
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	QueryID string `json:"query_id"`
+	Source  string `json:"source,omitempty"`
 }
 
 type annotationDetail struct {
-	ID          string `json:"id"                    yaml:"id"`
-	Name        string `json:"name"                  yaml:"name"`
-	Description string `json:"description,omitempty" yaml:"description,omitempty"`
-	QueryID     string `json:"query_id"              yaml:"query_id"`
-	Source      string `json:"source,omitempty"       yaml:"source,omitempty"`
-	CreatedAt   string `json:"created_at,omitempty"  yaml:"created_at,omitempty"`
-	UpdatedAt   string `json:"updated_at,omitempty"  yaml:"updated_at,omitempty"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	QueryID     string `json:"query_id"`
+	Source      string `json:"source,omitempty"`
+	CreatedAt   string `json:"created_at,omitempty"`
+	UpdatedAt   string `json:"updated_at,omitempty"`
 }
 
 func annotationToDetail(a api.QueryAnnotation) annotationDetail {

--- a/cmd/query/view.go
+++ b/cmd/query/view.go
@@ -15,7 +15,7 @@ import (
 
 type annotationWithQuery struct {
 	annotationDetail
-	Query *api.Query `json:"query,omitempty" yaml:"query,omitempty"`
+	Query *api.Query `json:"query,omitempty"`
 }
 
 func NewViewCmd(opts *options.RootOptions, dataset *string) *cobra.Command {

--- a/cmd/recipient/recipient.go
+++ b/cmd/recipient/recipient.go
@@ -39,17 +39,17 @@ func keyEditor(key string) api.RequestEditorFn {
 }
 
 type recipientItem struct {
-	ID     string `json:"id"              yaml:"id"`
-	Type   string `json:"type"            yaml:"type"`
-	Target string `json:"target,omitempty" yaml:"target,omitempty"`
+	ID     string `json:"id"`
+	Type   string `json:"type"`
+	Target string `json:"target,omitempty"`
 }
 
 type recipientDetail struct {
-	ID        string         `json:"id"                    yaml:"id"`
-	Type      string         `json:"type"                  yaml:"type"`
-	Details   map[string]any `json:"details,omitempty"     yaml:"details,omitempty"`
-	CreatedAt string         `json:"created_at,omitempty"  yaml:"created_at,omitempty"`
-	UpdatedAt string         `json:"updated_at,omitempty"  yaml:"updated_at,omitempty"`
+	ID        string         `json:"id"`
+	Type      string         `json:"type"`
+	Details   map[string]any `json:"details,omitempty"`
+	CreatedAt string         `json:"created_at,omitempty"`
+	UpdatedAt string         `json:"updated_at,omitempty"`
 }
 
 func unmarshalRecipients(body []byte) ([]recipientDetail, error) {

--- a/cmd/recipient/triggers.go
+++ b/cmd/recipient/triggers.go
@@ -13,13 +13,13 @@ import (
 )
 
 type triggerItem struct {
-	ID          string `json:"id"                       yaml:"id"`
-	Name        string `json:"name"                     yaml:"name"`
-	Description string `json:"description,omitempty"    yaml:"description,omitempty"`
-	Disabled    bool   `json:"disabled"                 yaml:"disabled"`
-	Triggered   bool   `json:"triggered"                yaml:"triggered"`
-	AlertType   string `json:"alert_type,omitempty"     yaml:"alert_type,omitempty"`
-	Threshold   string `json:"threshold,omitempty"      yaml:"threshold,omitempty"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Disabled    bool   `json:"disabled"`
+	Triggered   bool   `json:"triggered"`
+	AlertType   string `json:"alert_type,omitempty"`
+	Threshold   string `json:"threshold,omitempty"`
 }
 
 var triggerListTable = output.TableDef{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,7 +54,7 @@ func NewRootCmd(ios *iostreams.IOStreams) *cobra.Command {
 	}
 
 	cmd.PersistentFlags().BoolVar(&opts.NoInteractive, "no-interactive", false, "Disable interactive prompts")
-	cmd.PersistentFlags().StringVar(&opts.Format, "format", "", "Output format: json, table, yaml")
+	cmd.PersistentFlags().StringVar(&opts.Format, "format", "", "Output format: json, table")
 	cmd.PersistentFlags().StringVar(&opts.APIUrl, "api-url", "", "Honeycomb API URL")
 	cmd.PersistentFlags().StringVar(&opts.Profile, "profile", "", "Configuration profile to use")
 

--- a/cmd/slo/burn_alert.go
+++ b/cmd/slo/burn_alert.go
@@ -7,22 +7,22 @@ import (
 )
 
 type burnAlertItem struct {
-	ID        string `json:"id"                   yaml:"id"`
-	AlertType string `json:"alert_type"           yaml:"alert_type"`
-	SloID     string `json:"slo_id,omitempty"     yaml:"slo_id,omitempty"`
-	CreatedAt string `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	ID        string `json:"id"`
+	AlertType string `json:"alert_type"`
+	SloID     string `json:"slo_id,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
 }
 
 type burnAlertDetail struct {
-	ID                                    string `json:"id"                                                  yaml:"id"`
-	AlertType                             string `json:"alert_type"                                          yaml:"alert_type"`
-	Description                           string `json:"description,omitempty"                               yaml:"description,omitempty"`
-	SloID                                 string `json:"slo_id,omitempty"                                    yaml:"slo_id,omitempty"`
-	CreatedAt                             string `json:"created_at,omitempty"                                yaml:"created_at,omitempty"`
-	UpdatedAt                             string `json:"updated_at,omitempty"                                yaml:"updated_at,omitempty"`
-	ExhaustionMinutes                     *int   `json:"exhaustion_minutes,omitempty"                        yaml:"exhaustion_minutes,omitempty"`
-	BudgetRateDecreaseThresholdPerMillion *int   `json:"budget_rate_decrease_threshold_per_million,omitempty" yaml:"budget_rate_decrease_threshold_per_million,omitempty"`
-	BudgetRateWindowMinutes               *int   `json:"budget_rate_window_minutes,omitempty"                yaml:"budget_rate_window_minutes,omitempty"`
+	ID                                    string `json:"id"`
+	AlertType                             string `json:"alert_type"`
+	Description                           string `json:"description,omitempty"`
+	SloID                                 string `json:"slo_id,omitempty"`
+	CreatedAt                             string `json:"created_at,omitempty"`
+	UpdatedAt                             string `json:"updated_at,omitempty"`
+	ExhaustionMinutes                     *int   `json:"exhaustion_minutes,omitempty"`
+	BudgetRateDecreaseThresholdPerMillion *int   `json:"budget_rate_decrease_threshold_per_million,omitempty"`
+	BudgetRateWindowMinutes               *int   `json:"budget_rate_window_minutes,omitempty"`
 }
 
 var burnAlertListTable = output.TableDef{

--- a/cmd/slo/format.go
+++ b/cmd/slo/format.go
@@ -29,29 +29,29 @@ func truncate(s string, max int) string {
 }
 
 type sloItem struct {
-	ID               string `json:"id"                        yaml:"id"`
-	Name             string `json:"name"                      yaml:"name"`
-	TargetPerMillion int    `json:"target_per_million"         yaml:"target_per_million"`
-	TimePeriodDays   int    `json:"time_period_days"           yaml:"time_period_days"`
-	SLIAlias         string `json:"sli_alias"                  yaml:"sli_alias"`
-	Description      string `json:"description,omitempty"      yaml:"description,omitempty"`
+	ID               string `json:"id"`
+	Name             string `json:"name"`
+	TargetPerMillion int    `json:"target_per_million"`
+	TimePeriodDays   int    `json:"time_period_days"`
+	SLIAlias         string `json:"sli_alias"`
+	Description      string `json:"description,omitempty"`
 }
 
 type sloDetail struct {
-	ID               string   `json:"id"                         yaml:"id"`
-	Name             string   `json:"name"                       yaml:"name"`
-	Description      string   `json:"description,omitempty"      yaml:"description,omitempty"`
-	TargetPerMillion int      `json:"target_per_million"         yaml:"target_per_million"`
-	TimePeriodDays   int      `json:"time_period_days"           yaml:"time_period_days"`
-	SLIAlias         string   `json:"sli_alias"                  yaml:"sli_alias"`
-	DatasetSlugs     []string `json:"dataset_slugs,omitempty"    yaml:"dataset_slugs,omitempty"`
-	CreatedAt        string   `json:"created_at,omitempty"       yaml:"created_at,omitempty"`
-	UpdatedAt        string   `json:"updated_at,omitempty"       yaml:"updated_at,omitempty"`
-	ResetAt          string   `json:"reset_at,omitempty"         yaml:"reset_at,omitempty"`
+	ID               string   `json:"id"`
+	Name             string   `json:"name"`
+	Description      string   `json:"description,omitempty"`
+	TargetPerMillion int      `json:"target_per_million"`
+	TimePeriodDays   int      `json:"time_period_days"`
+	SLIAlias         string   `json:"sli_alias"`
+	DatasetSlugs     []string `json:"dataset_slugs,omitempty"`
+	CreatedAt        string   `json:"created_at,omitempty"`
+	UpdatedAt        string   `json:"updated_at,omitempty"`
+	ResetAt          string   `json:"reset_at,omitempty"`
 
 	// Detailed fields (only populated with --detailed)
-	Compliance      *float64 `json:"compliance,omitempty"       yaml:"compliance,omitempty"`
-	BudgetRemaining *float64 `json:"budget_remaining,omitempty" yaml:"budget_remaining,omitempty"`
+	Compliance      *float64 `json:"compliance,omitempty"`
+	BudgetRemaining *float64 `json:"budget_remaining,omitempty"`
 }
 
 // sloDetailedResponse extends api.SLO with the detailed fields that

--- a/cmd/trigger/trigger.go
+++ b/cmd/trigger/trigger.go
@@ -38,48 +38,48 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 type triggerItem struct {
-	ID          string `json:"id"                       yaml:"id"`
-	Name        string `json:"name"                     yaml:"name"`
-	Description string `json:"description,omitempty"    yaml:"description,omitempty"`
-	Disabled    bool   `json:"disabled"                 yaml:"disabled"`
-	Triggered   bool   `json:"triggered"                yaml:"triggered"`
-	AlertType   string `json:"alert_type,omitempty"     yaml:"alert_type,omitempty"`
-	Threshold   string `json:"threshold,omitempty"      yaml:"threshold,omitempty"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Disabled    bool   `json:"disabled"`
+	Triggered   bool   `json:"triggered"`
+	AlertType   string `json:"alert_type,omitempty"`
+	Threshold   string `json:"threshold,omitempty"`
 }
 
 type triggerDetail struct {
-	ID          string            `json:"id"                       yaml:"id"`
-	Name        string            `json:"name"                     yaml:"name"`
-	Description string            `json:"description,omitempty"    yaml:"description,omitempty"`
-	DatasetSlug string            `json:"dataset_slug,omitempty"   yaml:"dataset_slug,omitempty"`
-	Disabled    bool              `json:"disabled"                 yaml:"disabled"`
-	Triggered   bool              `json:"triggered"                yaml:"triggered"`
-	AlertType   string            `json:"alert_type,omitempty"     yaml:"alert_type,omitempty"`
-	Frequency   int               `json:"frequency,omitempty"      yaml:"frequency,omitempty"`
-	Threshold   *triggerThreshold `json:"threshold,omitempty"     yaml:"threshold,omitempty"`
-	QueryID     string            `json:"query_id,omitempty"       yaml:"query_id,omitempty"`
-	HasQuery    bool              `json:"has_query,omitempty"      yaml:"has_query,omitempty"`
-	Recipients  []recipientItem   `json:"recipients,omitempty"     yaml:"recipients,omitempty"`
-	Tags        []tagItem         `json:"tags,omitempty"           yaml:"tags,omitempty"`
-	CreatedAt   string            `json:"created_at,omitempty"     yaml:"created_at,omitempty"`
-	UpdatedAt   string            `json:"updated_at,omitempty"     yaml:"updated_at,omitempty"`
+	ID          string            `json:"id"`
+	Name        string            `json:"name"`
+	Description string            `json:"description,omitempty"`
+	DatasetSlug string            `json:"dataset_slug,omitempty"`
+	Disabled    bool              `json:"disabled"`
+	Triggered   bool              `json:"triggered"`
+	AlertType   string            `json:"alert_type,omitempty"`
+	Frequency   int               `json:"frequency,omitempty"`
+	Threshold   *triggerThreshold `json:"threshold,omitempty"`
+	QueryID     string            `json:"query_id,omitempty"`
+	HasQuery    bool              `json:"has_query,omitempty"`
+	Recipients  []recipientItem   `json:"recipients,omitempty"`
+	Tags        []tagItem         `json:"tags,omitempty"`
+	CreatedAt   string            `json:"created_at,omitempty"`
+	UpdatedAt   string            `json:"updated_at,omitempty"`
 }
 
 type triggerThreshold struct {
-	Op            string  `json:"op"                        yaml:"op"`
-	Value         float64 `json:"value"                     yaml:"value"`
-	ExceededLimit int     `json:"exceeded_limit,omitempty"  yaml:"exceeded_limit,omitempty"`
+	Op            string  `json:"op"`
+	Value         float64 `json:"value"`
+	ExceededLimit int     `json:"exceeded_limit,omitempty"`
 }
 
 type recipientItem struct {
-	ID     string `json:"id,omitempty"     yaml:"id,omitempty"`
-	Type   string `json:"type,omitempty"   yaml:"type,omitempty"`
-	Target string `json:"target,omitempty" yaml:"target,omitempty"`
+	ID     string `json:"id,omitempty"`
+	Type   string `json:"type,omitempty"`
+	Target string `json:"target,omitempty"`
 }
 
 type tagItem struct {
-	Key   string `json:"key"   yaml:"key"`
-	Value string `json:"value" yaml:"value"`
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 func formatThreshold(t *api.TriggerResponse) string {

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/zalando/go-keyring v0.2.6
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -77,6 +76,7 @@ require (
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/tools v0.25.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,22 +1,23 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
-
-	"gopkg.in/yaml.v3"
 )
 
+const configFile = "config.json"
+
 type Config struct {
-	APIUrl        string              `yaml:"api_url,omitempty"`
-	MCPUrl        string              `yaml:"mcp_url,omitempty"`
-	ActiveProfile string              `yaml:"active_profile,omitempty"`
-	Profiles      map[string]*Profile `yaml:"profiles,omitempty"`
+	APIUrl        string              `json:"api_url,omitempty"`
+	MCPUrl        string              `json:"mcp_url,omitempty"`
+	ActiveProfile string              `json:"active_profile,omitempty"`
+	Profiles      map[string]*Profile `json:"profiles,omitempty"`
 }
 
 type Profile struct {
-	APIUrl string `yaml:"api_url,omitempty"`
-	MCPUrl string `yaml:"mcp_url,omitempty"`
+	APIUrl string `json:"api_url,omitempty"`
+	MCPUrl string `json:"mcp_url,omitempty"`
 }
 
 func DefaultDir() string {
@@ -28,7 +29,7 @@ func DefaultDir() string {
 }
 
 func DefaultPath() string {
-	return filepath.Join(DefaultDir(), "config.yaml")
+	return filepath.Join(DefaultDir(), configFile)
 }
 
 func Load(path string) (*Config, error) {
@@ -41,7 +42,7 @@ func Load(path string) (*Config, error) {
 	}
 
 	var cfg Config
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	if err := json.Unmarshal(data, &cfg); err != nil {
 		return nil, err
 	}
 	return &cfg, nil
@@ -52,9 +53,10 @@ func (c *Config) Save(path string) error {
 		return err
 	}
 
-	data, err := yaml.Marshal(c)
+	data, err := json.MarshalIndent(c, "", "  ")
 	if err != nil {
 		return err
 	}
+	data = append(data, '\n')
 	return os.WriteFile(path, data, 0o644)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -17,7 +17,7 @@ func TestLoadMissing(t *testing.T) {
 }
 
 func TestSaveAndLoad(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "config.yaml")
+	path := filepath.Join(t.TempDir(), configFile)
 
 	cfg := &Config{
 		APIUrl:        "https://api.honeycomb.io",

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -7,13 +7,10 @@ import (
 	"reflect"
 	"strings"
 	"text/tabwriter"
-
-	"gopkg.in/yaml.v3"
 )
 
 const (
 	FormatJSON  = "json"
-	FormatYAML  = "yaml"
 	FormatTable = "table"
 )
 
@@ -43,8 +40,6 @@ func (w *Writer) Write(data any, table TableDef) error {
 		enc := json.NewEncoder(w.out)
 		enc.SetIndent("", "  ")
 		return enc.Encode(data)
-	case FormatYAML:
-		return yaml.NewEncoder(w.out).Encode(data)
 	case FormatTable:
 		return w.writeTable(data, table)
 	default:
@@ -58,8 +53,6 @@ func (w *Writer) WriteValue(data any, writeTable func(io.Writer) error) error {
 		enc := json.NewEncoder(w.out)
 		enc.SetIndent("", "  ")
 		return enc.Encode(data)
-	case FormatYAML:
-		return yaml.NewEncoder(w.out).Encode(data)
 	case FormatTable:
 		return writeTable(w.out)
 	default:
@@ -111,8 +104,6 @@ func (w *Writer) WriteDynamic(data any, table DynamicTableDef) error {
 		enc := json.NewEncoder(w.out)
 		enc.SetIndent("", "  ")
 		return enc.Encode(data)
-	case FormatYAML:
-		return yaml.NewEncoder(w.out).Encode(data)
 	case FormatTable:
 		return w.writeDynamicTable(table)
 	default:

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 type testItem struct {
-	Name  string `json:"name" yaml:"name"`
-	Count int    `json:"count" yaml:"count"`
+	Name  string `json:"name"`
+	Count int    `json:"count"`
 }
 
 var testTable = TableDef{
@@ -36,24 +36,6 @@ func TestWrite_JSON(t *testing.T) {
 	}
 	if len(got) != 2 || got[0].Name != "a" || got[1].Count != 2 {
 		t.Errorf("got %+v", got)
-	}
-}
-
-func TestWrite_YAML(t *testing.T) {
-	var buf bytes.Buffer
-	w := New(&buf, FormatYAML)
-
-	items := []testItem{{Name: "a", Count: 1}}
-	if err := w.Write(items, testTable); err != nil {
-		t.Fatal(err)
-	}
-
-	out := buf.String()
-	if !strings.Contains(out, "name: a") {
-		t.Errorf("yaml missing 'name: a': %s", out)
-	}
-	if !strings.Contains(out, "count: 1") {
-		t.Errorf("yaml missing 'count: 1': %s", out)
 	}
 }
 
@@ -135,21 +117,6 @@ func TestWriteValue_JSON(t *testing.T) {
 	}
 	if got.Name != "a" || got.Count != 1 {
 		t.Errorf("got %+v", got)
-	}
-}
-
-func TestWriteValue_YAML(t *testing.T) {
-	var buf bytes.Buffer
-	w := New(&buf, FormatYAML)
-
-	item := testItem{Name: "b", Count: 2}
-	if err := w.WriteValue(item, nil); err != nil {
-		t.Fatal(err)
-	}
-
-	out := buf.String()
-	if !strings.Contains(out, "name: b") {
-		t.Errorf("yaml missing 'name: b': %s", out)
 	}
 }
 


### PR DESCRIPTION
Remove all YAML usage from the codebase. JSON covers machine-readable output and table covers human-readable. YAML sat awkwardly between the two and caused a `yaml.v3` panic with `nullable.Nullable[T]` types from oapi-codegen (fixed in #53 with a JSON round-trip hack). Removing YAML eliminates that class of bugs entirely.

## Changes

- Remove `FormatYAML` constant and YAML cases from `internal/output`
- Remove `yaml` struct tags from all output structs in `cmd/`
- Remove YAML-only fields (`PanelsAny`, `FiltersAny`) from board structs
- Remove `yaml.v3` import and YAML case from `cmd/auth/login.go`
- Convert `internal/config` from YAML to JSON (`config.json`), dropping the direct `yaml.v3` dependency
- Update `--format` flag help text and `CLAUDE.md`

## References

- Closes #53 