### PR TITLE
chore: add repository and license to plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,5 +4,7 @@
   "author": {
     "name": "Ben Drucker",
     "url": "https://github.com/bendrucker"
-  }
+  },
+  "repository": "https://github.com/bendrucker/honeycomb-cli",
+  "license": "MIT"
 }


### PR DESCRIPTION
Adds `repository` and `license` fields to `.claude-plugin/plugin.json` for consistency with other plugins.

Closes #63
