### PR TITLE
fix: surface type_detail field errors in API error responses

### DIFF
--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -27,8 +27,12 @@ func CheckResponse(statusCode int, body []byte) error {
 	apiErr := &APIError{StatusCode: statusCode}
 
 	var parsed struct {
-		Error  *string `json:"error"`
-		Detail *string `json:"detail"`
+		Error      *string `json:"error"`
+		Detail     *string `json:"detail"`
+		TypeDetail []struct {
+			Field       string `json:"field"`
+			Description string `json:"description"`
+		} `json:"type_detail"`
 	}
 	if json.Unmarshal(body, &parsed) == nil {
 		switch {
@@ -36,6 +40,14 @@ func CheckResponse(statusCode int, body []byte) error {
 			apiErr.Message = *parsed.Error
 		case parsed.Detail != nil:
 			apiErr.Message = *parsed.Detail
+		}
+
+		if len(parsed.TypeDetail) > 0 {
+			details := make([]string, len(parsed.TypeDetail))
+			for i, d := range parsed.TypeDetail {
+				details[i] = d.Field + " " + d.Description
+			}
+			apiErr.Message += ": " + strings.Join(details, ", ")
 		}
 	}
 

--- a/internal/api/response_test.go
+++ b/internal/api/response_test.go
@@ -70,6 +70,20 @@ func TestCheckResponse(t *testing.T) {
 			wantMsg:    "bad request",
 		},
 		{
+			name:       "422 with error and type detail",
+			statusCode: 422,
+			body:       `{"error":"The provided input is invalid.","type_detail":[{"field":"name","description":"is required"},{"field":"slug","description":"is invalid"}]}`,
+			wantCode:   422,
+			wantMsg:    "The provided input is invalid.: name is required, slug is invalid",
+		},
+		{
+			name:       "422 with error and empty type detail",
+			statusCode: 422,
+			body:       `{"error":"The provided input is invalid.","type_detail":[]}`,
+			wantCode:   422,
+			wantMsg:    "The provided input is invalid.",
+		},
+		{
 			name:       "500 with empty body",
 			statusCode: 500,
 			body:       "",


### PR DESCRIPTION
Parse `type_detail` field from API error responses in `CheckResponse`, appending field-level validation details (e.g., field name + description) to the error message. This surfaces the specific validation failures from 422 responses instead of showing only the generic error string.

Closes #68
