### PR TITLE
fix: return nil from fields.Parse when no fields are specified

### DIFF
--- a/internal/fields/fields.go
+++ b/internal/fields/fields.go
@@ -9,6 +9,10 @@ import (
 )
 
 func Parse(raw, typed []string, stdin io.Reader) (map[string]any, error) {
+	if len(raw) == 0 && len(typed) == 0 {
+		return nil, nil
+	}
+
 	result := make(map[string]any)
 
 	for _, f := range raw {

--- a/internal/fields/fields_test.go
+++ b/internal/fields/fields_test.go
@@ -13,8 +13,13 @@ func TestParse(t *testing.T) {
 		raw     []string
 		typed   []string
 		want    string
+		wantNil bool
 		wantErr bool
 	}{
+		{
+			name:    "no fields returns nil",
+			wantNil: true,
+		},
 		{
 			name: "simple string field",
 			raw:  []string{"name=My Board"},
@@ -86,6 +91,12 @@ func TestParse(t *testing.T) {
 				return
 			}
 			if tt.wantErr {
+				return
+			}
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("Parse() = %v, want nil", got)
+				}
 				return
 			}
 


### PR DESCRIPTION
`fields.Parse` returned an empty `map[string]any{}` when no fields were specified. `buildRequest` serialized this as an empty JSON body `{}`, causing the API to reject PUT requests that should have had no body. The fix returns `nil` when both `raw` and `typed` slices are empty.

Closes #69
