### PR TITLE
feat: add --version command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,3 +14,25 @@ archives:
       - goos: windows
         formats:
           - zip
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  use: github
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - "^build\\(deps\\):"
+  groups:
+    - title: Features
+      regexp: "^.*feat(\\(.+\\))??!?:.+$"
+      order: 0
+    - title: Bug Fixes
+      regexp: "^.*fix(\\(.+\\))??!?:.+$"
+      order: 1
+    - title: Others
+      order: 999

--- a/cmd/honeycomb/main.go
+++ b/cmd/honeycomb/main.go
@@ -5,12 +5,23 @@ import (
 	"os"
 
 	"github.com/bendrucker/honeycomb-cli/cmd"
+	"github.com/bendrucker/honeycomb-cli/internal/build"
 	"github.com/bendrucker/honeycomb-cli/internal/iostreams"
+)
+
+// Build metadata, stamped by GoReleaser's default -X main.* ldflags. They keep
+// these defaults for `go build`/`go run`; build.Version fills in the module
+// version for `go install`.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
 )
 
 func main() {
 	ios := iostreams.System()
 	rootCmd := cmd.NewRootCmd(ios)
+	rootCmd.Version = build.String(version, commit, date)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,6 +55,8 @@ func NewRootCmd(ios *iostreams.IOStreams) *cobra.Command {
 		},
 	}
 
+	cmd.SetVersionTemplate("honeycomb {{.Version}}\n")
+
 	cmd.PersistentFlags().BoolVar(&opts.NoInteractive, "no-interactive", false, "Disable interactive prompts")
 	cmd.PersistentFlags().StringVar(&opts.Format, "format", "", "Output format: json, table")
 	cmd.PersistentFlags().StringVar(&opts.APIUrl, "api-url", "", "Honeycomb API URL")

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1,0 +1,36 @@
+// Package build formats the version metadata that GoReleaser stamps into the
+// binary through its default -X main.{version,commit,date} ldflags.
+package build
+
+import "runtime/debug"
+
+// Version resolves the version to report. A release build passes a real version
+// string; otherwise it falls back to the module version from the build info
+// (set for `go install module@version`), then to the supplied default.
+func Version(version string) string {
+	if version != "dev" {
+		return version
+	}
+
+	if info, ok := debug.ReadBuildInfo(); ok {
+		if v := info.Main.Version; v != "" && v != "(devel)" {
+			return v
+		}
+	}
+
+	return version
+}
+
+// String renders the version, appending the commit and date when a release
+// build set them. The `go build`/`go run` defaults ("none", "unknown") are
+// omitted.
+func String(version, commit, date string) string {
+	s := Version(version)
+	if commit != "" && commit != "none" {
+		s += " (" + commit + ")"
+	}
+	if date != "" && date != "unknown" {
+		s += " " + date
+	}
+	return s
+}

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -1,0 +1,39 @@
+package build
+
+import "testing"
+
+func TestString(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		version string
+		commit  string
+		date    string
+		want    string
+	}{
+		{
+			name:    "explicit version",
+			version: "v1.2.3",
+			want:    "v1.2.3",
+		},
+		{
+			name:    "version with commit and date",
+			version: "v1.2.3",
+			commit:  "abc1234",
+			date:    "2026-05-31",
+			want:    "v1.2.3 (abc1234) 2026-05-31",
+		},
+		{
+			name:    "dev defaults omit commit and date",
+			version: "dev",
+			commit:  "none",
+			date:    "unknown",
+			want:    "dev",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := String(tc.version, tc.commit, tc.date); got != tc.want {
+				t.Errorf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a `--version` command, ahead of the first tagged version.

## `--version` (Closes #157)

`version`, `commit`, and `date` live in `package main`, so GoReleaser fills them through its default `-X main.*` ldflags with no custom `ldflags` block. `internal/build` formats the string and falls back to `runtime/debug` build info for `go install` builds. A plain working-copy build reports `dev`.

Verified against a `goreleaser build --snapshot`, whose binary reports `honeycomb 0.0.0-SNAPSHOT-<commit> (<sha>) <date>`, confirming the default ldflags inject the values without any explicit configuration.

## GoReleaser (Refs #158)

`.goreleaser.yml` gains a `checksum` block and a grouped `changelog` that GoReleaser uses to generate GitHub Release notes. No committed changelog file. The Homebrew tap and README install paths are deferred until there is a distribution decision.

The contributor guide that was previously bundled here merged separately in #236.
