### PR TITLE
refactor(cmd): add opts.Client and api.Decode request/response seam

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,33 @@ Commands follow a consistent pattern:
 - Support `--format` for output
 - Both interactive and non-interactive paths
 
+## API Requests
+
+Build the client with `opts.Client(kt config.KeyType)`, which bakes the auth
+request editor in, so call sites issue requests without passing an editor
+argument:
+
+```go
+client, err := opts.Client(config.KeyConfig)
+if err != nil {
+	return err
+}
+resp, err := client.ListTriggersWithResponse(ctx, dataset)
+if err != nil {
+	return fmt.Errorf("listing triggers: %w", err)
+}
+triggers, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+if err != nil {
+	return err
+}
+```
+
+`api.Decode` runs `CheckResponse` (the status/error-body check) and guards the
+typed-nil case, returning the typed body. Use it wherever a `JSON200`/`JSON201`
+field is read directly. Responses decoded by hand (SLO union types, the raw
+`ListColumns` body) keep their own `api.CheckResponse` + `json.Unmarshal`.
+Delete commands keep `api.CheckResponse` and any status guard.
+
 ## Testing
 
 **Unit tests** use `keyring.MockInit()` for an in-memory keyring and `httptest.NewServer` for API stubs. These run in `go test` with no external dependencies.

--- a/cmd/board/create.go
+++ b/cmd/board/create.go
@@ -48,20 +48,15 @@ characters) for each entry:
 }
 
 func runBoardCreate(cmd *cobra.Command, opts *options.RootOptions, file, name, desc string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	ctx := cmd.Context()
 
 	if file != "" {
-		return createFromFile(ctx, client, opts, auth, file)
+		return createFromFile(ctx, client, opts, file)
 	}
 
 	if name == "" {
@@ -91,23 +86,20 @@ func runBoardCreate(cmd *cobra.Command, opts *options.RootOptions, file, name, d
 		board.Description = &desc
 	}
 
-	resp, err := client.CreateBoardWithResponse(ctx, board, auth)
+	resp, err := client.CreateBoardWithResponse(ctx, board)
 	if err != nil {
 		return fmt.Errorf("creating board: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	created, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON201)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON201 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeBoardDetail(opts, boardToDetail(*resp.JSON201))
+	return writeBoardDetail(opts, boardToDetail(*created))
 }
 
-func createFromFile(ctx context.Context, client *api.ClientWithResponses, opts *options.RootOptions, auth api.RequestEditorFn, file string) error {
+func createFromFile(ctx context.Context, client *api.ClientWithResponses, opts *options.RootOptions, file string) error {
 	var r io.Reader
 	if file == "-" {
 		r = opts.IOStreams.In
@@ -140,18 +132,15 @@ func createFromFile(ctx context.Context, client *api.ClientWithResponses, opts *
 		return fmt.Errorf("stripping panel dataset: %w", err)
 	}
 
-	resp, err := client.CreateBoardWithBodyWithResponse(ctx, "application/json", bytes.NewReader(data), auth)
+	resp, err := client.CreateBoardWithBodyWithResponse(ctx, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("creating board: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	created, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON201)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON201 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeBoardDetail(opts, boardToDetail(*resp.JSON201))
+	return writeBoardDetail(opts, boardToDetail(*created))
 }

--- a/cmd/board/delete.go
+++ b/cmd/board/delete.go
@@ -30,14 +30,9 @@ func NewDeleteCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runBoardDelete(ctx context.Context, opts *options.RootOptions, boardID string, yes bool) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	if !yes {
@@ -45,7 +40,7 @@ func runBoardDelete(ctx context.Context, opts *options.RootOptions, boardID stri
 			return fmt.Errorf("--yes is required in non-interactive mode")
 		}
 
-		board, err := getBoard(ctx, client, auth, boardID)
+		board, err := getBoard(ctx, client, boardID)
 		if err != nil {
 			return err
 		}
@@ -59,7 +54,7 @@ func runBoardDelete(ctx context.Context, opts *options.RootOptions, boardID stri
 		}
 	}
 
-	resp, err := client.DeleteBoardWithResponse(ctx, boardID, auth)
+	resp, err := client.DeleteBoardWithResponse(ctx, boardID)
 	if err != nil {
 		return fmt.Errorf("deleting board: %w", err)
 	}

--- a/cmd/board/get.go
+++ b/cmd/board/get.go
@@ -22,28 +22,20 @@ func NewGetCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runBoardGet(ctx context.Context, opts *options.RootOptions, boardID string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.GetBoardWithResponse(ctx, boardID, auth)
+	resp, err := client.GetBoardWithResponse(ctx, boardID)
 	if err != nil {
 		return fmt.Errorf("getting board: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	board, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeBoardDetail(opts, boardToDetail(*resp.JSON200))
+	return writeBoardDetail(opts, boardToDetail(*board))
 }

--- a/cmd/board/list.go
+++ b/cmd/board/list.go
@@ -40,31 +40,23 @@ func NewListCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runBoardList(ctx context.Context, opts *options.RootOptions) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.ListBoardsWithResponse(ctx, auth)
+	resp, err := client.ListBoardsWithResponse(ctx)
 	if err != nil {
 		return fmt.Errorf("listing boards: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	boards, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	items := make([]boardListItem, len(*resp.JSON200))
-	for i, b := range *resp.JSON200 {
+	items := make([]boardListItem, len(*boards))
+	for i, b := range *boards {
 		item := boardListItem{
 			ID:           deref.String(b.Id),
 			Name:         b.Name,

--- a/cmd/board/update.go
+++ b/cmd/board/update.go
@@ -51,27 +51,22 @@ preset_filters array requires both "column" (the column name) and "alias"
 }
 
 func runBoardUpdate(cmd *cobra.Command, opts *options.RootOptions, boardID, file string, replace bool, name, desc string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	ctx := cmd.Context()
 
 	if file != "" {
-		return updateFromFile(ctx, client, opts, auth, boardID, file, replace)
+		return updateFromFile(ctx, client, opts, boardID, file, replace)
 	}
 
 	if !cmd.Flags().Changed("name") && !cmd.Flags().Changed("description") {
 		return fmt.Errorf("--file, --name, or --description is required")
 	}
 
-	current, err := getBoard(ctx, client, auth, boardID)
+	current, err := getBoard(ctx, client, boardID)
 	if err != nil {
 		return err
 	}
@@ -93,23 +88,20 @@ func runBoardUpdate(cmd *cobra.Command, opts *options.RootOptions, boardID, file
 		return fmt.Errorf("stripping panel dataset: %w", err)
 	}
 
-	resp, err := client.UpdateBoardWithBodyWithResponse(ctx, boardID, "application/json", bytes.NewReader(data), auth)
+	resp, err := client.UpdateBoardWithBodyWithResponse(ctx, boardID, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("updating board: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	updated, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeBoardDetail(opts, boardToDetail(*resp.JSON200))
+	return writeBoardDetail(opts, boardToDetail(*updated))
 }
 
-func updateFromFile(ctx context.Context, client *api.ClientWithResponses, opts *options.RootOptions, auth api.RequestEditorFn, boardID, file string, replace bool) error {
+func updateFromFile(ctx context.Context, client *api.ClientWithResponses, opts *options.RootOptions, boardID, file string, replace bool) error {
 	var r io.Reader
 	if file == "-" {
 		r = opts.IOStreams.In
@@ -131,7 +123,7 @@ func updateFromFile(ctx context.Context, client *api.ClientWithResponses, opts *
 		}
 
 		var fillErr error
-		data, fillErr = fillRequiredFields(ctx, client, auth, boardID, raw)
+		data, fillErr = fillRequiredFields(ctx, client, boardID, raw)
 		if fillErr != nil {
 			return fillErr
 		}
@@ -146,7 +138,7 @@ func updateFromFile(ctx context.Context, client *api.ClientWithResponses, opts *
 			return err
 		}
 
-		current, err := getBoard(ctx, client, auth, boardID)
+		current, err := getBoard(ctx, client, boardID)
 		if err != nil {
 			return err
 		}
@@ -169,37 +161,26 @@ func updateFromFile(ctx context.Context, client *api.ClientWithResponses, opts *
 		return fmt.Errorf("stripping panel dataset: %w", panelErr)
 	}
 
-	resp, err := client.UpdateBoardWithBodyWithResponse(ctx, boardID, "application/json", bytes.NewReader(data), auth)
+	resp, err := client.UpdateBoardWithBodyWithResponse(ctx, boardID, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("updating board: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	updated, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeBoardDetail(opts, boardToDetail(*resp.JSON200))
+	return writeBoardDetail(opts, boardToDetail(*updated))
 }
 
-func getBoard(ctx context.Context, client *api.ClientWithResponses, auth api.RequestEditorFn, boardID string) (*api.Board, error) {
-	resp, err := client.GetBoardWithResponse(ctx, boardID, auth)
+func getBoard(ctx context.Context, client *api.ClientWithResponses, boardID string) (*api.Board, error) {
+	resp, err := client.GetBoardWithResponse(ctx, boardID)
 	if err != nil {
 		return nil, fmt.Errorf("getting board: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
-		return nil, err
-	}
-
-	if resp.JSON200 == nil {
-		return nil, fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return resp.JSON200, nil
+	return api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
 }
 
 // mergeBoard applies non-zero fields from src onto dst.
@@ -228,7 +209,7 @@ func mergeBoard(dst *api.Board, src *api.Board) {
 // fillRequiredFields ensures that "name" and "type" are present in the board
 // JSON, fetching the current board to fill them in when missing. This allows
 // --replace to work without redundantly specifying fields that are already known.
-func fillRequiredFields(ctx context.Context, client *api.ClientWithResponses, auth api.RequestEditorFn, boardID string, data []byte) ([]byte, error) {
+func fillRequiredFields(ctx context.Context, client *api.ClientWithResponses, boardID string, data []byte) ([]byte, error) {
 	var m map[string]json.RawMessage
 	if err := json.Unmarshal(data, &m); err != nil {
 		return nil, fmt.Errorf("parsing board JSON: %w", err)
@@ -240,7 +221,7 @@ func fillRequiredFields(ctx context.Context, client *api.ClientWithResponses, au
 		return data, nil
 	}
 
-	current, err := getBoard(ctx, client, auth, boardID)
+	current, err := getBoard(ctx, client, boardID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/board/view_create.go
+++ b/cmd/board/view_create.go
@@ -42,20 +42,15 @@ func NewViewCreateCmd(opts *options.RootOptions, board *string) *cobra.Command {
 }
 
 func runViewCreate(cmd *cobra.Command, opts *options.RootOptions, boardID, file, name string, filterArgs []string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	ctx := cmd.Context()
 
 	if file != "" {
-		return createViewFromFile(ctx, client, opts, auth, boardID, file)
+		return createViewFromFile(ctx, client, opts, boardID, file)
 	}
 
 	if name == "" {
@@ -85,20 +80,17 @@ func runViewCreate(cmd *cobra.Command, opts *options.RootOptions, boardID, file,
 		Filters: filters,
 	}
 
-	resp, err := client.CreateBoardViewWithResponse(ctx, boardID, body, auth)
+	resp, err := client.CreateBoardViewWithResponse(ctx, boardID, body)
 	if err != nil {
 		return fmt.Errorf("creating board view: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	created, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON201)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON201 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeViewDetail(opts, viewResponseToDetail(*resp.JSON201))
+	return writeViewDetail(opts, viewResponseToDetail(*created))
 }
 
 func parseViewFilters(args []string) ([]api.BoardViewFilter, error) {
@@ -120,7 +112,7 @@ func parseViewFilters(args []string) ([]api.BoardViewFilter, error) {
 	return filters, nil
 }
 
-func createViewFromFile(ctx context.Context, client *api.ClientWithResponses, opts *options.RootOptions, auth api.RequestEditorFn, boardID, file string) error {
+func createViewFromFile(ctx context.Context, client *api.ClientWithResponses, opts *options.RootOptions, boardID, file string) error {
 	var r io.Reader
 	if file == "-" {
 		r = opts.IOStreams.In
@@ -143,18 +135,15 @@ func createViewFromFile(ctx context.Context, client *api.ClientWithResponses, op
 		return fmt.Errorf("invalid JSON: %w", err)
 	}
 
-	resp, err := client.CreateBoardViewWithBodyWithResponse(ctx, boardID, "application/json", bytes.NewReader(data), auth)
+	resp, err := client.CreateBoardViewWithBodyWithResponse(ctx, boardID, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("creating board view: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	created, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON201)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON201 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeViewDetail(opts, viewResponseToDetail(*resp.JSON201))
+	return writeViewDetail(opts, viewResponseToDetail(*created))
 }

--- a/cmd/board/view_delete.go
+++ b/cmd/board/view_delete.go
@@ -30,14 +30,9 @@ func NewViewDeleteCmd(opts *options.RootOptions, board *string) *cobra.Command {
 }
 
 func runViewDelete(ctx context.Context, opts *options.RootOptions, boardID, viewID string, yes bool) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	if !yes {
@@ -45,7 +40,7 @@ func runViewDelete(ctx context.Context, opts *options.RootOptions, boardID, view
 			return fmt.Errorf("--yes is required in non-interactive mode")
 		}
 
-		view, err := getView(ctx, client, auth, boardID, viewID)
+		view, err := getView(ctx, client, boardID, viewID)
 		if err != nil {
 			return err
 		}
@@ -64,7 +59,7 @@ func runViewDelete(ctx context.Context, opts *options.RootOptions, boardID, view
 		}
 	}
 
-	resp, err := client.DeleteBoardViewWithResponse(ctx, boardID, viewID, auth)
+	resp, err := client.DeleteBoardViewWithResponse(ctx, boardID, viewID)
 	if err != nil {
 		return fmt.Errorf("deleting board view: %w", err)
 	}

--- a/cmd/board/view_get.go
+++ b/cmd/board/view_get.go
@@ -22,28 +22,20 @@ func NewViewGetCmd(opts *options.RootOptions, board *string) *cobra.Command {
 }
 
 func runViewGet(ctx context.Context, opts *options.RootOptions, boardID, viewID string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.GetBoardViewWithResponse(ctx, boardID, viewID, auth)
+	resp, err := client.GetBoardViewWithResponse(ctx, boardID, viewID)
 	if err != nil {
 		return fmt.Errorf("getting board view: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	view, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeViewDetail(opts, viewResponseToDetail(*resp.JSON200))
+	return writeViewDetail(opts, viewResponseToDetail(*view))
 }

--- a/cmd/board/view_list.go
+++ b/cmd/board/view_list.go
@@ -21,31 +21,23 @@ func NewViewListCmd(opts *options.RootOptions, board *string) *cobra.Command {
 }
 
 func runViewList(ctx context.Context, opts *options.RootOptions, boardID string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.ListBoardViewsWithResponse(ctx, boardID, auth)
+	resp, err := client.ListBoardViewsWithResponse(ctx, boardID)
 	if err != nil {
 		return fmt.Errorf("listing board views: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	views, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	items := make([]viewItem, len(*resp.JSON200))
-	for i, v := range *resp.JSON200 {
+	items := make([]viewItem, len(*views))
+	for i, v := range *views {
 		items[i] = viewResponseToItem(v)
 	}
 

--- a/cmd/board/view_update.go
+++ b/cmd/board/view_update.go
@@ -42,27 +42,22 @@ func NewViewUpdateCmd(opts *options.RootOptions, board *string) *cobra.Command {
 }
 
 func runViewUpdate(cmd *cobra.Command, opts *options.RootOptions, boardID, viewID, file, name string, filterArgs []string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	ctx := cmd.Context()
 
 	if file != "" {
-		return updateViewFromFile(ctx, client, opts, auth, boardID, viewID, file)
+		return updateViewFromFile(ctx, client, opts, boardID, viewID, file)
 	}
 
 	if !cmd.Flags().Changed("name") && !cmd.Flags().Changed("filter") {
 		return fmt.Errorf("--file, --name, or --filter is required")
 	}
 
-	current, err := getView(ctx, client, auth, boardID, viewID)
+	current, err := getView(ctx, client, boardID, viewID)
 	if err != nil {
 		return err
 	}
@@ -85,23 +80,20 @@ func runViewUpdate(cmd *cobra.Command, opts *options.RootOptions, boardID, viewI
 		body.Filters = *current.Filters
 	}
 
-	resp, err := client.UpdateBoardViewWithResponse(ctx, boardID, viewID, body, auth)
+	resp, err := client.UpdateBoardViewWithResponse(ctx, boardID, viewID, body)
 	if err != nil {
 		return fmt.Errorf("updating board view: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	updated, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeViewDetail(opts, viewResponseToDetail(*resp.JSON200))
+	return writeViewDetail(opts, viewResponseToDetail(*updated))
 }
 
-func updateViewFromFile(ctx context.Context, client *api.ClientWithResponses, opts *options.RootOptions, auth api.RequestEditorFn, boardID, viewID, file string) error {
+func updateViewFromFile(ctx context.Context, client *api.ClientWithResponses, opts *options.RootOptions, boardID, viewID, file string) error {
 	var r io.Reader
 	if file == "-" {
 		r = opts.IOStreams.In
@@ -124,35 +116,24 @@ func updateViewFromFile(ctx context.Context, client *api.ClientWithResponses, op
 		return fmt.Errorf("invalid JSON: %w", err)
 	}
 
-	resp, err := client.UpdateBoardViewWithBodyWithResponse(ctx, boardID, viewID, "application/json", bytes.NewReader(data), auth)
+	resp, err := client.UpdateBoardViewWithBodyWithResponse(ctx, boardID, viewID, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("updating board view: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	updated, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeViewDetail(opts, viewResponseToDetail(*resp.JSON200))
+	return writeViewDetail(opts, viewResponseToDetail(*updated))
 }
 
-func getView(ctx context.Context, client *api.ClientWithResponses, auth api.RequestEditorFn, boardID, viewID string) (*api.BoardViewResponse, error) {
-	resp, err := client.GetBoardViewWithResponse(ctx, boardID, viewID, auth)
+func getView(ctx context.Context, client *api.ClientWithResponses, boardID, viewID string) (*api.BoardViewResponse, error) {
+	resp, err := client.GetBoardViewWithResponse(ctx, boardID, viewID)
 	if err != nil {
 		return nil, fmt.Errorf("getting board view: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
-		return nil, err
-	}
-
-	if resp.JSON200 == nil {
-		return nil, fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return resp.JSON200, nil
+	return api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
 }

--- a/cmd/column/calculated_create.go
+++ b/cmd/column/calculated_create.go
@@ -78,7 +78,7 @@ func NewCalculatedCreateCmd(opts *options.RootOptions, dataset *string) *cobra.C
 }
 
 func runCalculatedCreateFromFile(ctx context.Context, opts *options.RootOptions, dataset, file string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
@@ -105,50 +105,34 @@ func runCalculatedCreateFromFile(ctx context.Context, opts *options.RootOptions,
 		return fmt.Errorf("invalid JSON: %w", err)
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.CreateCalculatedFieldWithBodyWithResponse(ctx, dataset, "application/json", bytes.NewReader(data), auth)
+	resp, err := client.CreateCalculatedFieldWithBodyWithResponse(ctx, dataset, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("creating calculated column: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	field, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON201)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON201 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeCalculatedDetail(opts, *resp.JSON201)
+	return writeCalculatedDetail(opts, *field)
 }
 
 func runCalculatedCreate(ctx context.Context, opts *options.RootOptions, dataset string, body api.CreateCalculatedFieldJSONRequestBody) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.CreateCalculatedFieldWithResponse(ctx, dataset, body, auth)
+	resp, err := client.CreateCalculatedFieldWithResponse(ctx, dataset, body)
 	if err != nil {
 		return fmt.Errorf("creating calculated column: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	field, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON201)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON201 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeCalculatedDetail(opts, *resp.JSON201)
+	return writeCalculatedDetail(opts, *field)
 }

--- a/cmd/column/calculated_delete.go
+++ b/cmd/column/calculated_delete.go
@@ -29,14 +29,9 @@ func NewCalculatedDeleteCmd(opts *options.RootOptions, dataset *string) *cobra.C
 }
 
 func runCalculatedDelete(ctx context.Context, opts *options.RootOptions, dataset, id string, yes bool) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	if !yes {
@@ -44,7 +39,7 @@ func runCalculatedDelete(ctx context.Context, opts *options.RootOptions, dataset
 			return fmt.Errorf("--yes is required in non-interactive mode")
 		}
 
-		getResp, err := client.GetCalculatedFieldWithResponse(ctx, dataset, id, auth)
+		getResp, err := client.GetCalculatedFieldWithResponse(ctx, dataset, id)
 		if err != nil {
 			return fmt.Errorf("getting calculated column: %w", err)
 		}
@@ -66,7 +61,7 @@ func runCalculatedDelete(ctx context.Context, opts *options.RootOptions, dataset
 		}
 	}
 
-	resp, err := client.DeleteCalculatedFieldWithResponse(ctx, dataset, id, auth)
+	resp, err := client.DeleteCalculatedFieldWithResponse(ctx, dataset, id)
 	if err != nil {
 		return fmt.Errorf("deleting calculated column: %w", err)
 	}

--- a/cmd/column/calculated_get.go
+++ b/cmd/column/calculated_get.go
@@ -22,28 +22,20 @@ func NewCalculatedGetCmd(opts *options.RootOptions, dataset *string) *cobra.Comm
 }
 
 func runCalculatedGet(ctx context.Context, opts *options.RootOptions, dataset, id string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.GetCalculatedFieldWithResponse(ctx, dataset, id, auth)
+	resp, err := client.GetCalculatedFieldWithResponse(ctx, dataset, id)
 	if err != nil {
 		return fmt.Errorf("getting calculated column: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	field, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeCalculatedDetail(opts, *resp.JSON200)
+	return writeCalculatedDetail(opts, *field)
 }

--- a/cmd/column/calculated_list.go
+++ b/cmd/column/calculated_list.go
@@ -23,20 +23,15 @@ func NewCalculatedListCmd(opts *options.RootOptions, dataset *string) *cobra.Com
 }
 
 func runCalculatedList(ctx context.Context, opts *options.RootOptions, dataset string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	// Use the raw ListCalculatedFields method because the generated
 	// ListCalculatedFieldsWithResponse parser cannot unmarshal the response
 	// into its union type (JSON200 is struct { union json.RawMessage }).
-	resp, err := client.ListCalculatedFields(ctx, dataset, nil, auth)
+	resp, err := client.ListCalculatedFields(ctx, dataset, nil)
 	if err != nil {
 		return fmt.Errorf("listing calculated columns: %w", err)
 	}

--- a/cmd/column/calculated_update.go
+++ b/cmd/column/calculated_update.go
@@ -74,14 +74,9 @@ type calculatedUpdateFlags struct {
 }
 
 func runCalculatedUpdate(ctx context.Context, opts *options.RootOptions, dataset, id string, flags calculatedUpdateFlags) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	var body api.CalculatedField
@@ -111,17 +106,15 @@ func runCalculatedUpdate(ctx context.Context, opts *options.RootOptions, dataset
 			return fmt.Errorf("parsing calculated column JSON: %w", err)
 		}
 	} else {
-		getResp, err := client.GetCalculatedFieldWithResponse(ctx, dataset, id, auth)
+		getResp, err := client.GetCalculatedFieldWithResponse(ctx, dataset, id)
 		if err != nil {
 			return fmt.Errorf("getting calculated column: %w", err)
 		}
-		if err := api.CheckResponse(getResp.StatusCode(), getResp.Body); err != nil {
+		current, err := api.Decode(getResp.StatusCode(), getResp.Status(), getResp.Body, getResp.JSON200)
+		if err != nil {
 			return err
 		}
-		if getResp.JSON200 == nil {
-			return fmt.Errorf("unexpected response: %s", getResp.Status())
-		}
-		body = *getResp.JSON200
+		body = *current
 
 		if flags.hasAlias {
 			body.Alias = flags.alias
@@ -139,18 +132,15 @@ func runCalculatedUpdate(ctx context.Context, opts *options.RootOptions, dataset
 		return fmt.Errorf("encoding calculated column: %w", err)
 	}
 
-	resp, err := client.UpdateCalculatedFieldWithBodyWithResponse(ctx, dataset, id, "application/json", bytes.NewReader(data), auth)
+	resp, err := client.UpdateCalculatedFieldWithBodyWithResponse(ctx, dataset, id, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("updating calculated column: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	updated, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeCalculatedDetail(opts, *resp.JSON200)
+	return writeCalculatedDetail(opts, *updated)
 }

--- a/cmd/column/create.go
+++ b/cmd/column/create.go
@@ -54,14 +54,9 @@ func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runColumnCreate(cmd *cobra.Command, opts *options.RootOptions, dataset, keyName, colType, description string, hidden bool) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	body := api.CreateColumnJSONRequestBody{
@@ -78,18 +73,15 @@ func runColumnCreate(cmd *cobra.Command, opts *options.RootOptions, dataset, key
 		body.Hidden = &hidden
 	}
 
-	resp, err := client.CreateColumnWithResponse(cmd.Context(), dataset, body, auth)
+	resp, err := client.CreateColumnWithResponse(cmd.Context(), dataset, body)
 	if err != nil {
 		return fmt.Errorf("creating column: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	col, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON201)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON201 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeColumnDetail(opts, *resp.JSON201)
+	return writeColumnDetail(opts, *col)
 }

--- a/cmd/column/delete.go
+++ b/cmd/column/delete.go
@@ -29,14 +29,9 @@ func NewDeleteCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runColumnDelete(ctx context.Context, opts *options.RootOptions, dataset, columnID string, yes bool) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	if !yes {
@@ -44,7 +39,7 @@ func runColumnDelete(ctx context.Context, opts *options.RootOptions, dataset, co
 			return fmt.Errorf("--yes is required in non-interactive mode")
 		}
 
-		getResp, err := client.GetColumnWithResponse(ctx, dataset, columnID, auth)
+		getResp, err := client.GetColumnWithResponse(ctx, dataset, columnID)
 		if err != nil {
 			return fmt.Errorf("getting column: %w", err)
 		}
@@ -66,7 +61,7 @@ func runColumnDelete(ctx context.Context, opts *options.RootOptions, dataset, co
 		}
 	}
 
-	resp, err := client.DeleteColumnWithResponse(ctx, dataset, columnID, auth)
+	resp, err := client.DeleteColumnWithResponse(ctx, dataset, columnID)
 	if err != nil {
 		return fmt.Errorf("deleting column: %w", err)
 	}

--- a/cmd/column/get.go
+++ b/cmd/column/get.go
@@ -22,28 +22,20 @@ func NewGetCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runColumnGet(ctx context.Context, opts *options.RootOptions, dataset, columnID string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.GetColumnWithResponse(ctx, dataset, columnID, auth)
+	resp, err := client.GetColumnWithResponse(ctx, dataset, columnID)
 	if err != nil {
 		return fmt.Errorf("getting column: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	col, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeColumnDetail(opts, *resp.JSON200)
+	return writeColumnDetail(opts, *col)
 }

--- a/cmd/column/list.go
+++ b/cmd/column/list.go
@@ -24,20 +24,15 @@ func NewListCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runColumnList(ctx context.Context, opts *options.RootOptions, dataset string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	// Use the raw ListColumns method because the generated ListColumnsWithResponse
 	// parser cannot unmarshal the response into its union type (JSON200 is
 	// struct { union json.RawMessage } which fails on the JSON array body).
-	resp, err := client.ListColumns(ctx, dataset, nil, auth)
+	resp, err := client.ListColumns(ctx, dataset, nil)
 	if err != nil {
 		return fmt.Errorf("listing columns: %w", err)
 	}

--- a/cmd/column/update.go
+++ b/cmd/column/update.go
@@ -32,32 +32,24 @@ func NewUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runColumnUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, columnID, description string, hidden bool) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	ctx := cmd.Context()
 
-	getResp, err := client.GetColumnWithResponse(ctx, dataset, columnID, auth)
+	getResp, err := client.GetColumnWithResponse(ctx, dataset, columnID)
 	if err != nil {
 		return fmt.Errorf("getting column: %w", err)
 	}
 
-	if err := api.CheckResponse(getResp.StatusCode(), getResp.Body); err != nil {
+	current, err := api.Decode(getResp.StatusCode(), getResp.Status(), getResp.Body, getResp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if getResp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", getResp.Status())
-	}
-
-	col := *getResp.JSON200
+	col := *current
 
 	if cmd.Flags().Changed("description") {
 		col.Description = &description
@@ -71,18 +63,15 @@ func runColumnUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, col
 		return fmt.Errorf("encoding column: %w", err)
 	}
 
-	resp, err := client.UpdateColumnWithBodyWithResponse(ctx, dataset, columnID, "application/json", bytes.NewReader(data), auth)
+	resp, err := client.UpdateColumnWithBodyWithResponse(ctx, dataset, columnID, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("updating column: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	updated, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeColumnDetail(opts, *resp.JSON200)
+	return writeColumnDetail(opts, *updated)
 }

--- a/cmd/dataset/create.go
+++ b/cmd/dataset/create.go
@@ -60,14 +60,9 @@ func runDatasetCreate(ctx context.Context, opts *options.RootOptions, name, desc
 		}
 	}
 
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	body := api.DatasetCreationPayload{
@@ -80,7 +75,7 @@ func runDatasetCreate(ctx context.Context, opts *options.RootOptions, name, desc
 		body.ExpandJsonDepth = expandJsonDepth
 	}
 
-	resp, err := client.CreateDatasetWithResponse(ctx, body, auth)
+	resp, err := client.CreateDatasetWithResponse(ctx, body)
 	if err != nil {
 		return fmt.Errorf("creating dataset: %w", err)
 	}

--- a/cmd/dataset/definition_get.go
+++ b/cmd/dataset/definition_get.go
@@ -25,30 +25,22 @@ func NewDefinitionGetCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runDefinitionGet(ctx context.Context, opts *options.RootOptions, slug string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.ListDatasetDefinitionsWithResponse(ctx, slug, auth)
+	resp, err := client.ListDatasetDefinitionsWithResponse(ctx, slug)
 	if err != nil {
 		return fmt.Errorf("getting dataset definitions: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	defs, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeDefinitions(opts, resp.JSON200)
+	return writeDefinitions(opts, defs)
 }
 
 func writeDefinitions(opts *options.RootOptions, defs *api.DatasetDefinitions) error {

--- a/cmd/dataset/definition_update.go
+++ b/cmd/dataset/definition_update.go
@@ -33,7 +33,7 @@ func NewDefinitionUpdateCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runDefinitionUpdate(ctx context.Context, opts *options.RootOptions, slug, file string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
@@ -43,25 +43,17 @@ func runDefinitionUpdate(ctx context.Context, opts *options.RootOptions, slug, f
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.PatchDatasetDefinitionsWithBodyWithResponse(ctx, slug, "application/json", bytes.NewReader(data), auth)
+	resp, err := client.PatchDatasetDefinitionsWithBodyWithResponse(ctx, slug, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("updating dataset definitions: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	defs, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeDefinitions(opts, resp.JSON200)
+	return writeDefinitions(opts, defs)
 }
 
 func readDefinitionFile(opts *options.RootOptions, file string) ([]byte, error) {

--- a/cmd/dataset/delete.go
+++ b/cmd/dataset/delete.go
@@ -32,14 +32,9 @@ func NewDeleteCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runDatasetDelete(ctx context.Context, opts *options.RootOptions, slug string, yes bool) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	if !yes {
@@ -47,7 +42,7 @@ func runDatasetDelete(ctx context.Context, opts *options.RootOptions, slug strin
 			return fmt.Errorf("--yes is required in non-interactive mode")
 		}
 
-		resp, err := client.GetDatasetWithResponse(ctx, slug, auth)
+		resp, err := client.GetDatasetWithResponse(ctx, slug)
 		if err != nil {
 			return fmt.Errorf("getting dataset: %w", err)
 		}
@@ -67,7 +62,7 @@ func runDatasetDelete(ctx context.Context, opts *options.RootOptions, slug strin
 		}
 	}
 
-	httpResp, err := client.DeleteDataset(ctx, slug, auth)
+	httpResp, err := client.DeleteDataset(ctx, slug)
 	if err != nil {
 		return fmt.Errorf("deleting dataset: %w", err)
 	}

--- a/cmd/dataset/get.go
+++ b/cmd/dataset/get.go
@@ -58,30 +58,22 @@ func NewGetCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runDatasetGet(ctx context.Context, opts *options.RootOptions, slug string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.GetDatasetWithResponse(ctx, slug, auth)
+	resp, err := client.GetDatasetWithResponse(ctx, slug)
 	if err != nil {
 		return fmt.Errorf("getting dataset: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	dataset, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	detail := mapDatasetDetail(resp.JSON200)
+	detail := mapDatasetDetail(dataset)
 	return writeDatasetDetail(opts, detail)
 }
 

--- a/cmd/dataset/list.go
+++ b/cmd/dataset/list.go
@@ -52,31 +52,23 @@ func NewListCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runDatasetList(ctx context.Context, opts *options.RootOptions) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.ListDatasetsWithResponse(ctx, auth)
+	resp, err := client.ListDatasetsWithResponse(ctx)
 	if err != nil {
 		return fmt.Errorf("listing datasets: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	datasets, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	items := make([]datasetItem, len(*resp.JSON200))
-	for i, d := range *resp.JSON200 {
+	items := make([]datasetItem, len(*datasets))
+	for i, d := range *datasets {
 		item := datasetItem{
 			Name:        d.Name,
 			Slug:        deref.String(d.Slug),

--- a/cmd/dataset/update.go
+++ b/cmd/dataset/update.go
@@ -46,14 +46,9 @@ func NewUpdateCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runDatasetUpdate(ctx context.Context, opts *options.RootOptions, slug string, description *string, expandJsonDepth *int, deleteProtected *bool) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	body := api.DatasetUpdatePayload{}
@@ -71,19 +66,16 @@ func runDatasetUpdate(ctx context.Context, opts *options.RootOptions, slug strin
 		}
 	}
 
-	resp, err := client.UpdateDatasetWithResponse(ctx, slug, body, auth)
+	resp, err := client.UpdateDatasetWithResponse(ctx, slug, body)
 	if err != nil {
 		return fmt.Errorf("updating dataset: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	dataset, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	detail := mapDatasetDetail(resp.JSON200)
+	detail := mapDatasetDetail(dataset)
 	return writeDatasetDetail(opts, detail)
 }

--- a/cmd/environment/create.go
+++ b/cmd/environment/create.go
@@ -36,14 +36,9 @@ func NewCreateCmd(opts *options.RootOptions, team *string) *cobra.Command {
 }
 
 func runEnvironmentCreate(cmd *cobra.Command, opts *options.RootOptions, team, name, desc, color string) error {
-	auth, err := opts.KeyEditor(config.KeyManagement)
+	client, err := opts.Client(config.KeyManagement)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	if name == "" {
@@ -76,18 +71,15 @@ func runEnvironmentCreate(cmd *cobra.Command, opts *options.RootOptions, team, n
 		body.Data.Attributes.Color = &c
 	}
 
-	resp, err := client.CreateEnvironmentWithApplicationVndAPIPlusJSONBodyWithResponse(cmd.Context(), team, body, auth)
+	resp, err := client.CreateEnvironmentWithApplicationVndAPIPlusJSONBodyWithResponse(cmd.Context(), team, body)
 	if err != nil {
 		return fmt.Errorf("creating environment: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	env, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.ApplicationvndApiJSON201)
+	if err != nil {
 		return err
 	}
 
-	if resp.ApplicationvndApiJSON201 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeEnvironmentDetail(opts, envToDetail(resp.ApplicationvndApiJSON201.Data))
+	return writeEnvironmentDetail(opts, envToDetail(env.Data))
 }

--- a/cmd/environment/delete.go
+++ b/cmd/environment/delete.go
@@ -33,14 +33,9 @@ func NewDeleteCmd(opts *options.RootOptions, team *string) *cobra.Command {
 }
 
 func runEnvironmentDelete(ctx context.Context, opts *options.RootOptions, team, envID string, yes bool) error {
-	auth, err := opts.KeyEditor(config.KeyManagement)
+	client, err := opts.Client(config.KeyManagement)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	if !yes {
@@ -48,7 +43,7 @@ func runEnvironmentDelete(ctx context.Context, opts *options.RootOptions, team, 
 			return fmt.Errorf("--yes is required in non-interactive mode")
 		}
 
-		getResp, err := client.GetEnvironmentWithResponse(ctx, team, envID, auth)
+		getResp, err := client.GetEnvironmentWithResponse(ctx, team, envID)
 		if err != nil {
 			return fmt.Errorf("getting environment: %w", err)
 		}
@@ -70,7 +65,7 @@ func runEnvironmentDelete(ctx context.Context, opts *options.RootOptions, team, 
 		}
 	}
 
-	resp, err := client.DeleteEnvironmentWithResponse(ctx, team, envID, auth)
+	resp, err := client.DeleteEnvironmentWithResponse(ctx, team, envID)
 	if err != nil {
 		return fmt.Errorf("deleting environment: %w", err)
 	}

--- a/cmd/environment/get.go
+++ b/cmd/environment/get.go
@@ -25,28 +25,20 @@ func NewGetCmd(opts *options.RootOptions, team *string) *cobra.Command {
 }
 
 func runEnvironmentGet(ctx context.Context, opts *options.RootOptions, team, envID string) error {
-	auth, err := opts.KeyEditor(config.KeyManagement)
+	client, err := opts.Client(config.KeyManagement)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.GetEnvironmentWithResponse(ctx, team, envID, auth)
+	resp, err := client.GetEnvironmentWithResponse(ctx, team, envID)
 	if err != nil {
 		return fmt.Errorf("getting environment: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	env, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.ApplicationvndApiJSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.ApplicationvndApiJSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeEnvironmentDetail(opts, envToDetail(resp.ApplicationvndApiJSON200.Data))
+	return writeEnvironmentDetail(opts, envToDetail(env.Data))
 }

--- a/cmd/environment/list.go
+++ b/cmd/environment/list.go
@@ -35,31 +35,23 @@ func NewListCmd(opts *options.RootOptions, team *string) *cobra.Command {
 }
 
 func runEnvironmentList(ctx context.Context, opts *options.RootOptions, team string) error {
-	auth, err := opts.KeyEditor(config.KeyManagement)
+	client, err := opts.Client(config.KeyManagement)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.ListEnvironmentsWithResponse(ctx, team, nil, auth)
+	resp, err := client.ListEnvironmentsWithResponse(ctx, team, nil)
 	if err != nil {
 		return fmt.Errorf("listing environments: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	list, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.ApplicationvndApiJSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.ApplicationvndApiJSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	items := make([]environmentItem, len(resp.ApplicationvndApiJSON200.Data))
-	for i, e := range resp.ApplicationvndApiJSON200.Data {
+	items := make([]environmentItem, len(list.Data))
+	for i, e := range list.Data {
 		items[i] = envToItem(e)
 	}
 

--- a/cmd/environment/update.go
+++ b/cmd/environment/update.go
@@ -40,14 +40,9 @@ func runEnvironmentUpdate(cmd *cobra.Command, opts *options.RootOptions, team, e
 		return fmt.Errorf("--description, --color, or --delete-protected is required")
 	}
 
-	auth, err := opts.KeyEditor(config.KeyManagement)
+	client, err := opts.Client(config.KeyManagement)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	body := api.UpdateEnvironmentRequest{}
@@ -68,18 +63,15 @@ func runEnvironmentUpdate(cmd *cobra.Command, opts *options.RootOptions, team, e
 		}
 	}
 
-	resp, err := client.UpdateEnvironmentWithApplicationVndAPIPlusJSONBodyWithResponse(cmd.Context(), team, envID, body, auth)
+	resp, err := client.UpdateEnvironmentWithApplicationVndAPIPlusJSONBodyWithResponse(cmd.Context(), team, envID, body)
 	if err != nil {
 		return fmt.Errorf("updating environment: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	env, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.ApplicationvndApiJSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.ApplicationvndApiJSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeEnvironmentDetail(opts, envToDetail(resp.ApplicationvndApiJSON200.Data))
+	return writeEnvironmentDetail(opts, envToDetail(env.Data))
 }

--- a/cmd/key/create.go
+++ b/cmd/key/create.go
@@ -75,14 +75,9 @@ func runKeyCreate(cmd *cobra.Command, opts *options.RootOptions, team, file, nam
 }
 
 func runKeyCreateFromFile(ctx context.Context, opts *options.RootOptions, team, file string) error {
-	auth, err := opts.KeyEditor(config.KeyManagement)
+	client, err := opts.Client(config.KeyManagement)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	data, err := readBodyFile(opts, file)
@@ -90,7 +85,7 @@ func runKeyCreateFromFile(ctx context.Context, opts *options.RootOptions, team, 
 		return err
 	}
 
-	resp, err := client.CreateApiKeyWithBodyWithResponse(ctx, api.TeamSlug(team), "application/vnd.api+json", bytes.NewReader(data), auth)
+	resp, err := client.CreateApiKeyWithBodyWithResponse(ctx, api.TeamSlug(team), "application/vnd.api+json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("creating API key: %w", err)
 	}
@@ -149,14 +144,9 @@ func runKeyCreateFromFlags(cmd *cobra.Command, opts *options.RootOptions, team, 
 		}
 	}
 
-	auth, err := opts.KeyEditor(config.KeyManagement)
+	client, err := opts.Client(config.KeyManagement)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	body := api.ApiKeyCreateRequest{}
@@ -192,7 +182,7 @@ func runKeyCreateFromFlags(cmd *cobra.Command, opts *options.RootOptions, team, 
 		return fmt.Errorf("building request: %w", err)
 	}
 
-	resp, err := client.CreateApiKeyWithApplicationVndAPIPlusJSONBodyWithResponse(cmd.Context(), api.TeamSlug(team), body, auth)
+	resp, err := client.CreateApiKeyWithApplicationVndAPIPlusJSONBodyWithResponse(cmd.Context(), api.TeamSlug(team), body)
 	if err != nil {
 		return fmt.Errorf("creating API key: %w", err)
 	}
@@ -258,15 +248,12 @@ func setPermissions(attrs *api.ConfigurationKeyAttributes, permissions []string)
 }
 
 func handleCreateResponse(opts *options.RootOptions, resp *api.CreateApiKeyResp) error {
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	created, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.ApplicationvndApiJSON201)
+	if err != nil {
 		return err
 	}
 
-	if resp.ApplicationvndApiJSON201 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	detail := createResponseToDetail(resp.ApplicationvndApiJSON201)
+	detail := createResponseToDetail(created)
 
 	if detail.Secret != "" {
 		_, _ = fmt.Fprintf(opts.IOStreams.Err, "Save this key now — it cannot be retrieved again.\n")

--- a/cmd/key/delete.go
+++ b/cmd/key/delete.go
@@ -32,14 +32,9 @@ func NewDeleteCmd(opts *options.RootOptions, team *string) *cobra.Command {
 }
 
 func runKeyDelete(ctx context.Context, opts *options.RootOptions, team, id string, yes bool) error {
-	auth, err := opts.KeyEditor(config.KeyManagement)
+	client, err := opts.Client(config.KeyManagement)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	if !yes {
@@ -59,7 +54,7 @@ func runKeyDelete(ctx context.Context, opts *options.RootOptions, team, id strin
 		}
 	}
 
-	resp, err := client.DeleteApiKeyWithResponse(ctx, api.TeamSlug(team), api.ID(id), auth)
+	resp, err := client.DeleteApiKeyWithResponse(ctx, api.TeamSlug(team), api.ID(id))
 	if err != nil {
 		return fmt.Errorf("deleting API key: %w", err)
 	}

--- a/cmd/key/get.go
+++ b/cmd/key/get.go
@@ -25,28 +25,20 @@ func NewGetCmd(opts *options.RootOptions, team *string) *cobra.Command {
 }
 
 func runKeyGet(ctx context.Context, opts *options.RootOptions, team, id string) error {
-	auth, err := opts.KeyEditor(config.KeyManagement)
+	client, err := opts.Client(config.KeyManagement)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.GetApiKeyWithResponse(ctx, api.TeamSlug(team), api.ID(id), auth)
+	resp, err := client.GetApiKeyWithResponse(ctx, api.TeamSlug(team), api.ID(id))
 	if err != nil {
 		return fmt.Errorf("getting API key: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	key, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.ApplicationvndApiJSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.ApplicationvndApiJSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeKeyDetail(opts, objectToDetail(resp.ApplicationvndApiJSON200.Data))
+	return writeKeyDetail(opts, objectToDetail(key.Data))
 }

--- a/cmd/key/list.go
+++ b/cmd/key/list.go
@@ -30,14 +30,9 @@ func NewListCmd(opts *options.RootOptions, team *string) *cobra.Command {
 }
 
 func runKeyList(ctx context.Context, opts *options.RootOptions, team, filterType string) error {
-	auth, err := opts.KeyEditor(config.KeyManagement)
+	client, err := opts.Client(config.KeyManagement)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	var params *api.ListApiKeysParams
@@ -46,21 +41,18 @@ func runKeyList(ctx context.Context, opts *options.RootOptions, team, filterType
 		params = &api.ListApiKeysParams{FilterType: &ft}
 	}
 
-	resp, err := client.ListApiKeysWithResponse(ctx, api.TeamSlug(team), params, auth)
+	resp, err := client.ListApiKeysWithResponse(ctx, api.TeamSlug(team), params)
 	if err != nil {
 		return fmt.Errorf("listing API keys: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	list, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.ApplicationvndApiJSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.ApplicationvndApiJSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	items := make([]keyItem, len(resp.ApplicationvndApiJSON200.Data))
-	for i, obj := range resp.ApplicationvndApiJSON200.Data {
+	items := make([]keyItem, len(list.Data))
+	for i, obj := range list.Data {
 		items[i] = objectToItem(obj)
 	}
 

--- a/cmd/key/update.go
+++ b/cmd/key/update.go
@@ -49,14 +49,9 @@ func NewUpdateCmd(opts *options.RootOptions, team *string) *cobra.Command {
 }
 
 func runKeyUpdateFromFile(ctx context.Context, opts *options.RootOptions, team, id, file string) error {
-	auth, err := opts.KeyEditor(config.KeyManagement)
+	client, err := opts.Client(config.KeyManagement)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	data, err := readBodyFile(opts, file)
@@ -64,20 +59,17 @@ func runKeyUpdateFromFile(ctx context.Context, opts *options.RootOptions, team, 
 		return err
 	}
 
-	resp, err := client.UpdateApiKeyWithBodyWithResponse(ctx, api.TeamSlug(team), api.ID(id), "application/vnd.api+json", bytes.NewReader(data), auth)
+	resp, err := client.UpdateApiKeyWithBodyWithResponse(ctx, api.TeamSlug(team), api.ID(id), "application/vnd.api+json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("updating API key: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	updated, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.ApplicationvndApiJSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.ApplicationvndApiJSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeKeyDetail(opts, objectToDetail(resp.ApplicationvndApiJSON200.Data))
+	return writeKeyDetail(opts, objectToDetail(updated.Data))
 }
 
 func runKeyUpdateFromFlags(cmd *cobra.Command, opts *options.RootOptions, team, id, name string) error {
@@ -85,30 +77,23 @@ func runKeyUpdateFromFlags(cmd *cobra.Command, opts *options.RootOptions, team, 
 		return fmt.Errorf("--file, --name, --disabled, or --enabled is required")
 	}
 
-	auth, err := opts.KeyEditor(config.KeyManagement)
+	client, err := opts.Client(config.KeyManagement)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	ctx := cmd.Context()
 
-	getResp, err := client.GetApiKeyWithResponse(ctx, api.TeamSlug(team), api.ID(id), auth)
+	getResp, err := client.GetApiKeyWithResponse(ctx, api.TeamSlug(team), api.ID(id))
 	if err != nil {
 		return fmt.Errorf("getting API key: %w", err)
 	}
-	if err := api.CheckResponse(getResp.StatusCode(), getResp.Body); err != nil {
+	existing, err := api.Decode(getResp.StatusCode(), getResp.Status(), getResp.Body, getResp.ApplicationvndApiJSON200)
+	if err != nil {
 		return err
 	}
-	if getResp.ApplicationvndApiJSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", getResp.Status())
-	}
 
-	current := objectToDetail(getResp.ApplicationvndApiJSON200.Data)
+	current := objectToDetail(existing.Data)
 
 	if cmd.Flags().Changed("name") {
 		current.Name = name
@@ -125,20 +110,17 @@ func runKeyUpdateFromFlags(cmd *cobra.Command, opts *options.RootOptions, team, 
 		return err
 	}
 
-	resp, err := client.UpdateApiKeyWithApplicationVndAPIPlusJSONBodyWithResponse(ctx, api.TeamSlug(team), api.ID(id), body, auth)
+	resp, err := client.UpdateApiKeyWithApplicationVndAPIPlusJSONBodyWithResponse(ctx, api.TeamSlug(team), api.ID(id), body)
 	if err != nil {
 		return fmt.Errorf("updating API key: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	updated, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.ApplicationvndApiJSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.ApplicationvndApiJSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeKeyDetail(opts, objectToDetail(resp.ApplicationvndApiJSON200.Data))
+	return writeKeyDetail(opts, objectToDetail(updated.Data))
 }
 
 func buildKeyUpdateRequest(id, name string, disabled bool) (api.ApiKeyUpdateRequest, error) {

--- a/cmd/marker/create.go
+++ b/cmd/marker/create.go
@@ -76,28 +76,20 @@ func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runMarkerCreate(ctx context.Context, opts *options.RootOptions, dataset string, body api.CreateMarkerJSONRequestBody) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.CreateMarkerWithResponse(ctx, dataset, body, auth)
+	resp, err := client.CreateMarkerWithResponse(ctx, dataset, body)
 	if err != nil {
 		return fmt.Errorf("creating marker: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	marker, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON201)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON201 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeDetail(opts, markerToItem(*resp.JSON201))
+	return writeDetail(opts, markerToItem(*marker))
 }

--- a/cmd/marker/delete.go
+++ b/cmd/marker/delete.go
@@ -29,14 +29,9 @@ func NewDeleteCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runMarkerDelete(ctx context.Context, opts *options.RootOptions, dataset, markerID string, yes bool) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	if !yes {
@@ -45,7 +40,7 @@ func runMarkerDelete(ctx context.Context, opts *options.RootOptions, dataset, ma
 		}
 
 		// Fetch marker for confirmation display
-		listResp, err := client.GetMarkerWithResponse(ctx, dataset, auth)
+		listResp, err := client.GetMarkerWithResponse(ctx, dataset)
 		if err != nil {
 			return fmt.Errorf("listing markers: %w", err)
 		}
@@ -80,7 +75,7 @@ func runMarkerDelete(ctx context.Context, opts *options.RootOptions, dataset, ma
 		}
 	}
 
-	resp, err := client.DeleteMarkerWithResponse(ctx, dataset, markerID, auth)
+	resp, err := client.DeleteMarkerWithResponse(ctx, dataset, markerID)
 	if err != nil {
 		return fmt.Errorf("deleting marker: %w", err)
 	}

--- a/cmd/marker/list.go
+++ b/cmd/marker/list.go
@@ -21,31 +21,23 @@ func NewListCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runMarkerList(ctx context.Context, opts *options.RootOptions, dataset string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.GetMarkerWithResponse(ctx, dataset, auth)
+	resp, err := client.GetMarkerWithResponse(ctx, dataset)
 	if err != nil {
 		return fmt.Errorf("listing markers: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	markers, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	items := make([]markerItem, len(*resp.JSON200))
-	for i, m := range *resp.JSON200 {
+	items := make([]markerItem, len(*markers))
+	for i, m := range *markers {
 		items[i] = markerToItem(m)
 	}
 

--- a/cmd/marker/setting_create.go
+++ b/cmd/marker/setting_create.go
@@ -53,28 +53,20 @@ func NewSettingCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Comm
 }
 
 func runSettingCreate(ctx context.Context, opts *options.RootOptions, dataset string, body api.CreateMarkerSettingJSONRequestBody) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.CreateMarkerSettingWithResponse(ctx, api.DatasetSlugOrAll(dataset), body, auth)
+	resp, err := client.CreateMarkerSettingWithResponse(ctx, api.DatasetSlugOrAll(dataset), body)
 	if err != nil {
 		return fmt.Errorf("creating marker setting: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	setting, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON201)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON201 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeSettingDetail(opts, toSettingItem(*resp.JSON201))
+	return writeSettingDetail(opts, toSettingItem(*setting))
 }

--- a/cmd/marker/setting_delete.go
+++ b/cmd/marker/setting_delete.go
@@ -29,14 +29,9 @@ func NewSettingDeleteCmd(opts *options.RootOptions, dataset *string) *cobra.Comm
 }
 
 func runSettingDelete(ctx context.Context, opts *options.RootOptions, dataset, settingID string, yes bool) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	if !yes {
@@ -56,7 +51,7 @@ func runSettingDelete(ctx context.Context, opts *options.RootOptions, dataset, s
 		}
 	}
 
-	resp, err := client.DeleteMarkerSettingsWithResponse(ctx, api.DatasetSlugOrAll(dataset), settingID, auth)
+	resp, err := client.DeleteMarkerSettingsWithResponse(ctx, api.DatasetSlugOrAll(dataset), settingID)
 	if err != nil {
 		return fmt.Errorf("deleting marker setting: %w", err)
 	}

--- a/cmd/marker/setting_list.go
+++ b/cmd/marker/setting_list.go
@@ -21,31 +21,23 @@ func NewSettingListCmd(opts *options.RootOptions, dataset *string) *cobra.Comman
 }
 
 func runSettingList(ctx context.Context, opts *options.RootOptions, dataset string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.ListMarkerSettingsWithResponse(ctx, api.DatasetSlugOrAll(dataset), auth)
+	resp, err := client.ListMarkerSettingsWithResponse(ctx, api.DatasetSlugOrAll(dataset))
 	if err != nil {
 		return fmt.Errorf("listing marker settings: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	settings, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	items := make([]settingItem, len(*resp.JSON200))
-	for i, s := range *resp.JSON200 {
+	items := make([]settingItem, len(*settings))
+	for i, s := range *settings {
 		items[i] = toSettingItem(s)
 	}
 

--- a/cmd/marker/setting_update.go
+++ b/cmd/marker/setting_update.go
@@ -34,18 +34,13 @@ func NewSettingUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.Comm
 func runSettingUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, settingID, settingType, color string) error {
 	ctx := cmd.Context()
 
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
 	if settingType == "" || color == "" {
-		existing, err := findMarkerSetting(ctx, client, dataset, settingID, auth)
+		existing, err := findMarkerSetting(ctx, client, dataset, settingID)
 		if err != nil {
 			return err
 		}
@@ -62,34 +57,29 @@ func runSettingUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, se
 		Color: color,
 	}
 
-	resp, err := client.UpdateMarkerSettingsWithResponse(ctx, api.DatasetSlugOrAll(dataset), settingID, body, auth)
+	resp, err := client.UpdateMarkerSettingsWithResponse(ctx, api.DatasetSlugOrAll(dataset), settingID, body)
 	if err != nil {
 		return fmt.Errorf("updating marker setting: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	setting, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeSettingDetail(opts, toSettingItem(*resp.JSON200))
+	return writeSettingDetail(opts, toSettingItem(*setting))
 }
 
-func findMarkerSetting(ctx context.Context, client *api.ClientWithResponses, dataset, settingID string, auth api.RequestEditorFn) (*api.MarkerSetting, error) {
-	resp, err := client.ListMarkerSettingsWithResponse(ctx, api.DatasetSlugOrAll(dataset), auth)
+func findMarkerSetting(ctx context.Context, client *api.ClientWithResponses, dataset, settingID string) (*api.MarkerSetting, error) {
+	resp, err := client.ListMarkerSettingsWithResponse(ctx, api.DatasetSlugOrAll(dataset))
 	if err != nil {
 		return nil, fmt.Errorf("listing marker settings: %w", err)
 	}
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	settings, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return nil, err
 	}
-	if resp.JSON200 == nil {
-		return nil, fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-	for _, s := range *resp.JSON200 {
+	for _, s := range *settings {
 		if s.Id != nil && *s.Id == settingID {
 			return &s, nil
 		}

--- a/cmd/marker/update.go
+++ b/cmd/marker/update.go
@@ -42,31 +42,23 @@ func NewUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 func runMarkerUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, markerID, markerType, message, url string, startTime, endTime int, color string) error {
 	ctx := cmd.Context()
 
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
 	// Fetch existing marker (no individual GET — list and filter)
-	listResp, err := client.GetMarkerWithResponse(ctx, dataset, auth)
+	listResp, err := client.GetMarkerWithResponse(ctx, dataset)
 	if err != nil {
 		return fmt.Errorf("listing markers: %w", err)
 	}
 
-	if err := api.CheckResponse(listResp.StatusCode(), listResp.Body); err != nil {
+	markers, err := api.Decode(listResp.StatusCode(), listResp.Status(), listResp.Body, listResp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if listResp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", listResp.Status())
-	}
-
-	existing, err := findMarker(*listResp.JSON200, markerID)
+	existing, err := findMarker(*markers, markerID)
 	if err != nil {
 		return err
 	}
@@ -96,18 +88,15 @@ func runMarkerUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, mar
 		return fmt.Errorf("encoding marker: %w", err)
 	}
 
-	resp, err := client.UpdateMarkerWithBodyWithResponse(ctx, dataset, markerID, "application/json", bytes.NewReader(data), auth)
+	resp, err := client.UpdateMarkerWithBodyWithResponse(ctx, dataset, markerID, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("updating marker: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	marker, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeDetail(opts, markerToItem(*resp.JSON200))
+	return writeDetail(opts, markerToItem(*marker))
 }

--- a/cmd/options/options.go
+++ b/cmd/options/options.go
@@ -92,6 +92,21 @@ func (o *RootOptions) KeyEditor(kt config.KeyType) (api.RequestEditorFn, error) 
 	}, nil
 }
 
+// Client builds an API client with auth for the given key type baked in via a
+// request editor, so call sites issue requests without threading an editor
+// argument through every WithResponse call.
+func (o *RootOptions) Client(kt config.KeyType) (*api.ClientWithResponses, error) {
+	editor, err := o.KeyEditor(kt)
+	if err != nil {
+		return nil, err
+	}
+	client, err := api.NewClientWithResponses(o.ResolveAPIUrl(), api.WithRequestEditorFn(editor))
+	if err != nil {
+		return nil, fmt.Errorf("creating API client: %w", err)
+	}
+	return client, nil
+}
+
 func (o *RootOptions) OutputWriter() *output.Writer {
 	return output.New(o.IOStreams.Out, o.ResolveFormat())
 }

--- a/cmd/query/annotation_create.go
+++ b/cmd/query/annotation_create.go
@@ -41,7 +41,7 @@ func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runAnnotationCreate(cmd *cobra.Command, opts *options.RootOptions, dataset, file, name, desc, queryID string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
@@ -91,12 +91,7 @@ func runAnnotationCreate(cmd *cobra.Command, opts *options.RootOptions, dataset,
 		}
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.CreateQueryAnnotationWithBodyWithResponse(ctx, dataset, "application/json", bytes.NewReader(data), auth)
+	resp, err := client.CreateQueryAnnotationWithBodyWithResponse(ctx, dataset, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("creating query annotation: %w", err)
 	}

--- a/cmd/query/annotation_delete.go
+++ b/cmd/query/annotation_delete.go
@@ -30,14 +30,9 @@ func NewDeleteCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runAnnotationDelete(ctx context.Context, opts *options.RootOptions, dataset, annotationID string, yes bool) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	if !yes {
@@ -45,7 +40,7 @@ func runAnnotationDelete(ctx context.Context, opts *options.RootOptions, dataset
 			return fmt.Errorf("--yes is required in non-interactive mode")
 		}
 
-		a, err := getAnnotation(ctx, client, auth, dataset, annotationID)
+		a, err := getAnnotation(ctx, client, dataset, annotationID)
 		if err != nil {
 			return err
 		}
@@ -59,7 +54,7 @@ func runAnnotationDelete(ctx context.Context, opts *options.RootOptions, dataset
 		}
 	}
 
-	resp, err := client.DeleteQueryAnnotationWithResponse(ctx, dataset, annotationID, auth)
+	resp, err := client.DeleteQueryAnnotationWithResponse(ctx, dataset, annotationID)
 	if err != nil {
 		return fmt.Errorf("deleting query annotation: %w", err)
 	}

--- a/cmd/query/annotation_list.go
+++ b/cmd/query/annotation_list.go
@@ -27,14 +27,9 @@ func NewListCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runAnnotationList(ctx context.Context, opts *options.RootOptions, dataset string, includeBoardAnnotations bool) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	params := &api.ListQueryAnnotationsParams{}
@@ -42,21 +37,18 @@ func runAnnotationList(ctx context.Context, opts *options.RootOptions, dataset s
 		params.IncludeBoardAnnotations = ptr(true)
 	}
 
-	resp, err := client.ListQueryAnnotationsWithResponse(ctx, dataset, params, auth)
+	resp, err := client.ListQueryAnnotationsWithResponse(ctx, dataset, params)
 	if err != nil {
 		return fmt.Errorf("listing query annotations: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	list, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	items := make([]annotationItem, len(*resp.JSON200))
-	for i, a := range *resp.JSON200 {
+	items := make([]annotationItem, len(*list))
+	for i, a := range *list {
 		item := annotationItem{
 			Name:    a.Name,
 			QueryID: a.QueryId,

--- a/cmd/query/annotation_update.go
+++ b/cmd/query/annotation_update.go
@@ -38,27 +38,22 @@ func NewUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runAnnotationUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, annotationID, file, name, desc string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	ctx := cmd.Context()
 
 	if file != "" {
-		return updateAnnotationFromFile(ctx, client, opts, auth, dataset, annotationID, file)
+		return updateAnnotationFromFile(ctx, client, opts, dataset, annotationID, file)
 	}
 
 	if !cmd.Flags().Changed("name") && !cmd.Flags().Changed("description") {
 		return fmt.Errorf("--file, --name, or --description is required")
 	}
 
-	current, err := getAnnotation(ctx, client, auth, dataset, annotationID)
+	current, err := getAnnotation(ctx, client, dataset, annotationID)
 	if err != nil {
 		return err
 	}
@@ -75,23 +70,20 @@ func runAnnotationUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset,
 		return fmt.Errorf("encoding query annotation: %w", err)
 	}
 
-	resp, err := client.UpdateQueryAnnotationWithBodyWithResponse(ctx, dataset, annotationID, "application/json", bytes.NewReader(data), auth)
+	resp, err := client.UpdateQueryAnnotationWithBodyWithResponse(ctx, dataset, annotationID, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("updating query annotation: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	annotation, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeAnnotationDetail(opts, annotationToDetail(*resp.JSON200))
+	return writeAnnotationDetail(opts, annotationToDetail(*annotation))
 }
 
-func updateAnnotationFromFile(ctx context.Context, client *api.ClientWithResponses, opts *options.RootOptions, auth api.RequestEditorFn, dataset, annotationID, file string) error {
+func updateAnnotationFromFile(ctx context.Context, client *api.ClientWithResponses, opts *options.RootOptions, dataset, annotationID, file string) error {
 	raw, err := readFile(opts, file)
 	if err != nil {
 		return err
@@ -102,35 +94,24 @@ func updateAnnotationFromFile(ctx context.Context, client *api.ClientWithRespons
 		return fmt.Errorf("stripping read-only fields: %w", err)
 	}
 
-	resp, err := client.UpdateQueryAnnotationWithBodyWithResponse(ctx, dataset, annotationID, "application/json", bytes.NewReader(data), auth)
+	resp, err := client.UpdateQueryAnnotationWithBodyWithResponse(ctx, dataset, annotationID, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("updating query annotation: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	annotation, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return writeAnnotationDetail(opts, annotationToDetail(*resp.JSON200))
+	return writeAnnotationDetail(opts, annotationToDetail(*annotation))
 }
 
-func getAnnotation(ctx context.Context, client *api.ClientWithResponses, auth api.RequestEditorFn, dataset, annotationID string) (*api.QueryAnnotation, error) {
-	resp, err := client.GetQueryAnnotationWithResponse(ctx, dataset, annotationID, auth)
+func getAnnotation(ctx context.Context, client *api.ClientWithResponses, dataset, annotationID string) (*api.QueryAnnotation, error) {
+	resp, err := client.GetQueryAnnotationWithResponse(ctx, dataset, annotationID)
 	if err != nil {
 		return nil, fmt.Errorf("getting query annotation: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
-		return nil, err
-	}
-
-	if resp.JSON200 == nil {
-		return nil, fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	return resp.JSON200, nil
+	return api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
 }

--- a/cmd/query/annotation_view.go
+++ b/cmd/query/annotation_view.go
@@ -29,32 +29,22 @@ func NewViewCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runAnnotationView(ctx context.Context, opts *options.RootOptions, dataset, annotationID string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.GetQueryAnnotationWithResponse(ctx, dataset, annotationID, auth)
+	resp, err := client.GetQueryAnnotationWithResponse(ctx, dataset, annotationID)
 	if err != nil {
 		return fmt.Errorf("getting query annotation: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	annotation, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	annotation := resp.JSON200
-
-	queryResp, err := client.GetQueryWithResponse(ctx, dataset, annotation.QueryId, auth)
+	queryResp, err := client.GetQueryWithResponse(ctx, dataset, annotation.QueryId)
 	if err != nil {
 		return fmt.Errorf("getting query: %w", err)
 	}

--- a/cmd/query/run.go
+++ b/cmd/query/run.go
@@ -36,17 +36,12 @@ func NewRunCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runQueryRun(ctx context.Context, opts *options.RootOptions, dataset, file, annotation string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	queryID, err := resolveQueryID(ctx, opts, client, dataset, auth, file, annotation)
+	queryID, err := resolveQueryID(ctx, opts, client, dataset, file, annotation)
 	if err != nil {
 		return err
 	}
@@ -54,38 +49,34 @@ func runQueryRun(ctx context.Context, opts *options.RootOptions, dataset, file, 
 	resultResp, err := client.CreateQueryResultWithResponse(ctx, dataset, api.CreateQueryResultRequest{
 		QueryId:       &queryID,
 		DisableSeries: ptr(true),
-	}, auth)
+	})
 	if err != nil {
 		return fmt.Errorf("creating query result: %w", err)
 	}
-	if err := api.CheckResponse(resultResp.StatusCode(), resultResp.Body); err != nil {
+	result, err := api.Decode(resultResp.StatusCode(), resultResp.Status(), resultResp.Body, resultResp.JSON201)
+	if err != nil {
 		return err
 	}
-	if resultResp.JSON201 == nil {
-		return fmt.Errorf("unexpected response: %s", resultResp.Status())
-	}
-	if resultResp.JSON201.Id == nil {
+	if result.Id == nil {
 		return fmt.Errorf("query result ID missing from response")
 	}
-	resultID := *resultResp.JSON201.Id
+	resultID := *result.Id
 
 	cfg := poll.Config{
 		Title:       "Running query...",
 		Interactive: opts.IOStreams.CanPrompt(),
 	}
 	details, err := poll.Poll(ctx, cfg, func(ctx context.Context) (*api.QueryResultDetails, bool, error) {
-		resp, err := client.GetQueryResultWithResponse(ctx, dataset, resultID, auth)
+		resp, err := client.GetQueryResultWithResponse(ctx, dataset, resultID)
 		if err != nil {
 			return nil, false, fmt.Errorf("getting query result: %w", err)
 		}
-		if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+		result, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+		if err != nil {
 			return nil, false, err
 		}
-		if resp.JSON200 == nil {
-			return nil, false, fmt.Errorf("unexpected response: %s", resp.Status())
-		}
-		complete := resp.JSON200.Complete != nil && *resp.JSON200.Complete
-		return resp.JSON200, complete, nil
+		complete := result.Complete != nil && *result.Complete
+		return result, complete, nil
 	})
 	if err != nil {
 		return err
@@ -98,56 +89,52 @@ func runQueryRun(ctx context.Context, opts *options.RootOptions, dataset, file, 
 	return opts.OutputWriter().WriteDynamic(details, buildResultTable(details))
 }
 
-func resolveQueryID(ctx context.Context, opts *options.RootOptions, client *api.ClientWithResponses, dataset string, auth api.RequestEditorFn, file, annotation string) (string, error) {
+func resolveQueryID(ctx context.Context, opts *options.RootOptions, client *api.ClientWithResponses, dataset string, file, annotation string) (string, error) {
 	switch {
 	case file != "":
-		return createQueryFromFile(ctx, opts, client, dataset, auth, file)
+		return createQueryFromFile(ctx, opts, client, dataset, file)
 	case annotation != "":
-		return queryIDFromAnnotation(ctx, client, dataset, auth, annotation)
+		return queryIDFromAnnotation(ctx, client, dataset, annotation)
 	case opts.IOStreams.CanPrompt():
-		return promptQueryID(ctx, opts, client, dataset, auth)
+		return promptQueryID(ctx, opts, client, dataset)
 	default:
 		return "", fmt.Errorf("either --file or --annotation is required")
 	}
 }
 
-func createQueryFromFile(ctx context.Context, opts *options.RootOptions, client *api.ClientWithResponses, dataset string, auth api.RequestEditorFn, file string) (string, error) {
+func createQueryFromFile(ctx context.Context, opts *options.RootOptions, client *api.ClientWithResponses, dataset string, file string) (string, error) {
 	data, err := readFile(opts, file)
 	if err != nil {
 		return "", err
 	}
 
-	resp, err := client.CreateQueryWithBodyWithResponse(ctx, dataset, "application/json", bytes.NewReader(data), auth)
+	resp, err := client.CreateQueryWithBodyWithResponse(ctx, dataset, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return "", fmt.Errorf("creating query: %w", err)
 	}
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	query, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return "", err
 	}
-	if resp.JSON200 == nil {
-		return "", fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-	if resp.JSON200.Id == nil {
+	if query.Id == nil {
 		return "", fmt.Errorf("query ID missing from response")
 	}
-	return *resp.JSON200.Id, nil
+	return *query.Id, nil
 }
 
-func queryIDFromAnnotation(ctx context.Context, client *api.ClientWithResponses, dataset string, auth api.RequestEditorFn, annotationID string) (string, error) {
-	resp, err := client.GetQueryAnnotationWithResponse(ctx, dataset, annotationID, auth)
+func queryIDFromAnnotation(ctx context.Context, client *api.ClientWithResponses, dataset string, annotationID string) (string, error) {
+	resp, err := client.GetQueryAnnotationWithResponse(ctx, dataset, annotationID)
 	if err != nil {
 		return "", fmt.Errorf("getting query annotation: %w", err)
 	}
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	annotation, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return "", err
 	}
-	if resp.JSON200 == nil {
-		return "", fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-	return resp.JSON200.QueryId, nil
+	return annotation.QueryId, nil
 }
 
-func promptQueryID(ctx context.Context, opts *options.RootOptions, client *api.ClientWithResponses, dataset string, auth api.RequestEditorFn) (string, error) {
+func promptQueryID(ctx context.Context, opts *options.RootOptions, client *api.ClientWithResponses, dataset string) (string, error) {
 	mode, err := prompt.Choice(opts.IOStreams.Out, opts.IOStreams.In, "Query source (file, annotation): ", []string{"file", "annotation"})
 	if err != nil {
 		return "", err
@@ -159,13 +146,13 @@ func promptQueryID(ctx context.Context, opts *options.RootOptions, client *api.C
 		if err != nil {
 			return "", err
 		}
-		return createQueryFromFile(ctx, opts, client, dataset, auth, path)
+		return createQueryFromFile(ctx, opts, client, dataset, path)
 	case "annotation":
 		id, err := prompt.Line(opts.IOStreams.Out, opts.IOStreams.In, "Annotation ID: ")
 		if err != nil {
 			return "", err
 		}
-		return queryIDFromAnnotation(ctx, client, dataset, auth, id)
+		return queryIDFromAnnotation(ctx, client, dataset, id)
 	default:
 		return "", fmt.Errorf("unexpected mode: %s", mode)
 	}

--- a/cmd/recipient/create.go
+++ b/cmd/recipient/create.go
@@ -237,17 +237,12 @@ func readFile(opts *options.RootOptions, file string) ([]byte, error) {
 }
 
 func sendCreate(ctx context.Context, opts *options.RootOptions, data []byte) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.CreateRecipientWithBodyWithResponse(ctx, "application/json", bytes.NewReader(data), auth)
+	resp, err := client.CreateRecipientWithBodyWithResponse(ctx, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("creating recipient: %w", err)
 	}

--- a/cmd/recipient/delete.go
+++ b/cmd/recipient/delete.go
@@ -30,14 +30,9 @@ func NewDeleteCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runDelete(ctx context.Context, opts *options.RootOptions, recipientID string, yes bool) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	if !yes {
@@ -54,7 +49,7 @@ func runDelete(ctx context.Context, opts *options.RootOptions, recipientID strin
 		}
 	}
 
-	resp, err := client.DeleteRecipientWithResponse(ctx, recipientID, auth)
+	resp, err := client.DeleteRecipientWithResponse(ctx, recipientID)
 	if err != nil {
 		return fmt.Errorf("deleting recipient: %w", err)
 	}

--- a/cmd/recipient/get.go
+++ b/cmd/recipient/get.go
@@ -22,17 +22,12 @@ func NewGetCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runGet(ctx context.Context, opts *options.RootOptions, recipientID string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.GetRecipientWithResponse(ctx, recipientID, auth)
+	resp, err := client.GetRecipientWithResponse(ctx, recipientID)
 	if err != nil {
 		return fmt.Errorf("getting recipient: %w", err)
 	}

--- a/cmd/recipient/list.go
+++ b/cmd/recipient/list.go
@@ -30,17 +30,12 @@ func NewListCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runList(ctx context.Context, opts *options.RootOptions) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.ListRecipientsWithResponse(ctx, auth)
+	resp, err := client.ListRecipientsWithResponse(ctx)
 	if err != nil {
 		return fmt.Errorf("listing recipients: %w", err)
 	}

--- a/cmd/recipient/triggers.go
+++ b/cmd/recipient/triggers.go
@@ -47,31 +47,23 @@ func NewTriggersCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runTriggers(ctx context.Context, opts *options.RootOptions, recipientID string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.ListTriggersWithRecipientWithResponse(ctx, recipientID, auth)
+	resp, err := client.ListTriggersWithRecipientWithResponse(ctx, recipientID)
 	if err != nil {
 		return fmt.Errorf("listing triggers for recipient: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	triggers, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	items := make([]triggerItem, len(*resp.JSON200))
-	for i, t := range *resp.JSON200 {
+	items := make([]triggerItem, len(*triggers))
+	for i, t := range *triggers {
 		items[i] = toTriggerItem(t)
 	}
 

--- a/cmd/recipient/update.go
+++ b/cmd/recipient/update.go
@@ -47,14 +47,9 @@ func NewUpdateCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runUpdate(cmd *cobra.Command, opts *options.RootOptions, recipientID, file, recipientType, target, channel, integrationKey, name, url string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	ctx := cmd.Context()
@@ -66,7 +61,7 @@ func runUpdate(cmd *cobra.Command, opts *options.RootOptions, recipientID, file,
 			return err
 		}
 	} else if hasAnyFlag(cmd, "type", "target", "channel", "integration-key", "name", "url") {
-		resp, err := client.GetRecipientWithResponse(ctx, recipientID, auth)
+		resp, err := client.GetRecipientWithResponse(ctx, recipientID)
 		if err != nil {
 			return fmt.Errorf("getting recipient: %w", err)
 		}
@@ -89,7 +84,7 @@ func runUpdate(cmd *cobra.Command, opts *options.RootOptions, recipientID, file,
 		return fmt.Errorf("--file, --type, --target, --channel, --integration-key, --name, or --url is required")
 	}
 
-	resp, err := client.UpdateRecipientWithBodyWithResponse(ctx, recipientID, "application/json", bytes.NewReader(data), auth)
+	resp, err := client.UpdateRecipientWithBodyWithResponse(ctx, recipientID, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("updating recipient: %w", err)
 	}

--- a/cmd/slo/burn_alert_create.go
+++ b/cmd/slo/burn_alert_create.go
@@ -56,7 +56,7 @@ func NewBurnAlertCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Co
 }
 
 func runBurnAlertCreateFromFile(ctx context.Context, opts *options.RootOptions, dataset, file string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
@@ -66,12 +66,7 @@ func runBurnAlertCreateFromFile(ctx context.Context, opts *options.RootOptions, 
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.CreateBurnAlertWithBodyWithResponse(ctx, dataset, "application/json", bytes.NewReader(data), auth)
+	resp, err := client.CreateBurnAlertWithBodyWithResponse(ctx, dataset, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("creating burn alert: %w", err)
 	}
@@ -138,17 +133,12 @@ func runBurnAlertCreateFromFlags(ctx context.Context, opts *options.RootOptions,
 		return fmt.Errorf("encoding burn alert: %w", err)
 	}
 
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.CreateBurnAlertWithBodyWithResponse(ctx, dataset, "application/json", bytes.NewReader(data), auth)
+	resp, err := client.CreateBurnAlertWithBodyWithResponse(ctx, dataset, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("creating burn alert: %w", err)
 	}

--- a/cmd/slo/burn_alert_delete.go
+++ b/cmd/slo/burn_alert_delete.go
@@ -30,7 +30,7 @@ func NewBurnAlertDeleteCmd(opts *options.RootOptions, dataset *string) *cobra.Co
 }
 
 func runBurnAlertDelete(ctx context.Context, opts *options.RootOptions, dataset, burnAlertID string, yes bool) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
@@ -49,12 +49,7 @@ func runBurnAlertDelete(ctx context.Context, opts *options.RootOptions, dataset,
 		}
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.DeleteBurnAlertWithResponse(ctx, dataset, burnAlertID, auth)
+	resp, err := client.DeleteBurnAlertWithResponse(ctx, dataset, burnAlertID)
 	if err != nil {
 		return fmt.Errorf("deleting burn alert: %w", err)
 	}

--- a/cmd/slo/burn_alert_get.go
+++ b/cmd/slo/burn_alert_get.go
@@ -24,17 +24,12 @@ func NewBurnAlertGetCmd(opts *options.RootOptions, dataset *string) *cobra.Comma
 }
 
 func runBurnAlertGet(ctx context.Context, opts *options.RootOptions, dataset, burnAlertID string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.GetBurnAlertWithResponse(ctx, dataset, burnAlertID, auth)
+	resp, err := client.GetBurnAlertWithResponse(ctx, dataset, burnAlertID)
 	if err != nil {
 		return fmt.Errorf("getting burn alert: %w", err)
 	}

--- a/cmd/slo/burn_alert_list.go
+++ b/cmd/slo/burn_alert_list.go
@@ -29,18 +29,13 @@ func NewBurnAlertListCmd(opts *options.RootOptions, dataset *string) *cobra.Comm
 }
 
 func runBurnAlertList(ctx context.Context, opts *options.RootOptions, dataset, sloID string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
 	params := &api.ListBurnAlertsBySloParams{SloId: sloID}
-	resp, err := client.ListBurnAlertsBySloWithResponse(ctx, dataset, params, auth)
+	resp, err := client.ListBurnAlertsBySloWithResponse(ctx, dataset, params)
 	if err != nil {
 		return fmt.Errorf("listing burn alerts: %w", err)
 	}

--- a/cmd/slo/burn_alert_update.go
+++ b/cmd/slo/burn_alert_update.go
@@ -47,14 +47,9 @@ func NewBurnAlertUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.Co
 var burnAlertUpdateFlags = []string{"exhaustion-minutes", "budget-rate-window-minutes", "budget-rate-threshold", "recipient", "description"}
 
 func runBurnAlertUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, burnAlertID, file string, exhaustionMinutes, budgetRateWindow, budgetRateThreshold int, recipients []string, description string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	ctx := cmd.Context()
@@ -66,7 +61,7 @@ func runBurnAlertUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, 
 			return err
 		}
 	} else if hasAnyFlag(cmd, burnAlertUpdateFlags...) {
-		resp, err := client.GetBurnAlertWithResponse(ctx, dataset, burnAlertID, auth)
+		resp, err := client.GetBurnAlertWithResponse(ctx, dataset, burnAlertID)
 		if err != nil {
 			return fmt.Errorf("getting burn alert: %w", err)
 		}
@@ -89,7 +84,7 @@ func runBurnAlertUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, 
 		return fmt.Errorf("--file, --exhaustion-minutes, --budget-rate-window-minutes, --budget-rate-threshold, --recipient, or --description is required")
 	}
 
-	resp, err := client.UpdateBurnAlertWithBodyWithResponse(ctx, dataset, burnAlertID, "application/json", bytes.NewReader(data), auth)
+	resp, err := client.UpdateBurnAlertWithBodyWithResponse(ctx, dataset, burnAlertID, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("updating burn alert: %w", err)
 	}

--- a/cmd/slo/create.go
+++ b/cmd/slo/create.go
@@ -49,7 +49,7 @@ func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runSLOCreate(cmd *cobra.Command, opts *options.RootOptions, dataset, file, name, sliAlias string, target, timePeriod int, desc string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
@@ -84,12 +84,7 @@ func runSLOCreate(cmd *cobra.Command, opts *options.RootOptions, dataset, file, 
 		}
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.CreateSloWithBodyWithResponse(cmd.Context(), dataset, "application/json", bytes.NewReader(data), auth)
+	resp, err := client.CreateSloWithBodyWithResponse(cmd.Context(), dataset, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("creating SLO: %w", err)
 	}

--- a/cmd/slo/delete.go
+++ b/cmd/slo/delete.go
@@ -30,14 +30,9 @@ func NewDeleteCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runSLODelete(ctx context.Context, opts *options.RootOptions, dataset, sloID string, yes bool) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	if !yes {
@@ -45,7 +40,7 @@ func runSLODelete(ctx context.Context, opts *options.RootOptions, dataset, sloID
 			return fmt.Errorf("--yes is required in non-interactive mode")
 		}
 
-		s, err := getSLO(ctx, client, auth, dataset, sloID)
+		s, err := getSLO(ctx, client, dataset, sloID)
 		if err != nil {
 			return err
 		}
@@ -59,7 +54,7 @@ func runSLODelete(ctx context.Context, opts *options.RootOptions, dataset, sloID
 		}
 	}
 
-	resp, err := client.DeleteSloWithResponse(ctx, dataset, sloID, auth)
+	resp, err := client.DeleteSloWithResponse(ctx, dataset, sloID)
 	if err != nil {
 		return fmt.Errorf("deleting SLO: %w", err)
 	}

--- a/cmd/slo/get.go
+++ b/cmd/slo/get.go
@@ -29,14 +29,9 @@ func NewGetCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runSLOGet(ctx context.Context, opts *options.RootOptions, dataset, sloID string, detailed bool) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	params := &api.GetSloParams{}
@@ -44,7 +39,7 @@ func runSLOGet(ctx context.Context, opts *options.RootOptions, dataset, sloID st
 		params.Detailed = ptr(true)
 	}
 
-	resp, err := client.GetSloWithResponse(ctx, dataset, sloID, params, auth)
+	resp, err := client.GetSloWithResponse(ctx, dataset, sloID, params)
 	if err != nil {
 		return fmt.Errorf("getting SLO: %w", err)
 	}

--- a/cmd/slo/history.go
+++ b/cmd/slo/history.go
@@ -39,14 +39,9 @@ func NewHistoryCmd(opts *options.RootOptions, _ *string) *cobra.Command {
 }
 
 func runHistory(ctx context.Context, opts *options.RootOptions, sloIDs []string, startTime, endTime int) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	ids := make([]interface{}, len(sloIDs))
@@ -60,20 +55,17 @@ func runHistory(ctx context.Context, opts *options.RootOptions, sloIDs []string,
 		EndTime:   endTime,
 	}
 
-	resp, err := client.GetSloHistoryWithResponse(ctx, body, auth)
+	resp, err := client.GetSloHistoryWithResponse(ctx, body)
 	if err != nil {
 		return fmt.Errorf("getting SLO history: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	history, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	data := *resp.JSON200
+	data := *history
 
 	return opts.OutputWriter().WriteDynamic(data, historyTable(data))
 }

--- a/cmd/slo/list.go
+++ b/cmd/slo/list.go
@@ -34,31 +34,23 @@ func NewListCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runSLOList(ctx context.Context, opts *options.RootOptions, dataset string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.ListSlosWithResponse(ctx, dataset, auth)
+	resp, err := client.ListSlosWithResponse(ctx, dataset)
 	if err != nil {
 		return fmt.Errorf("listing SLOs: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	slos, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	items := make([]sloItem, len(*resp.JSON200))
-	for i, s := range *resp.JSON200 {
+	items := make([]sloItem, len(*slos))
+	for i, s := range *slos {
 		items[i] = sloItem{
 			ID:               deref.String(s.Id),
 			Name:             s.Name,

--- a/cmd/slo/update.go
+++ b/cmd/slo/update.go
@@ -45,27 +45,22 @@ func NewUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runSLOUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, sloID, file, name, desc string, target, timePeriod int) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	ctx := cmd.Context()
 
 	if file != "" {
-		return updateFromFile(ctx, client, opts, auth, dataset, sloID, file)
+		return updateFromFile(ctx, client, opts, dataset, sloID, file)
 	}
 
 	if !cmd.Flags().Changed("name") && !cmd.Flags().Changed("description") && !cmd.Flags().Changed("target") && !cmd.Flags().Changed("time-period") {
 		return fmt.Errorf("--file, --name, --description, --target, or --time-period is required")
 	}
 
-	current, err := getSLO(ctx, client, auth, dataset, sloID)
+	current, err := getSLO(ctx, client, dataset, sloID)
 	if err != nil {
 		return err
 	}
@@ -88,7 +83,7 @@ func runSLOUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, sloID,
 		return fmt.Errorf("encoding SLO: %w", err)
 	}
 
-	resp, err := client.UpdateSloWithBodyWithResponse(ctx, dataset, sloID, "application/json", bytes.NewReader(data), auth)
+	resp, err := client.UpdateSloWithBodyWithResponse(ctx, dataset, sloID, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("updating SLO: %w", err)
 	}
@@ -104,7 +99,7 @@ func runSLOUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, sloID,
 	return writeSloDetail(opts, sloToDetail(*resp.JSON200))
 }
 
-func updateFromFile(ctx context.Context, client *api.ClientWithResponses, opts *options.RootOptions, auth api.RequestEditorFn, dataset, sloID, file string) error {
+func updateFromFile(ctx context.Context, client *api.ClientWithResponses, opts *options.RootOptions, dataset, sloID, file string) error {
 	raw, err := readFile(opts, file)
 	if err != nil {
 		return err
@@ -115,7 +110,7 @@ func updateFromFile(ctx context.Context, client *api.ClientWithResponses, opts *
 		return fmt.Errorf("stripping read-only fields: %w", err)
 	}
 
-	resp, err := client.UpdateSloWithBodyWithResponse(ctx, dataset, sloID, "application/json", bytes.NewReader(data), auth)
+	resp, err := client.UpdateSloWithBodyWithResponse(ctx, dataset, sloID, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("updating SLO: %w", err)
 	}
@@ -131,8 +126,8 @@ func updateFromFile(ctx context.Context, client *api.ClientWithResponses, opts *
 	return writeSloDetail(opts, sloToDetail(*resp.JSON200))
 }
 
-func getSLO(ctx context.Context, client *api.ClientWithResponses, auth api.RequestEditorFn, dataset, sloID string) (*api.SLO, error) {
-	resp, err := client.GetSloWithResponse(ctx, dataset, sloID, &api.GetSloParams{}, auth)
+func getSLO(ctx context.Context, client *api.ClientWithResponses, dataset, sloID string) (*api.SLO, error) {
+	resp, err := client.GetSloWithResponse(ctx, dataset, sloID, &api.GetSloParams{})
 	if err != nil {
 		return nil, fmt.Errorf("getting SLO: %w", err)
 	}

--- a/cmd/trigger/create.go
+++ b/cmd/trigger/create.go
@@ -68,7 +68,7 @@ type createFlags struct {
 }
 
 func runCreate(cmd *cobra.Command, opts *options.RootOptions, dataset string, flags createFlags) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
@@ -115,24 +115,15 @@ func runCreate(cmd *cobra.Command, opts *options.RootOptions, dataset string, fl
 		}
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.CreateTriggerWithBodyWithResponse(cmd.Context(), dataset, "application/json", bytes.NewReader(data), auth)
+	resp, err := client.CreateTriggerWithBodyWithResponse(cmd.Context(), dataset, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("creating trigger: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	trigger, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON201)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON201 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	detail := toDetail(*resp.JSON201)
-	return writeTriggerDetail(opts, detail)
+	return writeTriggerDetail(opts, toDetail(*trigger))
 }

--- a/cmd/trigger/delete.go
+++ b/cmd/trigger/delete.go
@@ -30,14 +30,9 @@ func NewDeleteCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runDelete(ctx context.Context, opts *options.RootOptions, dataset, triggerID string, yes bool) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	if !yes {
@@ -45,7 +40,7 @@ func runDelete(ctx context.Context, opts *options.RootOptions, dataset, triggerI
 			return fmt.Errorf("--yes is required in non-interactive mode")
 		}
 
-		resp, err := client.GetTriggerWithResponse(ctx, dataset, triggerID, auth)
+		resp, err := client.GetTriggerWithResponse(ctx, dataset, triggerID)
 		if err != nil {
 			return fmt.Errorf("getting trigger: %w", err)
 		}
@@ -67,7 +62,7 @@ func runDelete(ctx context.Context, opts *options.RootOptions, dataset, triggerI
 		}
 	}
 
-	resp, err := client.DeleteTriggerWithResponse(ctx, dataset, triggerID, auth)
+	resp, err := client.DeleteTriggerWithResponse(ctx, dataset, triggerID)
 	if err != nil {
 		return fmt.Errorf("deleting trigger: %w", err)
 	}

--- a/cmd/trigger/get.go
+++ b/cmd/trigger/get.go
@@ -22,29 +22,20 @@ func NewGetCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runGet(ctx context.Context, opts *options.RootOptions, dataset, triggerID string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.GetTriggerWithResponse(ctx, dataset, triggerID, auth)
+	resp, err := client.GetTriggerWithResponse(ctx, dataset, triggerID)
 	if err != nil {
 		return fmt.Errorf("getting trigger: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	trigger, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	detail := toDetail(*resp.JSON200)
-	return writeTriggerDetail(opts, detail)
+	return writeTriggerDetail(opts, toDetail(*trigger))
 }

--- a/cmd/trigger/list.go
+++ b/cmd/trigger/list.go
@@ -35,31 +35,23 @@ func NewListCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runList(ctx context.Context, opts *options.RootOptions, dataset string) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
-	}
-
-	resp, err := client.ListTriggersWithResponse(ctx, dataset, auth)
+	resp, err := client.ListTriggersWithResponse(ctx, dataset)
 	if err != nil {
 		return fmt.Errorf("listing triggers: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	triggers, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	items := make([]triggerItem, len(*resp.JSON200))
-	for i, t := range *resp.JSON200 {
+	items := make([]triggerItem, len(*triggers))
+	for i, t := range *triggers {
 		items[i] = toItem(t)
 	}
 

--- a/cmd/trigger/update.go
+++ b/cmd/trigger/update.go
@@ -81,14 +81,9 @@ type updateFlags struct {
 }
 
 func runUpdate(ctx context.Context, opts *options.RootOptions, dataset, triggerID string, flags updateFlags) error {
-	auth, err := opts.KeyEditor(config.KeyConfig)
+	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
-	}
-
-	client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
-	if err != nil {
-		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	var body api.TriggerResponse
@@ -102,17 +97,15 @@ func runUpdate(ctx context.Context, opts *options.RootOptions, dataset, triggerI
 			return fmt.Errorf("parsing trigger JSON: %w", err)
 		}
 	} else {
-		resp, err := client.GetTriggerWithResponse(ctx, dataset, triggerID, auth)
+		resp, err := client.GetTriggerWithResponse(ctx, dataset, triggerID)
 		if err != nil {
 			return fmt.Errorf("getting trigger: %w", err)
 		}
-		if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+		current, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+		if err != nil {
 			return err
 		}
-		if resp.JSON200 == nil {
-			return fmt.Errorf("unexpected response: %s", resp.Status())
-		}
-		body = *resp.JSON200
+		body = *current
 
 		if flags.hasName {
 			body.Name = &flags.name
@@ -134,19 +127,15 @@ func runUpdate(ctx context.Context, opts *options.RootOptions, dataset, triggerI
 		return fmt.Errorf("encoding trigger: %w", err)
 	}
 
-	resp, err := client.UpdateTriggerWithBodyWithResponse(ctx, dataset, triggerID, "application/json", bytes.NewReader(data), auth)
+	resp, err := client.UpdateTriggerWithBodyWithResponse(ctx, dataset, triggerID, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("updating trigger: %w", err)
 	}
 
-	if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
+	updated, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
 		return err
 	}
 
-	if resp.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", resp.Status())
-	}
-
-	detail := toDetail(*resp.JSON200)
-	return writeTriggerDetail(opts, detail)
+	return writeTriggerDetail(opts, toDetail(*updated))
 }

--- a/internal/api/decode.go
+++ b/internal/api/decode.go
@@ -1,0 +1,22 @@
+package api
+
+import "fmt"
+
+// Decode validates an API response and returns its typed body. It folds the
+// status check and the typed-nil guard that every WithResponse call site
+// repeats: CheckResponse rejects non-2xx/3xx status codes (parsing the body
+// for an error message), and a nil typed pointer means the server returned a
+// status the generated client could not decode into the expected type.
+//
+// The typed body is passed explicitly because the generated *Resp types expose
+// it as a concrete field (JSON200, JSON201, ...) that is not reachable through
+// a common interface.
+func Decode[T any](statusCode int, status string, body []byte, typed *T) (*T, error) {
+	if err := CheckResponse(statusCode, body); err != nil {
+		return nil, err
+	}
+	if typed == nil {
+		return nil, fmt.Errorf("unexpected response: %s", status)
+	}
+	return typed, nil
+}


### PR DESCRIPTION
Add RootOptions.Client(kt), which bakes the auth request editor into the
generated client, and api.Decode, which folds CheckResponse and the typed-nil
guard into one helper. Collapse the repeated client-build + status-check
prologue across every resource command (~570 fewer lines).

SLO union types and the raw ListColumns body keep their custom decode; delete
commands keep CheckResponse and any status guard.