### PR TITLE
fix: pass testing.TB to iostreams.Test for stderr logging

### DIFF
--- a/cmd/api/api_test.go
+++ b/cmd/api/api_test.go
@@ -24,7 +24,7 @@ func setupTest(t *testing.T, handler http.Handler, kt config.KeyType, key string
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -166,7 +166,7 @@ func TestRun_NonSuccess(t *testing.T) {
 }
 
 func TestRun_NoKey(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -185,7 +185,7 @@ func TestRun_NoKey(t *testing.T) {
 }
 
 func TestRun_InvalidKeyType(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -249,7 +249,7 @@ func TestRun_Paginate(t *testing.T) {
 }
 
 func TestRun_PaginateNonGET(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -284,7 +284,7 @@ func TestRun_InputStdin(t *testing.T) {
 		_, _ = w.Write([]byte(`{"received":true}`))
 	}), config.KeyIngest, "test-key")
 
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	ts.InBuf.WriteString(`{"data":[]}`)
 	opts.IOStreams = ts.IOStreams
 
@@ -515,7 +515,7 @@ func TestRun_V2_InputNotWrapped(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":{"id":"1","type":"environments","attributes":{}}}`))
 	}), config.KeyManagement, "mgmt-key")
 
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	ts.InBuf.WriteString(`{"data":{"type":"environments","attributes":{"name":"prod"}}}`)
 	opts.IOStreams = ts.IOStreams
 

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -111,7 +111,7 @@ func TestAuthLogin_Success(t *testing.T) {
 				apiURL = srv.URL
 			}
 
-			ts := iostreams.Test()
+			ts := iostreams.Test(t)
 			opts := &options.RootOptions{
 				IOStreams: ts.IOStreams,
 				Config:    &config.Config{},
@@ -154,7 +154,7 @@ func TestAuthLogin_InvalidKey(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -178,7 +178,7 @@ func TestAuthLogin_InvalidKey(t *testing.T) {
 }
 
 func TestAuthLogin_MissingKeyType(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -196,7 +196,7 @@ func TestAuthLogin_MissingKeyType(t *testing.T) {
 }
 
 func TestAuthLogin_MissingKeyID(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -214,7 +214,7 @@ func TestAuthLogin_MissingKeyID(t *testing.T) {
 }
 
 func TestAuthLogin_StdinSecret(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	ts.InBuf.WriteString("stdin-secret\n")
 
 	opts := &options.RootOptions{

--- a/cmd/auth/logout_test.go
+++ b/cmd/auth/logout_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAuthLogout_SingleKeyType(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -44,7 +44,7 @@ func TestAuthLogout_SingleKeyType(t *testing.T) {
 }
 
 func TestAuthLogout_AllKeys(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -80,7 +80,7 @@ func TestAuthLogout_AllKeys(t *testing.T) {
 }
 
 func TestAuthLogout_NoKeys(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -98,7 +98,7 @@ func TestAuthLogout_NoKeys(t *testing.T) {
 }
 
 func TestAuthLogout_KeyTypeNotFound(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -121,7 +121,7 @@ func TestAuthLogout_KeyTypeNotFound(t *testing.T) {
 }
 
 func TestAuthLogout_InvalidKeyType(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -138,7 +138,7 @@ func TestAuthLogout_InvalidKeyType(t *testing.T) {
 }
 
 func TestAuthLogout_NonDefaultProfile(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},

--- a/cmd/auth/status_test.go
+++ b/cmd/auth/status_test.go
@@ -25,7 +25,7 @@ func writeJSON(t *testing.T, w http.ResponseWriter, v any) {
 }
 
 func TestAuthStatus_NoKeys(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -43,7 +43,7 @@ func TestAuthStatus_NoKeys(t *testing.T) {
 }
 
 func TestAuthStatus_Offline(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -165,7 +165,7 @@ func TestAuthStatus_Verify(t *testing.T) {
 			srv := httptest.NewServer(tt.handler)
 			t.Cleanup(srv.Close)
 
-			ts := iostreams.Test()
+			ts := iostreams.Test(t)
 			opts := &options.RootOptions{
 				IOStreams: ts.IOStreams,
 				Config:    &config.Config{},
@@ -226,7 +226,7 @@ func TestAuthStatus_MultipleKeys(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},

--- a/cmd/board/list_test.go
+++ b/cmd/board/list_test.go
@@ -22,7 +22,7 @@ func setupTest(t *testing.T, handler http.Handler) (*options.RootOptions, *iostr
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -110,7 +110,7 @@ func TestList_Empty(t *testing.T) {
 }
 
 func TestList_NoKey(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},

--- a/cmd/column/list_test.go
+++ b/cmd/column/list_test.go
@@ -22,7 +22,7 @@ func setupTest(t *testing.T, handler http.Handler) (*options.RootOptions, *iostr
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -111,7 +111,7 @@ func TestList_Empty(t *testing.T) {
 }
 
 func TestList_NoKey(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},

--- a/cmd/dataset/definition_get_test.go
+++ b/cmd/dataset/definition_get_test.go
@@ -60,7 +60,7 @@ func TestDefinitionGet(t *testing.T) {
 }
 
 func TestDefinitionGet_NoKey(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},

--- a/cmd/dataset/list_test.go
+++ b/cmd/dataset/list_test.go
@@ -23,7 +23,7 @@ func setupTest(t *testing.T, handler http.Handler) (*options.RootOptions, *iostr
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -116,7 +116,7 @@ func TestList_Empty(t *testing.T) {
 }
 
 func TestList_NoKey(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},

--- a/cmd/dataset/update_test.go
+++ b/cmd/dataset/update_test.go
@@ -73,7 +73,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestUpdate_NoKey(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},

--- a/cmd/environment/environment_test.go
+++ b/cmd/environment/environment_test.go
@@ -22,7 +22,7 @@ func setupTest(t *testing.T, handler http.Handler) (*options.RootOptions, *iostr
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -128,7 +128,7 @@ func TestList_Empty(t *testing.T) {
 }
 
 func TestList_NoKey(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},

--- a/cmd/key/key_test.go
+++ b/cmd/key/key_test.go
@@ -22,7 +22,7 @@ func setupTest(t *testing.T, handler http.Handler) (*options.RootOptions, *iostr
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -139,7 +139,7 @@ func TestList_Empty(t *testing.T) {
 }
 
 func TestList_NoKey(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},

--- a/cmd/marker/list_test.go
+++ b/cmd/marker/list_test.go
@@ -22,7 +22,7 @@ func setupTest(t *testing.T, handler http.Handler) (*options.RootOptions, *iostr
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -114,7 +114,7 @@ func TestList_Empty(t *testing.T) {
 }
 
 func TestList_NoKey(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},

--- a/cmd/mcp/tools_test.go
+++ b/cmd/mcp/tools_test.go
@@ -46,7 +46,7 @@ func setupMCPTest(t *testing.T) (*server.MCPServer, *options.RootOptions, *iostr
 
 	srv := server.NewMCPServer("test-server", "1.0.0")
 
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},

--- a/cmd/query/list_test.go
+++ b/cmd/query/list_test.go
@@ -23,7 +23,7 @@ func setupTest(t *testing.T, handler http.Handler) (*options.RootOptions, *iostr
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -109,7 +109,7 @@ func TestList_Empty(t *testing.T) {
 }
 
 func TestList_NoKey(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},

--- a/cmd/recipient/recipient_test.go
+++ b/cmd/recipient/recipient_test.go
@@ -22,7 +22,7 @@ func setupTest(t *testing.T, handler http.Handler) (*options.RootOptions, *iostr
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -114,7 +114,7 @@ func TestList_Empty(t *testing.T) {
 }
 
 func TestList_NoKey(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},

--- a/cmd/slo/burn_alert_test.go
+++ b/cmd/slo/burn_alert_test.go
@@ -22,7 +22,7 @@ func setupBurnAlertTest(t *testing.T, handler http.Handler) (*options.RootOption
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -191,7 +191,7 @@ func TestBurnAlertDelete_RequiresYesNonInteractive(t *testing.T) {
 }
 
 func TestBurnAlertList_NoKey(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},

--- a/cmd/slo/list_test.go
+++ b/cmd/slo/list_test.go
@@ -23,7 +23,7 @@ func setupTest(t *testing.T, handler http.Handler) (*options.RootOptions, *iostr
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -113,7 +113,7 @@ func TestList_Empty(t *testing.T) {
 }
 
 func TestList_NoKey(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},

--- a/cmd/trigger/list_test.go
+++ b/cmd/trigger/list_test.go
@@ -23,7 +23,7 @@ func setupTest(t *testing.T, handler http.Handler) (*options.RootOptions, *iostr
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},
@@ -118,7 +118,7 @@ func TestList_Empty(t *testing.T) {
 }
 
 func TestList_NoKey(t *testing.T) {
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	opts := &options.RootOptions{
 		IOStreams: ts.IOStreams,
 		Config:    &config.Config{},

--- a/integration/auth_test.go
+++ b/integration/auth_test.go
@@ -91,7 +91,7 @@ func execAuthCmd(profile string, stdin []byte, args ...string) (result, error) {
 	}
 	allArgs := append(args, flags...)
 
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	if stdin != nil {
 		ts.InBuf.Write(stdin)
 	}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -254,7 +254,7 @@ func commonFlags() []string {
 func execCmd(stdin []byte, args ...string) (result, error) {
 	allArgs := append(args, commonFlags()...)
 
-	ts := iostreams.Test()
+	ts := iostreams.Test(t)
 	if stdin != nil {
 		ts.InBuf.Write(stdin)
 	}

--- a/internal/iostreams/iostreams_test.go
+++ b/internal/iostreams/iostreams_test.go
@@ -10,7 +10,7 @@ func TestSystem(t *testing.T) {
 }
 
 func TestTest(t *testing.T) {
-	ts := Test()
+	ts := Test(t)
 	if ts.CanPrompt() {
 		t.Fatal("Test streams should not be promptable")
 	}
@@ -32,7 +32,7 @@ func TestCanPrompt(t *testing.T) {
 }
 
 func TestColorEnabled(t *testing.T) {
-	ts := Test()
+	ts := Test(t)
 	if ts.ColorEnabled() {
 		t.Fatal("Test streams should not have color enabled")
 	}


### PR DESCRIPTION
## Summary

- `iostreams.Test()` now accepts `testing.TB` and tees stderr to `t.Log`, so stderr output (prompts, headers) appears in test output on failure
- Updated all 50 call sites across 22 files

Closes #84