### PR TITLE
refactor(cmd): add cmd/command CRUD helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,19 @@ field is read directly. Responses decoded by hand (SLO union types, the raw
 `ListColumns` body) keep their own `api.CheckResponse` + `json.Unmarshal`.
 Delete commands keep `api.CheckResponse` and any status guard.
 
+The `cmd/command` package holds CRUD command helpers:
+
+- `ConfirmDelete(ios, yes, noun, fallbackName, fetchName)`: the `--yes`
+  short-circuit, non-interactive guard, and y/N prompt. `fetchName` resolves a
+  display name lazily (only when prompting); pass `nil` to show `fallbackName`.
+  It returns whether to proceed; the caller decides what a declined delete
+  means.
+- `ReadDefinitionFile(ios, path)`: reads a JSON definition from a file or `-`
+  (stdin) and runs `jsonutil.Sanitize`.
+- `ApplyOverrides(data, overrides)`: merges flag overrides into a JSON object
+  body. Use only when the body is handled as `map[string]any`; commands that
+  build a typed request struct set fields directly.
+
 ## Testing
 
 **Unit tests** use `keyring.MockInit()` for an in-memory keyring and `httptest.NewServer` for API stubs. These run in `go test` with no external dependencies.

--- a/cmd/board/board.go
+++ b/cmd/board/board.go
@@ -2,13 +2,10 @@ package board
 
 import (
 	"encoding/json"
-	"fmt"
-	"io"
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
-	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
 	"github.com/bendrucker/honeycomb-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -59,24 +56,6 @@ func writeBoardDetail(opts *options.RootOptions, detail boardDetail) error {
 		{Label: "URL", Value: detail.URL},
 		{Label: "Preset Filters", Value: string(detail.PresetFilters)},
 	})
-}
-
-func readBoardJSON(r io.Reader) (api.Board, error) {
-	data, err := io.ReadAll(r)
-	if err != nil {
-		return api.Board{}, fmt.Errorf("reading input: %w", err)
-	}
-
-	data, err = jsonutil.Sanitize(data)
-	if err != nil {
-		return api.Board{}, fmt.Errorf("parsing board JSON: %w", err)
-	}
-
-	var board api.Board
-	if err := json.Unmarshal(data, &board); err != nil {
-		return api.Board{}, fmt.Errorf("parsing board JSON: %w", err)
-	}
-	return board, nil
 }
 
 func boardToDetail(b api.Board) boardDetail {

--- a/cmd/board/create.go
+++ b/cmd/board/create.go
@@ -4,13 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
-	"os"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
-	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
 	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
@@ -100,26 +98,9 @@ func runBoardCreate(cmd *cobra.Command, opts *options.RootOptions, file, name, d
 }
 
 func createFromFile(ctx context.Context, client *api.ClientWithResponses, opts *options.RootOptions, file string) error {
-	var r io.Reader
-	if file == "-" {
-		r = opts.IOStreams.In
-	} else {
-		f, err := os.Open(file)
-		if err != nil {
-			return fmt.Errorf("opening file: %w", err)
-		}
-		defer func() { _ = f.Close() }()
-		r = f
-	}
-
-	raw, err := io.ReadAll(r)
+	raw, err := command.ReadDefinitionFile(opts.IOStreams, file)
 	if err != nil {
-		return fmt.Errorf("reading file: %w", err)
-	}
-
-	raw, err = jsonutil.Sanitize(raw)
-	if err != nil {
-		return fmt.Errorf("invalid JSON: %w", err)
+		return err
 	}
 
 	data, err := api.StripReadOnly(raw, "Board")

--- a/cmd/board/delete.go
+++ b/cmd/board/delete.go
@@ -3,12 +3,11 @@ package board
 import (
 	"context"
 	"fmt"
-	"strings"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -35,23 +34,18 @@ func runBoardDelete(ctx context.Context, opts *options.RootOptions, boardID stri
 		return err
 	}
 
-	if !yes {
-		if !opts.IOStreams.CanPrompt() {
-			return fmt.Errorf("--yes is required in non-interactive mode")
-		}
-
+	proceed, err := command.ConfirmDelete(opts.IOStreams, yes, "board", boardID, func() (string, error) {
 		board, err := getBoard(ctx, client, boardID)
 		if err != nil {
-			return err
+			return "", err
 		}
-
-		answer, err := prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, fmt.Sprintf("Delete board %q? (y/N): ", board.Name))
-		if err != nil {
-			return err
-		}
-		if !strings.EqualFold(answer, "y") {
-			return fmt.Errorf("aborted")
-		}
+		return board.Name, nil
+	})
+	if err != nil {
+		return err
+	}
+	if !proceed {
+		return fmt.Errorf("aborted")
 	}
 
 	resp, err := client.DeleteBoardWithResponse(ctx, boardID)

--- a/cmd/board/update.go
+++ b/cmd/board/update.go
@@ -5,13 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"os"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
-	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
 	"github.com/spf13/cobra"
 )
 
@@ -102,40 +100,22 @@ func runBoardUpdate(cmd *cobra.Command, opts *options.RootOptions, boardID, file
 }
 
 func updateFromFile(ctx context.Context, client *api.ClientWithResponses, opts *options.RootOptions, boardID, file string, replace bool) error {
-	var r io.Reader
-	if file == "-" {
-		r = opts.IOStreams.In
-	} else {
-		f, err := os.Open(file)
-		if err != nil {
-			return fmt.Errorf("opening file: %w", err)
-		}
-		defer func() { _ = f.Close() }()
-		r = f
+	raw, err := command.ReadDefinitionFile(opts.IOStreams, file)
+	if err != nil {
+		return err
 	}
 
 	var data []byte
 
 	if replace {
-		raw, readErr := io.ReadAll(r)
-		if readErr != nil {
-			return fmt.Errorf("reading file: %w", readErr)
-		}
-
-		var fillErr error
-		data, fillErr = fillRequiredFields(ctx, client, boardID, raw)
-		if fillErr != nil {
-			return fillErr
-		}
-		sanitized, sanitizeErr := jsonutil.Sanitize(data)
-		if sanitizeErr != nil {
-			return fmt.Errorf("invalid JSON: %w", sanitizeErr)
-		}
-		data = sanitized
-	} else {
-		incoming, err := readBoardJSON(r)
+		data, err = fillRequiredFields(ctx, client, boardID, raw)
 		if err != nil {
 			return err
+		}
+	} else {
+		var incoming api.Board
+		if err := json.Unmarshal(raw, &incoming); err != nil {
+			return fmt.Errorf("parsing board JSON: %w", err)
 		}
 
 		current, err := getBoard(ctx, client, boardID)

--- a/cmd/board/view_create.go
+++ b/cmd/board/view_create.go
@@ -4,14 +4,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
-	"os"
 	"strings"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
-	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
 	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
@@ -113,26 +111,9 @@ func parseViewFilters(args []string) ([]api.BoardViewFilter, error) {
 }
 
 func createViewFromFile(ctx context.Context, client *api.ClientWithResponses, opts *options.RootOptions, boardID, file string) error {
-	var r io.Reader
-	if file == "-" {
-		r = opts.IOStreams.In
-	} else {
-		f, err := os.Open(file)
-		if err != nil {
-			return fmt.Errorf("opening file: %w", err)
-		}
-		defer func() { _ = f.Close() }()
-		r = f
-	}
-
-	data, err := io.ReadAll(r)
+	data, err := command.ReadDefinitionFile(opts.IOStreams, file)
 	if err != nil {
-		return fmt.Errorf("reading file: %w", err)
-	}
-
-	data, err = jsonutil.Sanitize(data)
-	if err != nil {
-		return fmt.Errorf("invalid JSON: %w", err)
+		return err
 	}
 
 	resp, err := client.CreateBoardViewWithBodyWithResponse(ctx, boardID, "application/json", bytes.NewReader(data))

--- a/cmd/board/view_delete.go
+++ b/cmd/board/view_delete.go
@@ -3,12 +3,11 @@ package board
 import (
 	"context"
 	"fmt"
-	"strings"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -35,28 +34,21 @@ func runViewDelete(ctx context.Context, opts *options.RootOptions, boardID, view
 		return err
 	}
 
-	if !yes {
-		if !opts.IOStreams.CanPrompt() {
-			return fmt.Errorf("--yes is required in non-interactive mode")
-		}
-
+	proceed, err := command.ConfirmDelete(opts.IOStreams, yes, "view", viewID, func() (string, error) {
 		view, err := getView(ctx, client, boardID, viewID)
 		if err != nil {
-			return err
+			return "", err
 		}
-
-		name := viewID
 		if view.Name != nil {
-			name = *view.Name
+			return *view.Name, nil
 		}
-
-		answer, err := prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, fmt.Sprintf("Delete view %q? (y/N): ", name))
-		if err != nil {
-			return err
-		}
-		if !strings.EqualFold(answer, "y") {
-			return fmt.Errorf("aborted")
-		}
+		return "", nil
+	})
+	if err != nil {
+		return err
+	}
+	if !proceed {
+		return fmt.Errorf("aborted")
 	}
 
 	resp, err := client.DeleteBoardViewWithResponse(ctx, boardID, viewID)

--- a/cmd/board/view_update.go
+++ b/cmd/board/view_update.go
@@ -4,14 +4,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
-	"os"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
-	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
 	"github.com/spf13/cobra"
 )
 
@@ -94,26 +92,9 @@ func runViewUpdate(cmd *cobra.Command, opts *options.RootOptions, boardID, viewI
 }
 
 func updateViewFromFile(ctx context.Context, client *api.ClientWithResponses, opts *options.RootOptions, boardID, viewID, file string) error {
-	var r io.Reader
-	if file == "-" {
-		r = opts.IOStreams.In
-	} else {
-		f, err := os.Open(file)
-		if err != nil {
-			return fmt.Errorf("opening file: %w", err)
-		}
-		defer func() { _ = f.Close() }()
-		r = f
-	}
-
-	data, err := io.ReadAll(r)
+	data, err := command.ReadDefinitionFile(opts.IOStreams, file)
 	if err != nil {
-		return fmt.Errorf("reading file: %w", err)
-	}
-
-	data, err = jsonutil.Sanitize(data)
-	if err != nil {
-		return fmt.Errorf("invalid JSON: %w", err)
+		return err
 	}
 
 	resp, err := client.UpdateBoardViewWithBodyWithResponse(ctx, boardID, viewID, "application/json", bytes.NewReader(data))

--- a/cmd/column/calculated_create.go
+++ b/cmd/column/calculated_create.go
@@ -4,13 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
-	"os"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
-	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
 	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
@@ -83,26 +81,9 @@ func runCalculatedCreateFromFile(ctx context.Context, opts *options.RootOptions,
 		return err
 	}
 
-	var r io.Reader
-	if file == "-" {
-		r = opts.IOStreams.In
-	} else {
-		f, err := os.Open(file)
-		if err != nil {
-			return fmt.Errorf("opening file: %w", err)
-		}
-		defer func() { _ = f.Close() }()
-		r = f
-	}
-
-	data, err := io.ReadAll(r)
+	data, err := command.ReadDefinitionFile(opts.IOStreams, file)
 	if err != nil {
-		return fmt.Errorf("reading file: %w", err)
-	}
-
-	data, err = jsonutil.Sanitize(data)
-	if err != nil {
-		return fmt.Errorf("invalid JSON: %w", err)
+		return err
 	}
 
 	resp, err := client.CreateCalculatedFieldWithBodyWithResponse(ctx, dataset, "application/json", bytes.NewReader(data))

--- a/cmd/column/calculated_delete.go
+++ b/cmd/column/calculated_delete.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -34,31 +34,27 @@ func runCalculatedDelete(ctx context.Context, opts *options.RootOptions, dataset
 		return err
 	}
 
-	if !yes {
-		if !opts.IOStreams.CanPrompt() {
-			return fmt.Errorf("--yes is required in non-interactive mode")
-		}
-
+	proceed, err := command.ConfirmDelete(opts.IOStreams, yes, "calculated column", id, func() (string, error) {
 		getResp, err := client.GetCalculatedFieldWithResponse(ctx, dataset, id)
 		if err != nil {
-			return fmt.Errorf("getting calculated column: %w", err)
+			return "", fmt.Errorf("getting calculated column: %w", err)
 		}
 
 		if err := api.CheckResponse(getResp.StatusCode(), getResp.Body); err != nil {
-			return err
+			return "", err
 		}
 
 		if getResp.JSON200 == nil {
-			return fmt.Errorf("unexpected response: %s", getResp.Status())
+			return "", fmt.Errorf("unexpected response: %s", getResp.Status())
 		}
 
-		answer, err := prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, fmt.Sprintf("Delete calculated column %q? (y/N): ", getResp.JSON200.Alias))
-		if err != nil {
-			return err
-		}
-		if answer != "y" && answer != "Y" {
-			return fmt.Errorf("aborted")
-		}
+		return getResp.JSON200.Alias, nil
+	})
+	if err != nil {
+		return err
+	}
+	if !proceed {
+		return fmt.Errorf("aborted")
 	}
 
 	resp, err := client.DeleteCalculatedFieldWithResponse(ctx, dataset, id)

--- a/cmd/column/calculated_update.go
+++ b/cmd/column/calculated_update.go
@@ -5,13 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"os"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
-	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
 	"github.com/spf13/cobra"
 )
 
@@ -82,25 +80,9 @@ func runCalculatedUpdate(ctx context.Context, opts *options.RootOptions, dataset
 	var body api.CalculatedField
 
 	if flags.hasFile {
-		var r io.Reader
-		if flags.file == "-" {
-			r = opts.IOStreams.In
-		} else {
-			f, err := os.Open(flags.file)
-			if err != nil {
-				return fmt.Errorf("opening file: %w", err)
-			}
-			defer func() { _ = f.Close() }()
-			r = f
-		}
-
-		data, err := io.ReadAll(r)
+		data, err := command.ReadDefinitionFile(opts.IOStreams, flags.file)
 		if err != nil {
-			return fmt.Errorf("reading file: %w", err)
-		}
-		data, err = jsonutil.Sanitize(data)
-		if err != nil {
-			return fmt.Errorf("invalid JSON: %w", err)
+			return err
 		}
 		if err := json.Unmarshal(data, &body); err != nil {
 			return fmt.Errorf("parsing calculated column JSON: %w", err)

--- a/cmd/column/delete.go
+++ b/cmd/column/delete.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -34,31 +34,27 @@ func runColumnDelete(ctx context.Context, opts *options.RootOptions, dataset, co
 		return err
 	}
 
-	if !yes {
-		if !opts.IOStreams.CanPrompt() {
-			return fmt.Errorf("--yes is required in non-interactive mode")
-		}
-
+	proceed, err := command.ConfirmDelete(opts.IOStreams, yes, "column", columnID, func() (string, error) {
 		getResp, err := client.GetColumnWithResponse(ctx, dataset, columnID)
 		if err != nil {
-			return fmt.Errorf("getting column: %w", err)
+			return "", fmt.Errorf("getting column: %w", err)
 		}
 
 		if err := api.CheckResponse(getResp.StatusCode(), getResp.Body); err != nil {
-			return err
+			return "", err
 		}
 
 		if getResp.JSON200 == nil {
-			return fmt.Errorf("unexpected response: %s", getResp.Status())
+			return "", fmt.Errorf("unexpected response: %s", getResp.Status())
 		}
 
-		answer, err := prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, fmt.Sprintf("Delete column %q? (y/N): ", getResp.JSON200.KeyName))
-		if err != nil {
-			return err
-		}
-		if answer != "y" && answer != "Y" {
-			return fmt.Errorf("aborted")
-		}
+		return getResp.JSON200.KeyName, nil
+	})
+	if err != nil {
+		return err
+	}
+	if !proceed {
+		return fmt.Errorf("aborted")
 	}
 
 	resp, err := client.DeleteColumnWithResponse(ctx, dataset, columnID)

--- a/cmd/command/confirm.go
+++ b/cmd/command/confirm.go
@@ -1,0 +1,45 @@
+// Package command holds helpers shared by the resource CRUD commands: delete
+// confirmation, definition-file intake, and flag-override merging.
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bendrucker/honeycomb-cli/internal/iostreams"
+	"github.com/bendrucker/honeycomb-cli/internal/prompt"
+)
+
+// ConfirmDelete reports whether a delete should proceed. When yes is set it
+// returns true without prompting. Otherwise it requires an interactive
+// terminal, resolves a display name (calling fetchName only when a prompt is
+// actually needed, so a --yes delete makes no extra API call), and prompts for
+// y/N. fetchName may be nil, in which case fallbackName is shown. The caller
+// decides what a declined delete means (return nil, or an error).
+func ConfirmDelete(ios *iostreams.IOStreams, yes bool, noun, fallbackName string, fetchName func() (string, error)) (bool, error) {
+	if yes {
+		return true, nil
+	}
+
+	if !ios.CanPrompt() {
+		return false, fmt.Errorf("--yes is required in non-interactive mode")
+	}
+
+	name := fallbackName
+	if fetchName != nil {
+		fetched, err := fetchName()
+		if err != nil {
+			return false, err
+		}
+		if fetched != "" {
+			name = fetched
+		}
+	}
+
+	answer, err := prompt.Line(ios.Err, ios.In, fmt.Sprintf("Delete %s %q? (y/N): ", noun, name))
+	if err != nil {
+		return false, err
+	}
+
+	return strings.EqualFold(answer, "y"), nil
+}

--- a/cmd/command/file.go
+++ b/cmd/command/file.go
@@ -1,0 +1,40 @@
+package command
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/bendrucker/honeycomb-cli/internal/iostreams"
+	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
+)
+
+// ReadDefinitionFile reads a JSON definition from a file path, or from stdin
+// when path is "-", and sanitizes shell-mangled escapes (see jsonutil). It is
+// the single home for the file/stdin intake that the create and update
+// commands repeat.
+func ReadDefinitionFile(ios *iostreams.IOStreams, path string) ([]byte, error) {
+	var r io.Reader
+	if path == "-" {
+		r = ios.In
+	} else {
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, fmt.Errorf("opening file: %w", err)
+		}
+		defer func() { _ = f.Close() }()
+		r = f
+	}
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("reading file: %w", err)
+	}
+
+	data, err = jsonutil.Sanitize(data)
+	if err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+
+	return data, nil
+}

--- a/cmd/command/overrides.go
+++ b/cmd/command/overrides.go
@@ -1,0 +1,32 @@
+package command
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ApplyOverrides merges overrides into a JSON object body and re-encodes it.
+// It returns data unchanged when there are no overrides, so callers can build
+// the map from whichever flags the user actually set and pass it through
+// unconditionally.
+func ApplyOverrides(data []byte, overrides map[string]any) ([]byte, error) {
+	if len(overrides) == 0 {
+		return data, nil
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(data, &body); err != nil {
+		return nil, fmt.Errorf("parsing JSON: %w", err)
+	}
+
+	for k, v := range overrides {
+		body[k] = v
+	}
+
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("encoding JSON: %w", err)
+	}
+
+	return encoded, nil
+}

--- a/cmd/dataset/definition_update.go
+++ b/cmd/dataset/definition_update.go
@@ -4,13 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
-	"os"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
-	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
 	"github.com/spf13/cobra"
 )
 
@@ -38,7 +36,7 @@ func runDefinitionUpdate(ctx context.Context, opts *options.RootOptions, slug, f
 		return err
 	}
 
-	data, err := readDefinitionFile(opts, file)
+	data, err := command.ReadDefinitionFile(opts.IOStreams, file)
 	if err != nil {
 		return err
 	}
@@ -54,30 +52,4 @@ func runDefinitionUpdate(ctx context.Context, opts *options.RootOptions, slug, f
 	}
 
 	return writeDefinitions(opts, defs)
-}
-
-func readDefinitionFile(opts *options.RootOptions, file string) ([]byte, error) {
-	var r io.Reader
-	if file == "-" {
-		r = opts.IOStreams.In
-	} else {
-		f, err := os.Open(file)
-		if err != nil {
-			return nil, fmt.Errorf("opening file: %w", err)
-		}
-		defer f.Close() //nolint:errcheck // best-effort close on read-only file
-		r = f
-	}
-
-	data, err := io.ReadAll(r)
-	if err != nil {
-		return nil, fmt.Errorf("reading file: %w", err)
-	}
-
-	data, err = jsonutil.Sanitize(data)
-	if err != nil {
-		return nil, fmt.Errorf("invalid JSON: %w", err)
-	}
-
-	return data, nil
 }

--- a/cmd/dataset/delete.go
+++ b/cmd/dataset/delete.go
@@ -7,10 +7,10 @@ import (
 	"io"
 	"strings"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -37,29 +37,24 @@ func runDatasetDelete(ctx context.Context, opts *options.RootOptions, slug strin
 		return err
 	}
 
-	if !yes {
-		if !opts.IOStreams.CanPrompt() {
-			return fmt.Errorf("--yes is required in non-interactive mode")
-		}
-
+	proceed, err := command.ConfirmDelete(opts.IOStreams, yes, "dataset", slug, func() (string, error) {
 		resp, err := client.GetDatasetWithResponse(ctx, slug)
 		if err != nil {
-			return fmt.Errorf("getting dataset: %w", err)
+			return "", fmt.Errorf("getting dataset: %w", err)
 		}
 		if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
-			return err
+			return "", err
 		}
 		if resp.JSON200 == nil {
-			return fmt.Errorf("unexpected response: %s", resp.Status())
+			return "", fmt.Errorf("unexpected response: %s", resp.Status())
 		}
-
-		answer, err := prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, fmt.Sprintf("Delete dataset %q? (y/N): ", resp.JSON200.Name))
-		if err != nil {
-			return err
-		}
-		if !strings.EqualFold(answer, "y") {
-			return fmt.Errorf("aborted")
-		}
+		return resp.JSON200.Name, nil
+	})
+	if err != nil {
+		return err
+	}
+	if !proceed {
+		return fmt.Errorf("aborted")
 	}
 
 	httpResp, err := client.DeleteDataset(ctx, slug)

--- a/cmd/environment/delete.go
+++ b/cmd/environment/delete.go
@@ -3,12 +3,11 @@ package environment
 import (
 	"context"
 	"fmt"
-	"strings"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -38,31 +37,24 @@ func runEnvironmentDelete(ctx context.Context, opts *options.RootOptions, team, 
 		return err
 	}
 
-	if !yes {
-		if !opts.IOStreams.CanPrompt() {
-			return fmt.Errorf("--yes is required in non-interactive mode")
-		}
-
+	proceed, err := command.ConfirmDelete(opts.IOStreams, yes, "environment", envID, func() (string, error) {
 		getResp, err := client.GetEnvironmentWithResponse(ctx, team, envID)
 		if err != nil {
-			return fmt.Errorf("getting environment: %w", err)
+			return "", fmt.Errorf("getting environment: %w", err)
 		}
 		if err := api.CheckResponse(getResp.StatusCode(), getResp.Body); err != nil {
-			return err
+			return "", err
 		}
-
-		name := envID
 		if getResp.ApplicationvndApiJSON200 != nil {
-			name = getResp.ApplicationvndApiJSON200.Data.Attributes.Name
+			return getResp.ApplicationvndApiJSON200.Data.Attributes.Name, nil
 		}
-
-		answer, err := prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, fmt.Sprintf("Delete environment %q? (y/N): ", name))
-		if err != nil {
-			return err
-		}
-		if !strings.EqualFold(answer, "y") {
-			return fmt.Errorf("aborted")
-		}
+		return "", nil
+	})
+	if err != nil {
+		return err
+	}
+	if !proceed {
+		return fmt.Errorf("aborted")
 	}
 
 	resp, err := client.DeleteEnvironmentWithResponse(ctx, team, envID)

--- a/cmd/key/create.go
+++ b/cmd/key/create.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
@@ -80,7 +80,7 @@ func runKeyCreateFromFile(ctx context.Context, opts *options.RootOptions, team, 
 		return err
 	}
 
-	data, err := readBodyFile(opts, file)
+	data, err := command.ReadDefinitionFile(opts.IOStreams, file)
 	if err != nil {
 		return err
 	}
@@ -294,12 +294,4 @@ func createResponseToDetail(resp *api.ApiKeyCreateResponse) keyDetail {
 	}
 
 	return detail
-}
-
-func openFile(path string) (*os.File, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("opening file: %w", err)
-	}
-	return f, nil
 }

--- a/cmd/key/delete.go
+++ b/cmd/key/delete.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -37,21 +37,12 @@ func runKeyDelete(ctx context.Context, opts *options.RootOptions, team, id strin
 		return err
 	}
 
-	if !yes {
-		if !opts.IOStreams.CanPrompt() {
-			return fmt.Errorf("--yes is required in non-interactive mode")
-		}
-
-		answer, err := prompt.Choice(opts.IOStreams.Err, opts.IOStreams.In,
-			fmt.Sprintf("Delete API key %s? (y/N): ", id),
-			[]string{"y", "N"},
-		)
-		if err != nil {
-			return err
-		}
-		if answer != "y" {
-			return nil
-		}
+	proceed, err := command.ConfirmDelete(opts.IOStreams, yes, "API key", id, nil)
+	if err != nil {
+		return err
+	}
+	if !proceed {
+		return nil
 	}
 
 	resp, err := client.DeleteApiKeyWithResponse(ctx, api.TeamSlug(team), api.ID(id))

--- a/cmd/key/key.go
+++ b/cmd/key/key.go
@@ -2,13 +2,11 @@ package key
 
 import (
 	"fmt"
-	"io"
 	"strconv"
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
-	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
 	"github.com/bendrucker/honeycomb-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -107,27 +105,4 @@ func fillFromAttributes(name *string, keyType *string, disabled *bool, attrs api
 		*disabled = deref.Bool(cfg.Disabled)
 		return
 	}
-}
-
-func readBodyFile(ios *options.RootOptions, file string) ([]byte, error) {
-	var r io.Reader
-	if file == "-" {
-		r = ios.IOStreams.In
-	} else {
-		f, err := openFile(file)
-		if err != nil {
-			return nil, err
-		}
-		defer func() { _ = f.Close() }()
-		r = f
-	}
-	data, err := io.ReadAll(r)
-	if err != nil {
-		return nil, fmt.Errorf("reading file: %w", err)
-	}
-	data, err = jsonutil.Sanitize(data)
-	if err != nil {
-		return nil, fmt.Errorf("invalid JSON: %w", err)
-	}
-	return data, nil
 }

--- a/cmd/key/update.go
+++ b/cmd/key/update.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
@@ -54,7 +55,7 @@ func runKeyUpdateFromFile(ctx context.Context, opts *options.RootOptions, team, 
 		return err
 	}
 
-	data, err := readBodyFile(opts, file)
+	data, err := command.ReadDefinitionFile(opts.IOStreams, file)
 	if err != nil {
 		return err
 	}

--- a/cmd/marker/delete.go
+++ b/cmd/marker/delete.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -34,45 +34,31 @@ func runMarkerDelete(ctx context.Context, opts *options.RootOptions, dataset, ma
 		return err
 	}
 
-	if !yes {
-		if !opts.IOStreams.CanPrompt() {
-			return fmt.Errorf("--yes is required in non-interactive mode")
-		}
-
-		// Fetch marker for confirmation display
+	proceed, err := command.ConfirmDelete(opts.IOStreams, yes, "marker", markerID, func() (string, error) {
 		listResp, err := client.GetMarkerWithResponse(ctx, dataset)
 		if err != nil {
-			return fmt.Errorf("listing markers: %w", err)
+			return "", fmt.Errorf("listing markers: %w", err)
 		}
 
 		if err := api.CheckResponse(listResp.StatusCode(), listResp.Body); err != nil {
-			return err
+			return "", err
 		}
 
 		if listResp.JSON200 == nil {
-			return fmt.Errorf("unexpected response: %s", listResp.Status())
+			return "", fmt.Errorf("unexpected response: %s", listResp.Status())
 		}
 
-		m, err := findMarker(*listResp.JSON200, markerID)
-		if err != nil {
-			return err
+		if _, err := findMarker(*listResp.JSON200, markerID); err != nil {
+			return "", err
 		}
 
-		markerType := ""
-		if m.Type != nil {
-			markerType = *m.Type
-		}
-
-		answer, err := prompt.Choice(opts.IOStreams.Err, opts.IOStreams.In,
-			fmt.Sprintf("Delete marker %q (type: %s)? (y/N): ", markerID, markerType),
-			[]string{"y", "N"},
-		)
-		if err != nil {
-			return err
-		}
-		if answer != "y" {
-			return nil
-		}
+		return "", nil
+	})
+	if err != nil {
+		return err
+	}
+	if !proceed {
+		return nil
 	}
 
 	resp, err := client.DeleteMarkerWithResponse(ctx, dataset, markerID)

--- a/cmd/marker/setting_delete.go
+++ b/cmd/marker/setting_delete.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -34,21 +34,12 @@ func runSettingDelete(ctx context.Context, opts *options.RootOptions, dataset, s
 		return err
 	}
 
-	if !yes {
-		if !opts.IOStreams.CanPrompt() {
-			return fmt.Errorf("--yes is required in non-interactive mode")
-		}
-
-		answer, err := prompt.Choice(opts.IOStreams.Err, opts.IOStreams.In,
-			fmt.Sprintf("Delete marker setting %s? (y/N): ", settingID),
-			[]string{"y", "N"},
-		)
-		if err != nil {
-			return err
-		}
-		if answer != "y" {
-			return nil
-		}
+	proceed, err := command.ConfirmDelete(opts.IOStreams, yes, "marker setting", settingID, nil)
+	if err != nil {
+		return err
+	}
+	if !proceed {
+		return nil
 	}
 
 	resp, err := client.DeleteMarkerSettingsWithResponse(ctx, api.DatasetSlugOrAll(dataset), settingID)

--- a/cmd/query/annotation_create.go
+++ b/cmd/query/annotation_create.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
@@ -50,7 +51,7 @@ func runAnnotationCreate(cmd *cobra.Command, opts *options.RootOptions, dataset,
 
 	var data []byte
 	if file != "" {
-		data, err = readFile(opts, file)
+		data, err = command.ReadDefinitionFile(opts.IOStreams, file)
 		if err != nil {
 			return err
 		}
@@ -85,7 +86,7 @@ func runAnnotationCreate(cmd *cobra.Command, opts *options.RootOptions, dataset,
 		if file == "" {
 			return fmt.Errorf("file path is required")
 		}
-		data, err = readFile(opts, file)
+		data, err = command.ReadDefinitionFile(opts.IOStreams, file)
 		if err != nil {
 			return err
 		}

--- a/cmd/query/annotation_delete.go
+++ b/cmd/query/annotation_delete.go
@@ -3,12 +3,11 @@ package query
 import (
 	"context"
 	"fmt"
-	"strings"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -35,23 +34,18 @@ func runAnnotationDelete(ctx context.Context, opts *options.RootOptions, dataset
 		return err
 	}
 
-	if !yes {
-		if !opts.IOStreams.CanPrompt() {
-			return fmt.Errorf("--yes is required in non-interactive mode")
-		}
-
+	proceed, err := command.ConfirmDelete(opts.IOStreams, yes, "query annotation", annotationID, func() (string, error) {
 		a, err := getAnnotation(ctx, client, dataset, annotationID)
 		if err != nil {
-			return err
+			return "", err
 		}
-
-		answer, err := prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, fmt.Sprintf("Delete query annotation %q? (y/N): ", a.Name))
-		if err != nil {
-			return err
-		}
-		if !strings.EqualFold(answer, "y") {
-			return fmt.Errorf("aborted")
-		}
+		return a.Name, nil
+	})
+	if err != nil {
+		return err
+	}
+	if !proceed {
+		return fmt.Errorf("aborted")
 	}
 
 	resp, err := client.DeleteQueryAnnotationWithResponse(ctx, dataset, annotationID)

--- a/cmd/query/annotation_update.go
+++ b/cmd/query/annotation_update.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
@@ -84,7 +85,7 @@ func runAnnotationUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset,
 }
 
 func updateAnnotationFromFile(ctx context.Context, client *api.ClientWithResponses, opts *options.RootOptions, dataset, annotationID, file string) error {
-	raw, err := readFile(opts, file)
+	raw, err := command.ReadDefinitionFile(opts.IOStreams, file)
 	if err != nil {
 		return err
 	}

--- a/cmd/query/query.go
+++ b/cmd/query/query.go
@@ -1,12 +1,7 @@
 package query
 
 import (
-	"fmt"
-	"io"
-	"os"
-
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
-	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
 	"github.com/spf13/cobra"
 )
 
@@ -26,30 +21,4 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 	cmd.AddCommand(NewAnnotationCmd(opts, &dataset))
 
 	return cmd
-}
-
-func readFile(opts *options.RootOptions, file string) ([]byte, error) {
-	var r io.Reader
-	if file == "-" {
-		r = opts.IOStreams.In
-	} else {
-		f, err := os.Open(file)
-		if err != nil {
-			return nil, fmt.Errorf("opening file: %w", err)
-		}
-		defer f.Close() //nolint:errcheck // best-effort close on read-only file
-		r = f
-	}
-
-	data, err := io.ReadAll(r)
-	if err != nil {
-		return nil, fmt.Errorf("reading file: %w", err)
-	}
-
-	data, err = jsonutil.Sanitize(data)
-	if err != nil {
-		return nil, fmt.Errorf("invalid JSON: %w", err)
-	}
-
-	return data, nil
 }

--- a/cmd/query/run.go
+++ b/cmd/query/run.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
@@ -103,7 +104,7 @@ func resolveQueryID(ctx context.Context, opts *options.RootOptions, client *api.
 }
 
 func createQueryFromFile(ctx context.Context, opts *options.RootOptions, client *api.ClientWithResponses, dataset string, file string) (string, error) {
-	data, err := readFile(opts, file)
+	data, err := command.ReadDefinitionFile(opts.IOStreams, file)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/recipient/create.go
+++ b/cmd/recipient/create.go
@@ -5,13 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"os"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
-	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
 	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
@@ -202,38 +200,12 @@ func buildRecipientBody(opts *options.RootOptions, recipientType, target, channe
 }
 
 func createFromFile(ctx context.Context, opts *options.RootOptions, file string) error {
-	data, err := readFile(opts, file)
+	data, err := command.ReadDefinitionFile(opts.IOStreams, file)
 	if err != nil {
 		return err
 	}
 
 	return sendCreate(ctx, opts, data)
-}
-
-func readFile(opts *options.RootOptions, file string) ([]byte, error) {
-	var r io.Reader
-	if file == "-" {
-		r = opts.IOStreams.In
-	} else {
-		f, err := os.Open(file)
-		if err != nil {
-			return nil, fmt.Errorf("opening file: %w", err)
-		}
-		defer func() { _ = f.Close() }()
-		r = f
-	}
-
-	data, err := io.ReadAll(r)
-	if err != nil {
-		return nil, fmt.Errorf("reading file: %w", err)
-	}
-
-	data, err = jsonutil.Sanitize(data)
-	if err != nil {
-		return nil, fmt.Errorf("invalid JSON: %w", err)
-	}
-
-	return data, nil
 }
 
 func sendCreate(ctx context.Context, opts *options.RootOptions, data []byte) error {

--- a/cmd/recipient/delete.go
+++ b/cmd/recipient/delete.go
@@ -3,12 +3,11 @@ package recipient
 import (
 	"context"
 	"fmt"
-	"strings"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -35,18 +34,12 @@ func runDelete(ctx context.Context, opts *options.RootOptions, recipientID strin
 		return err
 	}
 
-	if !yes {
-		if !opts.IOStreams.CanPrompt() {
-			return fmt.Errorf("--yes is required in non-interactive mode")
-		}
-
-		answer, err := prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, fmt.Sprintf("Delete recipient %s? (y/N): ", recipientID))
-		if err != nil {
-			return err
-		}
-		if !strings.EqualFold(answer, "y") {
-			return fmt.Errorf("aborted")
-		}
+	proceed, err := command.ConfirmDelete(opts.IOStreams, yes, "recipient", recipientID, nil)
+	if err != nil {
+		return err
+	}
+	if !proceed {
+		return fmt.Errorf("aborted")
 	}
 
 	resp, err := client.DeleteRecipientWithResponse(ctx, recipientID)

--- a/cmd/recipient/update.go
+++ b/cmd/recipient/update.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
@@ -56,7 +57,7 @@ func runUpdate(cmd *cobra.Command, opts *options.RootOptions, recipientID, file,
 
 	var data []byte
 	if file != "" {
-		data, err = readFile(opts, file)
+		data, err = command.ReadDefinitionFile(opts.IOStreams, file)
 		if err != nil {
 			return err
 		}

--- a/cmd/slo/burn_alert_create.go
+++ b/cmd/slo/burn_alert_create.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
@@ -61,7 +62,7 @@ func runBurnAlertCreateFromFile(ctx context.Context, opts *options.RootOptions, 
 		return err
 	}
 
-	data, err := readFile(opts, file)
+	data, err := command.ReadDefinitionFile(opts.IOStreams, file)
 	if err != nil {
 		return err
 	}

--- a/cmd/slo/burn_alert_delete.go
+++ b/cmd/slo/burn_alert_delete.go
@@ -3,12 +3,11 @@ package slo
 import (
 	"context"
 	"fmt"
-	"strings"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -35,18 +34,12 @@ func runBurnAlertDelete(ctx context.Context, opts *options.RootOptions, dataset,
 		return err
 	}
 
-	if !yes {
-		if !opts.IOStreams.CanPrompt() {
-			return fmt.Errorf("--yes is required in non-interactive mode")
-		}
-
-		answer, err := prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, fmt.Sprintf("Delete burn alert %q? (y/N): ", burnAlertID))
-		if err != nil {
-			return err
-		}
-		if !strings.EqualFold(answer, "y") {
-			return fmt.Errorf("aborted")
-		}
+	proceed, err := command.ConfirmDelete(opts.IOStreams, yes, "burn alert", burnAlertID, nil)
+	if err != nil {
+		return err
+	}
+	if !proceed {
+		return fmt.Errorf("aborted")
 	}
 
 	resp, err := client.DeleteBurnAlertWithResponse(ctx, dataset, burnAlertID)

--- a/cmd/slo/burn_alert_update.go
+++ b/cmd/slo/burn_alert_update.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
@@ -56,7 +57,7 @@ func runBurnAlertUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, 
 
 	var data []byte
 	if file != "" {
-		data, err = readFile(opts, file)
+		data, err = command.ReadDefinitionFile(opts.IOStreams, file)
 		if err != nil {
 			return err
 		}

--- a/cmd/slo/create.go
+++ b/cmd/slo/create.go
@@ -4,13 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
-	"os"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
-	"github.com/bendrucker/honeycomb-cli/internal/jsonutil"
 	"github.com/spf13/cobra"
 )
 
@@ -57,7 +55,7 @@ func runSLOCreate(cmd *cobra.Command, opts *options.RootOptions, dataset, file, 
 	var data []byte
 
 	if cmd.Flags().Changed("file") {
-		data, err = readFile(opts, file)
+		data, err = command.ReadDefinitionFile(opts.IOStreams, file)
 		if err != nil {
 			return err
 		}
@@ -99,30 +97,4 @@ func runSLOCreate(cmd *cobra.Command, opts *options.RootOptions, dataset, file, 
 	}
 
 	return writeSloDetail(opts, sloToDetail(slo))
-}
-
-func readFile(opts *options.RootOptions, file string) ([]byte, error) {
-	var r io.Reader
-	if file == "-" {
-		r = opts.IOStreams.In
-	} else {
-		f, err := os.Open(file)
-		if err != nil {
-			return nil, fmt.Errorf("opening file: %w", err)
-		}
-		defer f.Close() //nolint:errcheck // best-effort close on read-only file
-		r = f
-	}
-
-	data, err := io.ReadAll(r)
-	if err != nil {
-		return nil, fmt.Errorf("reading file: %w", err)
-	}
-
-	data, err = jsonutil.Sanitize(data)
-	if err != nil {
-		return nil, fmt.Errorf("invalid JSON: %w", err)
-	}
-
-	return data, nil
 }

--- a/cmd/slo/delete.go
+++ b/cmd/slo/delete.go
@@ -3,12 +3,11 @@ package slo
 import (
 	"context"
 	"fmt"
-	"strings"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -35,23 +34,18 @@ func runSLODelete(ctx context.Context, opts *options.RootOptions, dataset, sloID
 		return err
 	}
 
-	if !yes {
-		if !opts.IOStreams.CanPrompt() {
-			return fmt.Errorf("--yes is required in non-interactive mode")
-		}
-
+	proceed, err := command.ConfirmDelete(opts.IOStreams, yes, "SLO", sloID, func() (string, error) {
 		s, err := getSLO(ctx, client, dataset, sloID)
 		if err != nil {
-			return err
+			return "", err
 		}
-
-		answer, err := prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, fmt.Sprintf("Delete SLO %q? (y/N): ", s.Name))
-		if err != nil {
-			return err
-		}
-		if !strings.EqualFold(answer, "y") {
-			return fmt.Errorf("aborted")
-		}
+		return s.Name, nil
+	})
+	if err != nil {
+		return err
+	}
+	if !proceed {
+		return fmt.Errorf("aborted")
 	}
 
 	resp, err := client.DeleteSloWithResponse(ctx, dataset, sloID)

--- a/cmd/slo/update.go
+++ b/cmd/slo/update.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
@@ -100,7 +101,7 @@ func runSLOUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, sloID,
 }
 
 func updateFromFile(ctx context.Context, client *api.ClientWithResponses, opts *options.RootOptions, dataset, sloID, file string) error {
-	raw, err := readFile(opts, file)
+	raw, err := command.ReadDefinitionFile(opts.IOStreams, file)
 	if err != nil {
 		return err
 	}

--- a/cmd/trigger/create.go
+++ b/cmd/trigger/create.go
@@ -2,11 +2,9 @@ package trigger
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
-	"io"
-	"os"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
@@ -73,46 +71,28 @@ func runCreate(cmd *cobra.Command, opts *options.RootOptions, dataset string, fl
 		return err
 	}
 
-	var r io.Reader
-	if flags.file == "-" {
-		r = opts.IOStreams.In
-	} else {
-		f, err := os.Open(flags.file)
-		if err != nil {
-			return fmt.Errorf("opening file: %w", err)
-		}
-		defer func() { _ = f.Close() }()
-		r = f
-	}
-
-	data, err := io.ReadAll(r)
+	data, err := command.ReadDefinitionFile(opts.IOStreams, flags.file)
 	if err != nil {
-		return fmt.Errorf("reading file: %w", err)
+		return err
 	}
 
-	if flags.hasName || flags.hasDesc || flags.hasDisabled || flags.hasEnabled {
-		var body map[string]any
-		if err := json.Unmarshal(data, &body); err != nil {
-			return fmt.Errorf("parsing trigger JSON: %w", err)
-		}
+	overrides := map[string]any{}
+	if flags.hasName {
+		overrides["name"] = flags.name
+	}
+	if flags.hasDesc {
+		overrides["description"] = flags.description
+	}
+	if flags.hasDisabled {
+		overrides["disabled"] = flags.disabled
+	}
+	if flags.hasEnabled {
+		overrides["disabled"] = false
+	}
 
-		if flags.hasName {
-			body["name"] = flags.name
-		}
-		if flags.hasDesc {
-			body["description"] = flags.description
-		}
-		if flags.hasDisabled {
-			body["disabled"] = flags.disabled
-		}
-		if flags.hasEnabled {
-			body["disabled"] = false
-		}
-
-		data, err = json.Marshal(body)
-		if err != nil {
-			return fmt.Errorf("encoding trigger: %w", err)
-		}
+	data, err = command.ApplyOverrides(data, overrides)
+	if err != nil {
+		return err
 	}
 
 	resp, err := client.CreateTriggerWithBodyWithResponse(cmd.Context(), dataset, "application/json", bytes.NewReader(data))

--- a/cmd/trigger/delete.go
+++ b/cmd/trigger/delete.go
@@ -3,12 +3,11 @@ package trigger
 import (
 	"context"
 	"fmt"
-	"strings"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -35,31 +34,24 @@ func runDelete(ctx context.Context, opts *options.RootOptions, dataset, triggerI
 		return err
 	}
 
-	if !yes {
-		if !opts.IOStreams.CanPrompt() {
-			return fmt.Errorf("--yes is required in non-interactive mode")
-		}
-
+	proceed, err := command.ConfirmDelete(opts.IOStreams, yes, "trigger", triggerID, func() (string, error) {
 		resp, err := client.GetTriggerWithResponse(ctx, dataset, triggerID)
 		if err != nil {
-			return fmt.Errorf("getting trigger: %w", err)
+			return "", fmt.Errorf("getting trigger: %w", err)
 		}
 		if err := api.CheckResponse(resp.StatusCode(), resp.Body); err != nil {
-			return err
+			return "", err
 		}
-
-		name := triggerID
 		if resp.JSON200 != nil && resp.JSON200.Name != nil {
-			name = *resp.JSON200.Name
+			return *resp.JSON200.Name, nil
 		}
-
-		answer, err := prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, fmt.Sprintf("Delete trigger %q? (y/N): ", name))
-		if err != nil {
-			return err
-		}
-		if !strings.EqualFold(answer, "y") {
-			return nil
-		}
+		return "", nil
+	})
+	if err != nil {
+		return err
+	}
+	if !proceed {
+		return nil
 	}
 
 	resp, err := client.DeleteTriggerWithResponse(ctx, dataset, triggerID)


### PR DESCRIPTION
Add the cmd/command package with ConfirmDelete (delete confirmation guard +
lazy name fetch + y/N prompt), ReadDefinitionFile (file/stdin intake +
sanitize), and ApplyOverrides (flag merge into a JSON body). Adopt them across
the resource commands, deleting the per-package file-reader copies. Each delete
keeps its own abort action; typed-struct create/update paths are unchanged.