### PR TITLE
fix: sanitize invalid JSON escape sequences from stdin input

### DIFF
--- a/cmd/board/board.go
+++ b/cmd/board/board.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
+	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
 	"github.com/bendrucker/honeycomb-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -64,6 +65,11 @@ func readBoardJSON(r io.Reader) (api.Board, error) {
 	data, err := io.ReadAll(r)
 	if err != nil {
 		return api.Board{}, fmt.Errorf("reading input: %w", err)
+	}
+
+	data, err = jsonutil.Sanitize(data)
+	if err != nil {
+		return api.Board{}, fmt.Errorf("parsing board JSON: %w", err)
 	}
 
 	var board api.Board

--- a/cmd/board/create.go
+++ b/cmd/board/create.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
 	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
@@ -122,6 +123,11 @@ func createFromFile(ctx context.Context, client *api.ClientWithResponses, opts *
 	raw, err := io.ReadAll(r)
 	if err != nil {
 		return fmt.Errorf("reading file: %w", err)
+	}
+
+	raw, err = jsonutil.Sanitize(raw)
+	if err != nil {
+		return fmt.Errorf("invalid JSON: %w", err)
 	}
 
 	data, err := api.StripReadOnly(raw, "Board")

--- a/cmd/board/update.go
+++ b/cmd/board/update.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
 	"github.com/spf13/cobra"
 )
 
@@ -134,6 +135,11 @@ func updateFromFile(ctx context.Context, client *api.ClientWithResponses, opts *
 		if fillErr != nil {
 			return fillErr
 		}
+		sanitized, sanitizeErr := jsonutil.Sanitize(data)
+		if sanitizeErr != nil {
+			return fmt.Errorf("invalid JSON: %w", sanitizeErr)
+		}
+		data = sanitized
 	} else {
 		incoming, err := readBoardJSON(r)
 		if err != nil {

--- a/cmd/board/view_create.go
+++ b/cmd/board/view_create.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
 	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
@@ -135,6 +136,11 @@ func createViewFromFile(ctx context.Context, client *api.ClientWithResponses, op
 	data, err := io.ReadAll(r)
 	if err != nil {
 		return fmt.Errorf("reading file: %w", err)
+	}
+
+	data, err = jsonutil.Sanitize(data)
+	if err != nil {
+		return fmt.Errorf("invalid JSON: %w", err)
 	}
 
 	resp, err := client.CreateBoardViewWithBodyWithResponse(ctx, boardID, "application/json", bytes.NewReader(data), auth)

--- a/cmd/board/view_update.go
+++ b/cmd/board/view_update.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
+	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
 	"github.com/spf13/cobra"
 )
 
@@ -116,6 +117,11 @@ func updateViewFromFile(ctx context.Context, client *api.ClientWithResponses, op
 	data, err := io.ReadAll(r)
 	if err != nil {
 		return fmt.Errorf("reading file: %w", err)
+	}
+
+	data, err = jsonutil.Sanitize(data)
+	if err != nil {
+		return fmt.Errorf("invalid JSON: %w", err)
 	}
 
 	resp, err := client.UpdateBoardViewWithBodyWithResponse(ctx, boardID, viewID, "application/json", bytes.NewReader(data), auth)

--- a/cmd/column/calculated_create.go
+++ b/cmd/column/calculated_create.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
 	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
@@ -97,6 +98,11 @@ func runCalculatedCreateFromFile(ctx context.Context, opts *options.RootOptions,
 	data, err := io.ReadAll(r)
 	if err != nil {
 		return fmt.Errorf("reading file: %w", err)
+	}
+
+	data, err = jsonutil.Sanitize(data)
+	if err != nil {
+		return fmt.Errorf("invalid JSON: %w", err)
 	}
 
 	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())

--- a/cmd/column/calculated_update.go
+++ b/cmd/column/calculated_update.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
 	"github.com/spf13/cobra"
 )
 
@@ -101,6 +102,10 @@ func runCalculatedUpdate(ctx context.Context, opts *options.RootOptions, dataset
 		data, err := io.ReadAll(r)
 		if err != nil {
 			return fmt.Errorf("reading file: %w", err)
+		}
+		data, err = jsonutil.Sanitize(data)
+		if err != nil {
+			return fmt.Errorf("invalid JSON: %w", err)
 		}
 		if err := json.Unmarshal(data, &body); err != nil {
 			return fmt.Errorf("parsing calculated column JSON: %w", err)

--- a/cmd/dataset/definition_update.go
+++ b/cmd/dataset/definition_update.go
@@ -3,7 +3,6 @@ package dataset
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -11,6 +10,7 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
 	"github.com/spf13/cobra"
 )
 
@@ -82,8 +82,8 @@ func readDefinitionFile(opts *options.RootOptions, file string) ([]byte, error) 
 		return nil, fmt.Errorf("reading file: %w", err)
 	}
 
-	var js json.RawMessage
-	if err := json.Unmarshal(data, &js); err != nil {
+	data, err = jsonutil.Sanitize(data)
+	if err != nil {
 		return nil, fmt.Errorf("invalid JSON: %w", err)
 	}
 

--- a/cmd/key/key.go
+++ b/cmd/key/key.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
+	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
 	"github.com/bendrucker/honeycomb-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -123,6 +124,10 @@ func readBodyFile(ios *options.RootOptions, file string) ([]byte, error) {
 	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("reading file: %w", err)
+	}
+	data, err = jsonutil.Sanitize(data)
+	if err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
 	}
 	return data, nil
 }

--- a/cmd/query/query.go
+++ b/cmd/query/query.go
@@ -1,12 +1,12 @@
 package query
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
 	"github.com/spf13/cobra"
 )
 
@@ -50,8 +50,8 @@ func readFile(opts *options.RootOptions, file string) ([]byte, error) {
 		return nil, fmt.Errorf("reading file: %w", err)
 	}
 
-	var js json.RawMessage
-	if err := json.Unmarshal(data, &js); err != nil {
+	data, err = jsonutil.Sanitize(data)
+	if err != nil {
 		return nil, fmt.Errorf("invalid JSON: %w", err)
 	}
 

--- a/cmd/recipient/create.go
+++ b/cmd/recipient/create.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
 	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
@@ -227,8 +228,8 @@ func readFile(opts *options.RootOptions, file string) ([]byte, error) {
 		return nil, fmt.Errorf("reading file: %w", err)
 	}
 
-	var js json.RawMessage
-	if err := json.Unmarshal(data, &js); err != nil {
+	data, err = jsonutil.Sanitize(data)
+	if err != nil {
 		return nil, fmt.Errorf("invalid JSON: %w", err)
 	}
 

--- a/cmd/slo/create.go
+++ b/cmd/slo/create.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
 	"github.com/spf13/cobra"
 )
 
@@ -123,8 +124,8 @@ func readFile(opts *options.RootOptions, file string) ([]byte, error) {
 		return nil, fmt.Errorf("reading file: %w", err)
 	}
 
-	var js json.RawMessage
-	if err := json.Unmarshal(data, &js); err != nil {
+	data, err = jsonutil.Sanitize(data)
+	if err != nil {
 		return nil, fmt.Errorf("invalid JSON: %w", err)
 	}
 

--- a/internal/jsonutil/sanitize.go
+++ b/internal/jsonutil/sanitize.go
@@ -1,0 +1,72 @@
+package jsonutil
+
+import "encoding/json"
+
+// Sanitize validates data as JSON and returns it unchanged if valid. If
+// parsing fails, it sanitizes invalid escape sequences and returns the
+// corrected bytes. Returns the original parse error if sanitization does
+// not produce valid JSON.
+func Sanitize(data []byte) ([]byte, error) {
+	if json.Valid(data) {
+		return data, nil
+	}
+	fixed := SanitizeEscapes(data)
+	if !json.Valid(fixed) {
+		// Return a descriptive error from the original data
+		var js json.RawMessage
+		return nil, json.Unmarshal(data, &js)
+	}
+	return fixed, nil
+}
+
+// SanitizeEscapes removes invalid JSON escape sequences from within JSON
+// string values. Shells like zsh escape characters such as ! to \! via
+// history expansion, producing invalid JSON when piped to stdin. This
+// function replaces \X with X inside strings when X is not a valid JSON
+// escape character (", \, /, b, f, n, r, t, u).
+func SanitizeEscapes(data []byte) []byte {
+	out := make([]byte, 0, len(data))
+	inString := false
+
+	for i := 0; i < len(data); i++ {
+		b := data[i]
+
+		if !inString {
+			if b == '"' {
+				inString = true
+			}
+			out = append(out, b)
+			continue
+		}
+
+		// Inside a JSON string
+		if b == '"' {
+			inString = false
+			out = append(out, b)
+			continue
+		}
+
+		if b == '\\' && i+1 < len(data) {
+			next := data[i+1]
+			if isValidJSONEscape(next) {
+				out = append(out, b, next)
+			} else {
+				out = append(out, next)
+			}
+			i++
+			continue
+		}
+
+		out = append(out, b)
+	}
+
+	return out
+}
+
+func isValidJSONEscape(b byte) bool {
+	switch b {
+	case '"', '\\', '/', 'b', 'f', 'n', 'r', 't', 'u':
+		return true
+	}
+	return false
+}

--- a/internal/jsonutil/sanitize_test.go
+++ b/internal/jsonutil/sanitize_test.go
@@ -1,0 +1,128 @@
+package jsonutil
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeEscapes(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "valid JSON unchanged",
+			input: `{"op":"!="}`,
+			want:  `{"op":"!="}`,
+		},
+		{
+			name:  "backslash bang from zsh",
+			input: `{"op":"\!="}`,
+			want:  `{"op":"!="}`,
+		},
+		{
+			name:  "valid escape preserved",
+			input: `{"msg":"line\nbreak"}`,
+			want:  `{"msg":"line\nbreak"}`,
+		},
+		{
+			name:  "escaped quote preserved",
+			input: `{"msg":"say \"hello\""}`,
+			want:  `{"msg":"say \"hello\""}`,
+		},
+		{
+			name:  "escaped backslash preserved",
+			input: `{"path":"C:\\Users"}`,
+			want:  `{"path":"C:\\Users"}`,
+		},
+		{
+			name:  "unicode escape preserved",
+			input: `{"char":"\u0041"}`,
+			want:  `{"char":"\u0041"}`,
+		},
+		{
+			name:  "multiple invalid escapes",
+			input: `{"a":"\!","b":"\="}`,
+			want:  `{"a":"!","b":"="}`,
+		},
+		{
+			name:  "no strings",
+			input: `[1, 2, 3]`,
+			want:  `[1, 2, 3]`,
+		},
+		{
+			name:  "backslash outside string unchanged",
+			input: `{"key":"val"}`,
+			want:  `{"key":"val"}`,
+		},
+		{
+			name:  "nested objects",
+			input: `{"filters":[{"op":"\!=","value":"test"}]}`,
+			want:  `{"filters":[{"op":"!=","value":"test"}]}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := string(SanitizeEscapes([]byte(tc.input)))
+			if got != tc.want {
+				t.Errorf("SanitizeEscapes(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSanitize(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "valid JSON passes through",
+			input: `{"op":"!="}`,
+			want:  `{"op":"!="}`,
+		},
+		{
+			name:  "invalid escape gets sanitized",
+			input: `{"op":"\!="}`,
+			want:  `{"op":"!="}`,
+		},
+		{
+			name:  "nested invalid escapes",
+			input: `{"filters":[{"op":"\!=","value":"test"}]}`,
+			want:  `{"filters":[{"op":"!=","value":"test"}]}`,
+		},
+		{
+			name:    "unfixable JSON returns error",
+			input:   `{invalid`,
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Sanitize([]byte(tc.input))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("Sanitize(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSanitize_ErrorFromOriginal(t *testing.T) {
+	_, err := Sanitize([]byte(`not json at all`))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "invalid character") {
+		t.Errorf("error = %q, want original parse error", err.Error())
+	}
+}


### PR DESCRIPTION
## Issue

Piping JSON via stdin (`-f -`) failed when string values contained characters like `!=`. The reader was interpreting escape sequences before JSON parsing.

## Changes

- Read stdin as raw bytes before passing to the JSON decoder

Closes #104
