### PR TITLE
chore: add GoReleaser config and release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,20 @@ jobs:
           go-version-file: go.mod
       - uses: golangci/golangci-lint-action@v9
 
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: check
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,21 +1,16 @@
 version: 2
 
 builds:
-  - binary: honeycomb
+  - main: ./cmd/honeycomb
+    binary: honeycomb
     env:
       - CGO_ENABLED=0
-    goos:
-      - linux
-      - darwin
-      - windows
     goarch:
       - amd64
       - arm64
 
 archives:
-  - formats:
-      - tar.gz
-    format_overrides:
+  - format_overrides:
       - goos: windows
         formats:
           - zip


### PR DESCRIPTION
Simplifies `.goreleaser.yml` by removing defaults (`goos`, `formats: [tar.gz]`) and adding the required `main: ./cmd/honeycomb` directive. Adds a release workflow triggered on `v*` tags and a `release` CI job that runs `goreleaser check` to validate the config on every PR.

## Changes

- `.goreleaser.yml` — remove explicit `goos` and `formats` (defaults), add `main` path
- `.github/workflows/release.yml` — new workflow for publishing releases on semver tags
- `.github/workflows/ci.yml` — add `release` job running `goreleaser check`
