### PR TITLE
integration: expand SLO test coverage and add direct mode

### DIFF
--- a/.claude/skills/slo/SKILL.md
+++ b/.claude/skills/slo/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: slo
+description: Working with Honeycomb SLOs, burn alerts, and SLO history
+---
+
+# SLO Commands
+
+Dependency chain: derived column (SLI) → SLO → burn alert. All commands require `--dataset`.
+
+`target_per_million`: 99.9% = 999000, 99% = 990000, 95% = 950000.
+
+## SLO CRUD
+
+- `slo create -f -` (file-only, no flags yet — see #109)
+- `slo update <id> --name/--description/--target/--time-period` (flag-based, read-modify-write) or `-f` (mutually exclusive)
+- `slo get <id>` / `slo get <id> --detailed` (Enterprise-only)
+- `slo list` / `slo delete <id> --yes`
+
+Create body: `{"name":"...","sli":{"alias":"<derived-column-alias>"},"time_period_days":30,"target_per_million":999000}`
+
+## Burn Alerts
+
+Create/update require `recipients` (non-empty array of `{"id":"..."}`) and `slo` as `{"id":"..."}` (nested, not flat `slo_id`).
+
+Exhaustion time: `{"alert_type":"exhaustion_time","exhaustion_minutes":240,"slo":{"id":"..."},"recipients":[{"id":"..."}]}`
+
+Budget rate: `{"alert_type":"budget_rate","budget_rate_window_minutes":60,"budget_rate_decrease_threshold_per_million":50000,"slo":{"id":"..."},"recipients":[{"id":"..."}]}`
+
+All burn alert commands are file-only (`-f`), no flags yet (#110, #111).
+
+## SLO History
+
+`slo history --slo-id <id> --start-time <unix> --end-time <unix>` — `--slo-id` is repeatable. Response is a map keyed by SLO ID.

--- a/integration/helpers_test.go
+++ b/integration/helpers_test.go
@@ -62,6 +62,15 @@ func skipWithoutPro(t *testing.T) {
 	}
 }
 
+func toJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshaling JSON: %v", err)
+	}
+	return data
+}
+
 func writeTemp(t *testing.T, data []byte) string {
 	t.Helper()
 	f, err := os.CreateTemp(t.TempDir(), "integration-*.json")


### PR DESCRIPTION
First e2e validation of SLO commands against a live Pro account. Expands integration test coverage, fixes broken burn alert request format, and adds a direct mode for running tests without a management key.

## Changes

- Fix `TestBurnAlert` request bodies to use `slo.id` (nested) + `recipients` (required array) instead of flat `slo_id`
- Add `TestSLO/update-from-file` subtest — update via `-f` with a temp file
- Add `TestSLO/delete` — use its own derived column to avoid SLI alias conflicts
- Add `TestBurnAlert/update` subtest — change `exhaustion_minutes`, verify new value
- Add `TestBurnAlert/budget-rate` subtest — create `budget_rate` alert, verify `alert_type` and fields
- Add `TestSLOHistory` — create SLO, query history, validate response structure
- Add `toJSON` helper in `helpers_test.go` to replace `fmt.Sprintf` JSON generation
- Add direct mode to `TestMain` — set `HONEYCOMB_DATASET` (and optionally `HONEYCOMB_PROFILE`) to skip management key/environment/dataset setup
- Add `.claude/skills/slo/SKILL.md` project skill

## Testing

All 14 subtests pass against the `whirlai` Pro account in direct mode:

```
HONEYCOMB_TEAM=whirlai HONEYCOMB_DATASET=api go test -tags integration -count=1 -v \
  -run "TestSLO|TestBurnAlert|TestSLOHistory" ./integration/
```

## References

- #106 — apply `toJSON` to remaining integration test files
- #107 — document direct mode
