### PR TITLE
fix: add --name, --key-type, --environment flags to key create

### DIFF
--- a/cmd/key/create.go
+++ b/cmd/key/create.go
@@ -11,11 +11,17 @@ import (
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
+	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
 func NewCreateCmd(opts *options.RootOptions, team *string) *cobra.Command {
-	var file string
+	var (
+		file        string
+		name        string
+		keyType     string
+		environment string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -24,17 +30,30 @@ func NewCreateCmd(opts *options.RootOptions, team *string) *cobra.Command {
 			if err := opts.RequireTeam(team); err != nil {
 				return err
 			}
-			return runKeyCreate(cmd.Context(), opts, *team, file)
+			return runKeyCreate(cmd, opts, *team, file, name, keyType, environment)
 		},
 	}
 
 	cmd.Flags().StringVarP(&file, "file", "f", "", "Path to JSON:API request body (- for stdin)")
-	_ = cmd.MarkFlagRequired("file")
+	cmd.Flags().StringVar(&name, "name", "", "Key name")
+	cmd.Flags().StringVar(&keyType, "key-type", "", "Key type (ingest or configuration)")
+	cmd.Flags().StringVar(&environment, "environment", "", "Environment ID")
+
+	cmd.MarkFlagsMutuallyExclusive("file", "name")
+	cmd.MarkFlagsMutuallyExclusive("file", "key-type")
+	cmd.MarkFlagsMutuallyExclusive("file", "environment")
 
 	return cmd
 }
 
-func runKeyCreate(ctx context.Context, opts *options.RootOptions, team, file string) error {
+func runKeyCreate(cmd *cobra.Command, opts *options.RootOptions, team, file, name, keyType, environment string) error {
+	if file != "" {
+		return runKeyCreateFromFile(cmd.Context(), opts, team, file)
+	}
+	return runKeyCreateFromFlags(cmd, opts, team, name, keyType, environment)
+}
+
+func runKeyCreateFromFile(ctx context.Context, opts *options.RootOptions, team, file string) error {
 	auth, err := opts.KeyEditor(config.KeyManagement)
 	if err != nil {
 		return err
@@ -55,6 +74,97 @@ func runKeyCreate(ctx context.Context, opts *options.RootOptions, team, file str
 		return fmt.Errorf("creating API key: %w", err)
 	}
 
+	return handleCreateResponse(opts, resp)
+}
+
+func runKeyCreateFromFlags(cmd *cobra.Command, opts *options.RootOptions, team, name, keyType, environment string) error {
+	var err error
+
+	if name == "" {
+		if !opts.IOStreams.CanPrompt() {
+			return fmt.Errorf("--name is required in non-interactive mode")
+		}
+		name, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Key name: ")
+		if err != nil {
+			return err
+		}
+		if name == "" {
+			return fmt.Errorf("key name is required")
+		}
+	}
+
+	if keyType == "" {
+		if !opts.IOStreams.CanPrompt() {
+			return fmt.Errorf("--key-type is required in non-interactive mode")
+		}
+		keyType, err = prompt.Choice(opts.IOStreams.Err, opts.IOStreams.In, "Key type (ingest, configuration): ", []string{"ingest", "configuration"})
+		if err != nil {
+			return err
+		}
+	}
+
+	if keyType != "ingest" && keyType != "configuration" {
+		return fmt.Errorf("--key-type must be ingest or configuration")
+	}
+
+	if environment == "" {
+		if !opts.IOStreams.CanPrompt() {
+			return fmt.Errorf("--environment is required in non-interactive mode")
+		}
+		environment, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Environment ID: ")
+		if err != nil {
+			return err
+		}
+		if environment == "" {
+			return fmt.Errorf("environment ID is required")
+		}
+	}
+
+	auth, err := opts.KeyEditor(config.KeyManagement)
+	if err != nil {
+		return err
+	}
+
+	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
+	if err != nil {
+		return fmt.Errorf("creating API client: %w", err)
+	}
+
+	body := api.ApiKeyCreateRequest{}
+	body.Data.Type = api.ApiKeyCreateRequestDataTypeApiKeys
+	body.Data.Relationships.Environment = api.EnvironmentRelationship{
+		Data: struct {
+			Id   string                              `json:"id"`
+			Type api.EnvironmentRelationshipDataType `json:"type"`
+		}{
+			Id:   environment,
+			Type: api.EnvironmentRelationshipDataTypeEnvironments,
+		},
+	}
+
+	switch keyType {
+	case "ingest":
+		err = body.Data.Attributes.FromIngestKeyAttributes(api.IngestKeyAttributes{
+			Name: name,
+		})
+	case "configuration":
+		err = body.Data.Attributes.FromConfigurationKeyAttributes(api.ConfigurationKeyAttributes{
+			Name: name,
+		})
+	}
+	if err != nil {
+		return fmt.Errorf("building request: %w", err)
+	}
+
+	resp, err := client.CreateApiKeyWithApplicationVndAPIPlusJSONBodyWithResponse(cmd.Context(), api.TeamSlug(team), body, auth)
+	if err != nil {
+		return fmt.Errorf("creating API key: %w", err)
+	}
+
+	return handleCreateResponse(opts, resp)
+}
+
+func handleCreateResponse(opts *options.RootOptions, resp *api.CreateApiKeyResp) error {
 	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds `--name`, `--key-type`, and `--environment` flags to `key create` so users can create API keys without manually constructing the JSON:API envelope. The new flags are mutually exclusive with `-f`. In interactive mode, missing values are prompted.

Closes #81
