### PR TITLE
fix: collect and store team name during auth login

### DIFF
--- a/cmd/environment/create.go
+++ b/cmd/environment/create.go
@@ -21,6 +21,9 @@ func NewCreateCmd(opts *options.RootOptions, team *string) *cobra.Command {
 		Use:   "create",
 		Short: "Create an environment",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.RequireTeam(team); err != nil {
+				return err
+			}
 			return runEnvironmentCreate(cmd, opts, *team, name, desc, color)
 		},
 	}

--- a/cmd/environment/delete.go
+++ b/cmd/environment/delete.go
@@ -20,6 +20,9 @@ func NewDeleteCmd(opts *options.RootOptions, team *string) *cobra.Command {
 		Short: "Delete an environment",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.RequireTeam(team); err != nil {
+				return err
+			}
 			return runEnvironmentDelete(cmd.Context(), opts, *team, args[0], yes)
 		},
 	}

--- a/cmd/environment/environment.go
+++ b/cmd/environment/environment.go
@@ -19,8 +19,7 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 		Aliases: []string{"environments", "env"},
 	}
 
-	cmd.PersistentFlags().StringVar(&team, "team", "", "Team slug (required)")
-	_ = cmd.MarkPersistentFlagRequired("team")
+	cmd.PersistentFlags().StringVar(&team, "team", "", "Team slug")
 
 	cmd.AddCommand(NewListCmd(opts, &team))
 	cmd.AddCommand(NewGetCmd(opts, &team))

--- a/cmd/environment/get.go
+++ b/cmd/environment/get.go
@@ -16,6 +16,9 @@ func NewGetCmd(opts *options.RootOptions, team *string) *cobra.Command {
 		Short: "Get an environment",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.RequireTeam(team); err != nil {
+				return err
+			}
 			return runEnvironmentGet(cmd.Context(), opts, *team, args[0])
 		},
 	}

--- a/cmd/environment/list.go
+++ b/cmd/environment/list.go
@@ -26,6 +26,9 @@ func NewListCmd(opts *options.RootOptions, team *string) *cobra.Command {
 		Use:   "list",
 		Short: "List environments",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.RequireTeam(team); err != nil {
+				return err
+			}
 			return runEnvironmentList(cmd.Context(), opts, *team)
 		},
 	}

--- a/cmd/environment/update.go
+++ b/cmd/environment/update.go
@@ -21,6 +21,9 @@ func NewUpdateCmd(opts *options.RootOptions, team *string) *cobra.Command {
 		Short: "Update an environment",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.RequireTeam(team); err != nil {
+				return err
+			}
 			return runEnvironmentUpdate(cmd, opts, *team, args[0], desc, color, deleteProtected)
 		},
 	}

--- a/cmd/key/create.go
+++ b/cmd/key/create.go
@@ -21,6 +21,9 @@ func NewCreateCmd(opts *options.RootOptions, team *string) *cobra.Command {
 		Use:   "create",
 		Short: "Create an API key",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.RequireTeam(team); err != nil {
+				return err
+			}
 			return runKeyCreate(cmd.Context(), opts, *team, file)
 		},
 	}

--- a/cmd/key/delete.go
+++ b/cmd/key/delete.go
@@ -19,6 +19,9 @@ func NewDeleteCmd(opts *options.RootOptions, team *string) *cobra.Command {
 		Short: "Delete an API key",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.RequireTeam(team); err != nil {
+				return err
+			}
 			return runKeyDelete(cmd.Context(), opts, *team, args[0], yes)
 		},
 	}

--- a/cmd/key/get.go
+++ b/cmd/key/get.go
@@ -16,6 +16,9 @@ func NewGetCmd(opts *options.RootOptions, team *string) *cobra.Command {
 		Short: "Get an API key",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.RequireTeam(team); err != nil {
+				return err
+			}
 			return runKeyGet(cmd.Context(), opts, *team, args[0])
 		},
 	}

--- a/cmd/key/key.go
+++ b/cmd/key/key.go
@@ -21,8 +21,7 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 		Aliases: []string{"keys"},
 	}
 
-	cmd.PersistentFlags().StringVar(&team, "team", "", "Team slug (required)")
-	_ = cmd.MarkPersistentFlagRequired("team")
+	cmd.PersistentFlags().StringVar(&team, "team", "", "Team slug")
 
 	cmd.AddCommand(NewListCmd(opts, &team))
 	cmd.AddCommand(NewGetCmd(opts, &team))

--- a/cmd/key/list.go
+++ b/cmd/key/list.go
@@ -17,6 +17,9 @@ func NewListCmd(opts *options.RootOptions, team *string) *cobra.Command {
 		Use:   "list",
 		Short: "List API keys",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.RequireTeam(team); err != nil {
+				return err
+			}
 			return runKeyList(cmd.Context(), opts, *team, filterType)
 		},
 	}

--- a/cmd/key/update.go
+++ b/cmd/key/update.go
@@ -19,6 +19,9 @@ func NewUpdateCmd(opts *options.RootOptions, team *string) *cobra.Command {
 		Short: "Update an API key",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.RequireTeam(team); err != nil {
+				return err
+			}
 			return runKeyUpdate(cmd.Context(), opts, *team, args[0], file)
 		},
 	}

--- a/cmd/options/options.go
+++ b/cmd/options/options.go
@@ -22,6 +22,7 @@ type RootOptions struct {
 	APIUrl        string
 	MCPUrl        string
 	Profile       string
+	ConfigPath    string
 }
 
 const defaultAPIUrl = "https://api.honeycomb.io"
@@ -35,6 +36,27 @@ func (o *RootOptions) ActiveProfile() string {
 		return o.Config.ActiveProfile
 	}
 	return "default"
+}
+
+func (o *RootOptions) ResolveConfigPath() string {
+	if o.ConfigPath != "" {
+		return o.ConfigPath
+	}
+	return config.DefaultPath()
+}
+
+func (o *RootOptions) RequireTeam(flag *string) error {
+	if *flag != "" {
+		return nil
+	}
+	if o.Config != nil {
+		profile := o.ActiveProfile()
+		if p, ok := o.Config.Profiles[profile]; ok && p.Team != "" {
+			*flag = p.Team
+			return nil
+		}
+	}
+	return fmt.Errorf("--team is required (or set via honeycomb auth login --team)")
 }
 
 func (o *RootOptions) ResolveFormat() string {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,8 @@ func NewRootCmd(ios *iostreams.IOStreams) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
-			cfg, err := config.Load(config.DefaultPath())
+			opts.ConfigPath = config.DefaultPath()
+			cfg, err := config.Load(opts.ConfigPath)
 			if err != nil {
 				return err
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 type Profile struct {
 	APIUrl string `json:"api_url,omitempty"`
 	MCPUrl string `json:"mcp_url,omitempty"`
+	Team   string `json:"team,omitempty"`
 }
 
 func DefaultDir() string {
@@ -46,6 +47,16 @@ func Load(path string) (*Config, error) {
 		return nil, err
 	}
 	return &cfg, nil
+}
+
+func (c *Config) EnsureProfile(name string) *Profile {
+	if c.Profiles == nil {
+		c.Profiles = make(map[string]*Profile)
+	}
+	if c.Profiles[name] == nil {
+		c.Profiles[name] = &Profile{}
+	}
+	return c.Profiles[name]
 }
 
 func (c *Config) Save(path string) error {


### PR DESCRIPTION
Adds a `--team` flag to `auth login` for management keys (with interactive prompt support) and stores the team name in the config profile. Commands that require a team slug (`environment`, `key`) now resolve it from the config via `RequireTeam()` instead of requiring `--team` as a mandatory flag.

Closes #78
