### PR TITLE
docs: document preset_filters alias field in board create/update

### DIFF
--- a/cmd/board/create.go
+++ b/cmd/board/create.go
@@ -24,6 +24,13 @@ func NewCreateCmd(opts *options.RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a board",
+		Long: `Create a board.
+
+Use --file to provide a full board definition as JSON. The preset_filters array
+requires both "column" (the column name) and "alias" (a display label, max 50
+characters) for each entry:
+
+  {"preset_filters": [{"column": "service.name", "alias": "Service"}]}`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runBoardCreate(cmd, opts, file, name, desc)
 		},

--- a/cmd/board/update.go
+++ b/cmd/board/update.go
@@ -25,7 +25,14 @@ func NewUpdateCmd(opts *options.RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update <board-id>",
 		Short: "Update a board",
-		Args:  cobra.ExactArgs(1),
+		Long: `Update a board.
+
+Use --file to provide a full or partial board definition as JSON. The
+preset_filters array requires both "column" (the column name) and "alias"
+(a display label, max 50 characters) for each entry:
+
+  {"preset_filters": [{"column": "service.name", "alias": "Service"}]}`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runBoardUpdate(cmd, opts, args[0], file, replace, name, desc)
 		},


### PR DESCRIPTION
Adds `Long` descriptions to `board create` and `board update` documenting the `preset_filters` schema, including the required `alias` field (max 50 characters) that must accompany each filter column.

Closes #71
