### PR TITLE
fix: suggest disabling delete protection on dataset delete 409

### DIFF
--- a/cmd/dataset/delete.go
+++ b/cmd/dataset/delete.go
@@ -2,6 +2,7 @@ package dataset
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -78,6 +79,10 @@ func runDatasetDelete(ctx context.Context, opts *options.RootOptions, slug strin
 	}
 
 	if err := api.CheckResponse(httpResp.StatusCode, body); err != nil {
+		var apiErr *api.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == 409 && strings.Contains(apiErr.Message, "delete protected") {
+			return fmt.Errorf("dataset %s is delete protected; disable protection first with: honeycomb dataset update %s --delete-protected=false", slug, slug)
+		}
 		return err
 	}
 


### PR DESCRIPTION
## Summary

- When `dataset delete` returns a 409 with a "delete protected" message, surfaces a clear error suggesting `honeycomb dataset update <slug> --delete-protected=false`
- Adds test for the delete-protected 409 case

Closes #79