### PR TITLE
refactor(output): derive display declarations from struct tags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,14 @@ A Honeycomb MCP server is configured and available as a reference implementation
 
 The `--format` flag supports `json` and `table`. Default is `table` in TTY, `json` otherwise. List commands always default to `table` regardless of TTY detection, using `OutputWriterList()` instead of `OutputWriter()`.
 
+Derive list columns and detail fields from struct tags on the projection
+struct: `col:"Header"` for `output.TableFromTags[T]()`, `detail:"Label"` for
+`output.FieldsFromTags(v)`. Both format plain string/bool/int/float fields the
+way the hand-written closures did. A column or field that needs a join,
+pointer deref, conditional, or custom number/time formatting gets no tag and
+stays an explicit `output.Column`/`output.Field` appended after the derived
+set.
+
 ## Command Design
 
 Commands follow a consistent pattern:

--- a/cmd/board/board.go
+++ b/cmd/board/board.go
@@ -36,26 +36,20 @@ type boardListItem struct {
 }
 
 type boardDetail struct {
-	ID            string          `json:"id"`
-	Name          string          `json:"name"`
-	Description   string          `json:"description,omitempty"`
-	Type          string          `json:"type"`
-	ColumnLayout  string          `json:"column_layout,omitempty"`
-	URL           string          `json:"url,omitempty"`
+	ID            string          `json:"id" detail:"ID"`
+	Name          string          `json:"name" detail:"Name"`
+	Description   string          `json:"description,omitempty" detail:"Description"`
+	Type          string          `json:"type" detail:"Type"`
+	ColumnLayout  string          `json:"column_layout,omitempty" detail:"Column Layout"`
+	URL           string          `json:"url,omitempty" detail:"URL"`
 	PresetFilters json.RawMessage `json:"preset_filters,omitempty"`
 	Panels        json.RawMessage `json:"panels,omitempty"`
 }
 
 func writeBoardDetail(opts *options.RootOptions, detail boardDetail) error {
-	return opts.OutputWriter().WriteFields(detail, []output.Field{
-		{Label: "ID", Value: detail.ID},
-		{Label: "Name", Value: detail.Name},
-		{Label: "Description", Value: detail.Description},
-		{Label: "Type", Value: detail.Type},
-		{Label: "Column Layout", Value: detail.ColumnLayout},
-		{Label: "URL", Value: detail.URL},
-		{Label: "Preset Filters", Value: string(detail.PresetFilters)},
-	})
+	fields := output.FieldsFromTags(detail)
+	fields = append(fields, output.Field{Label: "Preset Filters", Value: string(detail.PresetFilters)})
+	return opts.OutputWriter().WriteFields(detail, fields)
 }
 
 func boardToDetail(b api.Board) boardDetail {

--- a/cmd/board/view.go
+++ b/cmd/board/view.go
@@ -11,22 +11,17 @@ import (
 )
 
 type viewItem struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID   string `json:"id" col:"ID"`
+	Name string `json:"name" col:"Name"`
 }
 
 type viewDetail struct {
-	ID      string          `json:"id"`
-	Name    string          `json:"name"`
+	ID      string          `json:"id" detail:"ID"`
+	Name    string          `json:"name" detail:"Name"`
 	Filters json.RawMessage `json:"filters,omitempty"`
 }
 
-var viewListTable = output.TableDef{
-	Columns: []output.Column{
-		{Header: "ID", Value: func(v any) string { return v.(viewItem).ID }},
-		{Header: "Name", Value: func(v any) string { return v.(viewItem).Name }},
-	},
-}
+var viewListTable = output.TableFromTags[viewItem]()
 
 func viewResponseToItem(v api.BoardViewResponse) viewItem {
 	return viewItem{
@@ -48,10 +43,7 @@ func viewResponseToDetail(v api.BoardViewResponse) viewDetail {
 }
 
 func writeViewDetail(opts *options.RootOptions, detail viewDetail) error {
-	return opts.OutputWriter().WriteFields(detail, []output.Field{
-		{Label: "ID", Value: detail.ID},
-		{Label: "Name", Value: detail.Name},
-	})
+	return opts.OutputWriter().WriteFields(detail, output.FieldsFromTags(detail))
 }
 
 func NewViewCmd(opts *options.RootOptions) *cobra.Command {

--- a/cmd/column/calculated.go
+++ b/cmd/column/calculated.go
@@ -9,29 +9,22 @@ import (
 )
 
 type calculatedItem struct {
-	ID          string `json:"id"`
-	Alias       string `json:"alias"`
-	Expression  string `json:"expression"`
-	Description string `json:"description,omitempty"`
+	ID          string `json:"id" col:"ID"`
+	Alias       string `json:"alias" col:"Alias"`
+	Expression  string `json:"expression" col:"Expression"`
+	Description string `json:"description,omitempty" col:"Description"`
 }
 
 type calculatedDetail struct {
-	ID          string `json:"id"`
-	Alias       string `json:"alias"`
-	Expression  string `json:"expression"`
-	Description string `json:"description,omitempty"`
-	CreatedAt   string `json:"created_at,omitempty"`
-	UpdatedAt   string `json:"updated_at,omitempty"`
+	ID          string `json:"id" detail:"ID"`
+	Alias       string `json:"alias" detail:"Alias"`
+	Expression  string `json:"expression" detail:"Expression"`
+	Description string `json:"description,omitempty" detail:"Description"`
+	CreatedAt   string `json:"created_at,omitempty" detail:"Created At"`
+	UpdatedAt   string `json:"updated_at,omitempty" detail:"Updated At"`
 }
 
-var calculatedListTable = output.TableDef{
-	Columns: []output.Column{
-		{Header: "ID", Value: func(v any) string { return v.(calculatedItem).ID }},
-		{Header: "Alias", Value: func(v any) string { return v.(calculatedItem).Alias }},
-		{Header: "Expression", Value: func(v any) string { return v.(calculatedItem).Expression }},
-		{Header: "Description", Value: func(v any) string { return v.(calculatedItem).Description }},
-	},
-}
+var calculatedListTable = output.TableFromTags[calculatedItem]()
 
 func toCalculatedItem(c api.CalculatedField) calculatedItem {
 	return calculatedItem{
@@ -55,14 +48,7 @@ func toCalculatedDetail(c api.CalculatedField) calculatedDetail {
 
 func writeCalculatedDetail(opts *options.RootOptions, c api.CalculatedField) error {
 	d := toCalculatedDetail(c)
-	return opts.OutputWriter().WriteFields(d, []output.Field{
-		{Label: "ID", Value: d.ID},
-		{Label: "Alias", Value: d.Alias},
-		{Label: "Expression", Value: d.Expression},
-		{Label: "Description", Value: d.Description},
-		{Label: "Created At", Value: d.CreatedAt},
-		{Label: "Updated At", Value: d.UpdatedAt},
-	})
+	return opts.OutputWriter().WriteFields(d, output.FieldsFromTags(d))
 }
 
 func NewCalculatedCmd(opts *options.RootOptions, dataset *string) *cobra.Command {

--- a/cmd/column/column.go
+++ b/cmd/column/column.go
@@ -1,8 +1,6 @@
 package column
 
 import (
-	"strconv"
-
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
@@ -20,14 +18,14 @@ type columnItem struct {
 }
 
 type columnDetail struct {
-	ID          string `json:"id"`
-	KeyName     string `json:"key_name"`
-	Type        string `json:"type,omitempty"`
-	Description string `json:"description,omitempty"`
-	Hidden      bool   `json:"hidden"`
-	LastWritten string `json:"last_written,omitempty"`
-	CreatedAt   string `json:"created_at,omitempty"`
-	UpdatedAt   string `json:"updated_at,omitempty"`
+	ID          string `json:"id" detail:"ID"`
+	KeyName     string `json:"key_name" detail:"Key Name"`
+	Type        string `json:"type,omitempty" detail:"Type"`
+	Description string `json:"description,omitempty" detail:"Description"`
+	Hidden      bool   `json:"hidden" detail:"Hidden"`
+	LastWritten string `json:"last_written,omitempty" detail:"Last Written"`
+	CreatedAt   string `json:"created_at,omitempty" detail:"Created At"`
+	UpdatedAt   string `json:"updated_at,omitempty" detail:"Updated At"`
 }
 
 var columnListTable = output.TableDef{
@@ -61,16 +59,7 @@ func columnToDetail(c api.Column) columnDetail {
 
 func writeColumnDetail(opts *options.RootOptions, c api.Column) error {
 	d := columnToDetail(c)
-	return opts.OutputWriter().WriteFields(d, []output.Field{
-		{Label: "ID", Value: d.ID},
-		{Label: "Key Name", Value: d.KeyName},
-		{Label: "Type", Value: d.Type},
-		{Label: "Description", Value: d.Description},
-		{Label: "Hidden", Value: strconv.FormatBool(d.Hidden)},
-		{Label: "Last Written", Value: d.LastWritten},
-		{Label: "Created At", Value: d.CreatedAt},
-		{Label: "Updated At", Value: d.UpdatedAt},
-	})
+	return opts.OutputWriter().WriteFields(d, output.FieldsFromTags(d))
 }
 
 func NewCmd(opts *options.RootOptions) *cobra.Command {

--- a/cmd/dataset/get.go
+++ b/cmd/dataset/get.go
@@ -3,7 +3,6 @@ package dataset
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
@@ -14,14 +13,14 @@ import (
 )
 
 type datasetDetail struct {
-	Name            string  `json:"name"`
-	Slug            string  `json:"slug"`
+	Name            string  `json:"name" detail:"Name"`
+	Slug            string  `json:"slug" detail:"Slug"`
 	Description     string  `json:"description,omitempty"`
 	ExpandJsonDepth *int    `json:"expand_json_depth,omitempty"`
 	Columns         *int    `json:"columns,omitempty"`
 	LastWritten     *string `json:"last_written,omitempty"`
-	DeleteProtected bool    `json:"delete_protected"`
-	CreatedAt       string  `json:"created_at"`
+	DeleteProtected bool    `json:"delete_protected" detail:"Delete Protected"`
+	CreatedAt       string  `json:"created_at" detail:"Created At"`
 }
 
 func mapDatasetDetail(d *api.Dataset) datasetDetail {
@@ -78,10 +77,7 @@ func runDatasetGet(ctx context.Context, opts *options.RootOptions, slug string) 
 }
 
 func writeDatasetDetail(opts *options.RootOptions, detail datasetDetail) error {
-	fields := []output.Field{
-		{Label: "Name", Value: detail.Name},
-		{Label: "Slug", Value: detail.Slug},
-	}
+	fields := output.FieldsFromTags(detail)
 	if detail.Description != "" {
 		fields = append(fields, output.Field{Label: "Description", Value: detail.Description})
 	}
@@ -94,9 +90,5 @@ func writeDatasetDetail(opts *options.RootOptions, detail datasetDetail) error {
 	if detail.LastWritten != nil {
 		fields = append(fields, output.Field{Label: "Last Written", Value: *detail.LastWritten})
 	}
-	fields = append(fields,
-		output.Field{Label: "Delete Protected", Value: strconv.FormatBool(detail.DeleteProtected)},
-		output.Field{Label: "Created At", Value: detail.CreatedAt},
-	)
 	return opts.OutputWriter().WriteFields(detail, fields)
 }

--- a/cmd/dataset/list.go
+++ b/cmd/dataset/list.go
@@ -13,33 +13,32 @@ import (
 )
 
 type datasetItem struct {
-	Name        string  `json:"name"`
-	Slug        string  `json:"slug"`
-	Description string  `json:"description,omitempty"`
+	Name        string  `json:"name" col:"Name"`
+	Slug        string  `json:"slug" col:"Slug"`
+	Description string  `json:"description,omitempty" col:"Description"`
 	Columns     *int    `json:"columns,omitempty"`
 	LastWritten *string `json:"last_written,omitempty"`
 	CreatedAt   string  `json:"created_at"`
 }
 
-var datasetListTable = output.TableDef{
-	Columns: []output.Column{
-		{Header: "Name", Value: func(v any) string { return v.(datasetItem).Name }},
-		{Header: "Slug", Value: func(v any) string { return v.(datasetItem).Slug }},
-		{Header: "Description", Value: func(v any) string { return v.(datasetItem).Description }},
-		{Header: "Columns", Value: func(v any) string {
+var datasetListTable = func() output.TableDef {
+	table := output.TableFromTags[datasetItem]()
+	table.Columns = append(table.Columns,
+		output.Column{Header: "Columns", Value: func(v any) string {
 			if c := v.(datasetItem).Columns; c != nil {
 				return fmt.Sprintf("%d", *c)
 			}
 			return "—"
 		}},
-		{Header: "Last Written", Value: func(v any) string {
+		output.Column{Header: "Last Written", Value: func(v any) string {
 			if lw := v.(datasetItem).LastWritten; lw != nil {
 				return *lw
 			}
 			return "—"
 		}},
-	},
-}
+	)
+	return table
+}()
 
 func NewListCmd(opts *options.RootOptions) *cobra.Command {
 	return &cobra.Command{

--- a/cmd/environment/environment.go
+++ b/cmd/environment/environment.go
@@ -2,7 +2,6 @@ package environment
 
 import (
 	"encoding/json"
-	"strconv"
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
@@ -31,20 +30,20 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 type environmentItem struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Slug        string `json:"slug"`
-	Description string `json:"description,omitempty"`
-	Color       string `json:"color,omitempty"`
+	ID          string `json:"id" col:"ID"`
+	Name        string `json:"name" col:"Name"`
+	Slug        string `json:"slug" col:"Slug"`
+	Description string `json:"description,omitempty" col:"Description"`
+	Color       string `json:"color,omitempty" col:"Color"`
 }
 
 type environmentDetail struct {
-	ID              string `json:"id"`
-	Name            string `json:"name"`
-	Slug            string `json:"slug"`
-	Description     string `json:"description,omitempty"`
-	Color           string `json:"color,omitempty"`
-	DeleteProtected bool   `json:"delete_protected"`
+	ID              string `json:"id" detail:"ID"`
+	Name            string `json:"name" detail:"Name"`
+	Slug            string `json:"slug" detail:"Slug"`
+	Description     string `json:"description,omitempty" detail:"Description"`
+	Color           string `json:"color,omitempty" detail:"Color"`
+	DeleteProtected bool   `json:"delete_protected" detail:"Delete Protected"`
 }
 
 func colorString(c api.Environment_Attributes_Color) string {
@@ -81,12 +80,5 @@ func envToDetail(e api.Environment) environmentDetail {
 }
 
 func writeEnvironmentDetail(opts *options.RootOptions, detail environmentDetail) error {
-	return opts.OutputWriter().WriteFields(detail, []output.Field{
-		{Label: "ID", Value: detail.ID},
-		{Label: "Name", Value: detail.Name},
-		{Label: "Slug", Value: detail.Slug},
-		{Label: "Description", Value: detail.Description},
-		{Label: "Color", Value: detail.Color},
-		{Label: "Delete Protected", Value: strconv.FormatBool(detail.DeleteProtected)},
-	})
+	return opts.OutputWriter().WriteFields(detail, output.FieldsFromTags(detail))
 }

--- a/cmd/environment/list.go
+++ b/cmd/environment/list.go
@@ -11,15 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var environmentListTable = output.TableDef{
-	Columns: []output.Column{
-		{Header: "ID", Value: func(v any) string { return v.(environmentItem).ID }},
-		{Header: "Name", Value: func(v any) string { return v.(environmentItem).Name }},
-		{Header: "Slug", Value: func(v any) string { return v.(environmentItem).Slug }},
-		{Header: "Description", Value: func(v any) string { return v.(environmentItem).Description }},
-		{Header: "Color", Value: func(v any) string { return v.(environmentItem).Color }},
-	},
-}
+var environmentListTable = output.TableFromTags[environmentItem]()
 
 func NewListCmd(opts *options.RootOptions, team *string) *cobra.Command {
 	return &cobra.Command{

--- a/cmd/key/key.go
+++ b/cmd/key/key.go
@@ -1,9 +1,6 @@
 package key
 
 import (
-	"fmt"
-	"strconv"
-
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
@@ -32,37 +29,25 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 type keyItem struct {
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	KeyType  string `json:"key_type"`
-	Disabled bool   `json:"disabled"`
+	ID       string `json:"id" col:"ID"`
+	Name     string `json:"name" col:"Name"`
+	KeyType  string `json:"key_type" col:"Key Type"`
+	Disabled bool   `json:"disabled" col:"Disabled"`
 }
 
 type keyDetail struct {
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	KeyType  string `json:"key_type"`
-	Disabled bool   `json:"disabled"`
+	ID       string `json:"id" detail:"ID"`
+	Name     string `json:"name" detail:"Name"`
+	KeyType  string `json:"key_type" detail:"Key Type"`
+	Disabled bool   `json:"disabled" detail:"Disabled"`
 	Secret   string `json:"secret,omitempty"`
 	Key      string `json:"key,omitempty"`
 }
 
-var keyListTable = output.TableDef{
-	Columns: []output.Column{
-		{Header: "ID", Value: func(v any) string { return v.(keyItem).ID }},
-		{Header: "Name", Value: func(v any) string { return v.(keyItem).Name }},
-		{Header: "Key Type", Value: func(v any) string { return v.(keyItem).KeyType }},
-		{Header: "Disabled", Value: func(v any) string { return fmt.Sprintf("%t", v.(keyItem).Disabled) }},
-	},
-}
+var keyListTable = output.TableFromTags[keyItem]()
 
 func writeKeyDetail(opts *options.RootOptions, detail keyDetail) error {
-	fields := []output.Field{
-		{Label: "ID", Value: detail.ID},
-		{Label: "Name", Value: detail.Name},
-		{Label: "Key Type", Value: detail.KeyType},
-		{Label: "Disabled", Value: strconv.FormatBool(detail.Disabled)},
-	}
+	fields := output.FieldsFromTags(detail)
 	if detail.Secret != "" {
 		fields = append(fields, output.Field{Label: "Secret", Value: detail.Secret})
 	}

--- a/cmd/marker/marker.go
+++ b/cmd/marker/marker.go
@@ -11,15 +11,15 @@ import (
 )
 
 type markerItem struct {
-	ID        string `json:"id"`
-	Type      string `json:"type,omitempty"`
-	Message   string `json:"message,omitempty"`
-	URL       string `json:"url,omitempty"`
+	ID        string `json:"id" detail:"ID"`
+	Type      string `json:"type,omitempty" detail:"Type"`
+	Message   string `json:"message,omitempty" detail:"Message"`
+	URL       string `json:"url,omitempty" detail:"URL"`
 	StartTime *int   `json:"start_time,omitempty"`
 	EndTime   *int   `json:"end_time,omitempty"`
-	Color     string `json:"color,omitempty"`
-	CreatedAt string `json:"created_at,omitempty"`
-	UpdatedAt string `json:"updated_at,omitempty"`
+	Color     string `json:"color,omitempty" detail:"Color"`
+	CreatedAt string `json:"created_at,omitempty" detail:"Created At"`
+	UpdatedAt string `json:"updated_at,omitempty" detail:"Updated At"`
 }
 
 var markerListTable = output.TableDef{
@@ -58,23 +58,13 @@ func markerToItem(m api.Marker) markerItem {
 }
 
 func writeDetail(opts *options.RootOptions, item markerItem) error {
-	fields := []output.Field{
-		{Label: "ID", Value: item.ID},
-		{Label: "Type", Value: item.Type},
-		{Label: "Message", Value: item.Message},
-		{Label: "URL", Value: item.URL},
-	}
+	fields := output.FieldsFromTags(item)
 	if item.StartTime != nil {
 		fields = append(fields, output.Field{Label: "Start Time", Value: fmt.Sprintf("%d", *item.StartTime)})
 	}
 	if item.EndTime != nil {
 		fields = append(fields, output.Field{Label: "End Time", Value: fmt.Sprintf("%d", *item.EndTime)})
 	}
-	fields = append(fields,
-		output.Field{Label: "Color", Value: item.Color},
-		output.Field{Label: "Created At", Value: item.CreatedAt},
-		output.Field{Label: "Updated At", Value: item.UpdatedAt},
-	)
 	return opts.OutputWriter().WriteFields(item, fields)
 }
 

--- a/cmd/marker/setting.go
+++ b/cmd/marker/setting.go
@@ -9,20 +9,14 @@ import (
 )
 
 type settingItem struct {
-	ID        string `json:"id"`
-	Type      string `json:"type"`
-	Color     string `json:"color"`
-	CreatedAt string `json:"created_at,omitempty"`
-	UpdatedAt string `json:"updated_at,omitempty"`
+	ID        string `json:"id" col:"ID" detail:"ID"`
+	Type      string `json:"type" col:"Type" detail:"Type"`
+	Color     string `json:"color" col:"Color" detail:"Color"`
+	CreatedAt string `json:"created_at,omitempty" detail:"Created At"`
+	UpdatedAt string `json:"updated_at,omitempty" detail:"Updated At"`
 }
 
-var settingListTable = output.TableDef{
-	Columns: []output.Column{
-		{Header: "ID", Value: func(v any) string { return v.(settingItem).ID }},
-		{Header: "Type", Value: func(v any) string { return v.(settingItem).Type }},
-		{Header: "Color", Value: func(v any) string { return v.(settingItem).Color }},
-	},
-}
+var settingListTable = output.TableFromTags[settingItem]()
 
 func toSettingItem(s api.MarkerSetting) settingItem {
 	item := settingItem{
@@ -38,13 +32,7 @@ func toSettingItem(s api.MarkerSetting) settingItem {
 }
 
 func writeSettingDetail(opts *options.RootOptions, item settingItem) error {
-	return opts.OutputWriter().WriteFields(item, []output.Field{
-		{Label: "ID", Value: item.ID},
-		{Label: "Type", Value: item.Type},
-		{Label: "Color", Value: item.Color},
-		{Label: "Created At", Value: item.CreatedAt},
-		{Label: "Updated At", Value: item.UpdatedAt},
-	})
+	return opts.OutputWriter().WriteFields(item, output.FieldsFromTags(item))
 }
 
 func NewSettingCmd(opts *options.RootOptions, dataset *string) *cobra.Command {

--- a/cmd/query/annotation.go
+++ b/cmd/query/annotation.go
@@ -9,30 +9,23 @@ import (
 )
 
 type annotationItem struct {
-	ID      string `json:"id"`
-	Name    string `json:"name"`
-	QueryID string `json:"query_id"`
-	Source  string `json:"source,omitempty"`
+	ID      string `json:"id" col:"ID"`
+	Name    string `json:"name" col:"Name"`
+	QueryID string `json:"query_id" col:"Query ID"`
+	Source  string `json:"source,omitempty" col:"Source"`
 }
 
 type annotationDetail struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
-	QueryID     string `json:"query_id"`
+	ID          string `json:"id" detail:"ID"`
+	Name        string `json:"name" detail:"Name"`
+	Description string `json:"description,omitempty" detail:"Description"`
+	QueryID     string `json:"query_id" detail:"Query ID"`
 	Source      string `json:"source,omitempty"`
 	CreatedAt   string `json:"created_at,omitempty"`
 	UpdatedAt   string `json:"updated_at,omitempty"`
 }
 
-var annotationListTable = output.TableDef{
-	Columns: []output.Column{
-		{Header: "ID", Value: func(v any) string { return v.(annotationItem).ID }},
-		{Header: "Name", Value: func(v any) string { return v.(annotationItem).Name }},
-		{Header: "Query ID", Value: func(v any) string { return v.(annotationItem).QueryID }},
-		{Header: "Source", Value: func(v any) string { return v.(annotationItem).Source }},
-	},
-}
+var annotationListTable = output.TableFromTags[annotationItem]()
 
 func annotationToDetail(a api.QueryAnnotation) annotationDetail {
 	return annotationDetail{
@@ -47,12 +40,7 @@ func annotationToDetail(a api.QueryAnnotation) annotationDetail {
 }
 
 func writeAnnotationDetail(opts *options.RootOptions, detail annotationDetail) error {
-	fields := []output.Field{
-		{Label: "ID", Value: detail.ID},
-		{Label: "Name", Value: detail.Name},
-		{Label: "Description", Value: detail.Description},
-		{Label: "Query ID", Value: detail.QueryID},
-	}
+	fields := output.FieldsFromTags(detail)
 	if detail.Source != "" {
 		fields = append(fields, output.Field{Label: "Source", Value: detail.Source})
 	}

--- a/cmd/query/annotation_view.go
+++ b/cmd/query/annotation_view.go
@@ -58,12 +58,7 @@ func runAnnotationView(ctx context.Context, opts *options.RootOptions, dataset, 
 		Query:            queryResp.JSON200,
 	}
 
-	fields := []output.Field{
-		{Label: "ID", Value: combined.ID},
-		{Label: "Name", Value: combined.Name},
-		{Label: "Description", Value: combined.Description},
-		{Label: "Query ID", Value: combined.QueryID},
-	}
+	fields := output.FieldsFromTags(combined.annotationDetail)
 	if combined.Source != "" {
 		fields = append(fields, output.Field{Label: "Source", Value: combined.Source})
 	}

--- a/cmd/recipient/list.go
+++ b/cmd/recipient/list.go
@@ -11,13 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var recipientListTable = output.TableDef{
-	Columns: []output.Column{
-		{Header: "ID", Value: func(v any) string { return v.(recipientItem).ID }},
-		{Header: "Type", Value: func(v any) string { return v.(recipientItem).Type }},
-		{Header: "Target", Value: func(v any) string { return v.(recipientItem).Target }},
-	},
-}
+var recipientListTable = output.TableFromTags[recipientItem]()
 
 func NewListCmd(opts *options.RootOptions) *cobra.Command {
 	return &cobra.Command{

--- a/cmd/recipient/recipient.go
+++ b/cmd/recipient/recipient.go
@@ -27,14 +27,14 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 type recipientItem struct {
-	ID     string `json:"id"`
-	Type   string `json:"type"`
-	Target string `json:"target,omitempty"`
+	ID     string `json:"id" col:"ID"`
+	Type   string `json:"type" col:"Type"`
+	Target string `json:"target,omitempty" col:"Target"`
 }
 
 type recipientDetail struct {
-	ID        string         `json:"id"`
-	Type      string         `json:"type"`
+	ID        string         `json:"id" detail:"ID"`
+	Type      string         `json:"type" detail:"Type"`
 	Details   map[string]any `json:"details,omitempty"`
 	CreatedAt string         `json:"created_at,omitempty"`
 	UpdatedAt string         `json:"updated_at,omitempty"`
@@ -118,10 +118,7 @@ func extractTarget(d recipientDetail) string {
 }
 
 func writeRecipientDetail(opts *options.RootOptions, detail recipientDetail) error {
-	fields := []output.Field{
-		{Label: "ID", Value: detail.ID},
-		{Label: "Type", Value: detail.Type},
-	}
+	fields := output.FieldsFromTags(detail)
 	if target := extractTarget(detail); target != "" {
 		fields = append(fields, output.Field{Label: "Target", Value: target})
 	}

--- a/cmd/recipient/triggers.go
+++ b/cmd/recipient/triggers.go
@@ -3,7 +3,6 @@ package recipient
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
@@ -14,26 +13,16 @@ import (
 )
 
 type triggerItem struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
-	Disabled    bool   `json:"disabled"`
-	Triggered   bool   `json:"triggered"`
-	AlertType   string `json:"alert_type,omitempty"`
-	Threshold   string `json:"threshold,omitempty"`
+	ID          string `json:"id" col:"ID"`
+	Name        string `json:"name" col:"Name"`
+	Description string `json:"description,omitempty" col:"Description"`
+	Disabled    bool   `json:"disabled" col:"Disabled"`
+	Triggered   bool   `json:"triggered" col:"Triggered"`
+	AlertType   string `json:"alert_type,omitempty" col:"Alert Type"`
+	Threshold   string `json:"threshold,omitempty" col:"Threshold"`
 }
 
-var triggerListTable = output.TableDef{
-	Columns: []output.Column{
-		{Header: "ID", Value: func(v any) string { return v.(triggerItem).ID }},
-		{Header: "Name", Value: func(v any) string { return v.(triggerItem).Name }},
-		{Header: "Description", Value: func(v any) string { return v.(triggerItem).Description }},
-		{Header: "Disabled", Value: func(v any) string { return strconv.FormatBool(v.(triggerItem).Disabled) }},
-		{Header: "Triggered", Value: func(v any) string { return strconv.FormatBool(v.(triggerItem).Triggered) }},
-		{Header: "Alert Type", Value: func(v any) string { return v.(triggerItem).AlertType }},
-		{Header: "Threshold", Value: func(v any) string { return v.(triggerItem).Threshold }},
-	},
-}
+var triggerListTable = output.TableFromTags[triggerItem]()
 
 func NewTriggersCmd(opts *options.RootOptions) *cobra.Command {
 	return &cobra.Command{

--- a/cmd/slo/burn_alert.go
+++ b/cmd/slo/burn_alert.go
@@ -7,15 +7,15 @@ import (
 )
 
 type burnAlertItem struct {
-	ID        string `json:"id"`
-	AlertType string `json:"alert_type"`
-	SloID     string `json:"slo_id,omitempty"`
-	CreatedAt string `json:"created_at,omitempty"`
+	ID        string `json:"id" col:"ID"`
+	AlertType string `json:"alert_type" col:"Alert Type"`
+	SloID     string `json:"slo_id,omitempty" col:"SLO ID"`
+	CreatedAt string `json:"created_at,omitempty" col:"Created At"`
 }
 
 type burnAlertDetail struct {
-	ID                                    string `json:"id"`
-	AlertType                             string `json:"alert_type"`
+	ID                                    string `json:"id" detail:"ID"`
+	AlertType                             string `json:"alert_type" detail:"Alert Type"`
 	Description                           string `json:"description,omitempty"`
 	SloID                                 string `json:"slo_id,omitempty"`
 	CreatedAt                             string `json:"created_at,omitempty"`
@@ -25,14 +25,7 @@ type burnAlertDetail struct {
 	BudgetRateWindowMinutes               *int   `json:"budget_rate_window_minutes,omitempty"`
 }
 
-var burnAlertListTable = output.TableDef{
-	Columns: []output.Column{
-		{Header: "ID", Value: func(v any) string { return v.(burnAlertItem).ID }},
-		{Header: "Alert Type", Value: func(v any) string { return v.(burnAlertItem).AlertType }},
-		{Header: "SLO ID", Value: func(v any) string { return v.(burnAlertItem).SloID }},
-		{Header: "Created At", Value: func(v any) string { return v.(burnAlertItem).CreatedAt }},
-	},
-}
+var burnAlertListTable = output.TableFromTags[burnAlertItem]()
 
 func NewBurnAlertCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	cmd := &cobra.Command{

--- a/cmd/slo/burn_alert_get.go
+++ b/cmd/slo/burn_alert_get.go
@@ -47,10 +47,7 @@ func runBurnAlertGet(ctx context.Context, opts *options.RootOptions, dataset, bu
 }
 
 func writeBurnAlertDetail(opts *options.RootOptions, detail burnAlertDetail) error {
-	fields := []output.Field{
-		{Label: "ID", Value: detail.ID},
-		{Label: "Alert Type", Value: detail.AlertType},
-	}
+	fields := output.FieldsFromTags(detail)
 	if detail.Description != "" {
 		fields = append(fields, output.Field{Label: "Description", Value: detail.Description})
 	}

--- a/cmd/slo/format.go
+++ b/cmd/slo/format.go
@@ -37,12 +37,12 @@ type sloItem struct {
 }
 
 type sloDetail struct {
-	ID               string   `json:"id"`
-	Name             string   `json:"name"`
-	Description      string   `json:"description,omitempty"`
+	ID               string   `json:"id" detail:"ID"`
+	Name             string   `json:"name" detail:"Name"`
+	Description      string   `json:"description,omitempty" detail:"Description"`
 	TargetPerMillion int      `json:"target_per_million"`
 	TimePeriodDays   int      `json:"time_period_days"`
-	SLIAlias         string   `json:"sli_alias"`
+	SLIAlias         string   `json:"sli_alias" detail:"SLI Alias"`
 	DatasetSlugs     []string `json:"dataset_slugs,omitempty"`
 	CreatedAt        string   `json:"created_at,omitempty"`
 	UpdatedAt        string   `json:"updated_at,omitempty"`
@@ -93,14 +93,11 @@ func detailedToDetail(s sloDetailedResponse) sloDetail {
 }
 
 func writeSloDetail(opts *options.RootOptions, detail sloDetail) error {
-	fields := []output.Field{
-		{Label: "ID", Value: detail.ID},
-		{Label: "Name", Value: detail.Name},
-		{Label: "Description", Value: detail.Description},
-		{Label: "SLI Alias", Value: detail.SLIAlias},
-		{Label: "Target", Value: formatTarget(detail.TargetPerMillion)},
-		{Label: "Time Period", Value: formatTimePeriod(detail.TimePeriodDays)},
-	}
+	fields := output.FieldsFromTags(detail)
+	fields = append(fields,
+		output.Field{Label: "Target", Value: formatTarget(detail.TargetPerMillion)},
+		output.Field{Label: "Time Period", Value: formatTimePeriod(detail.TimePeriodDays)},
+	)
 	if len(detail.DatasetSlugs) > 0 {
 		fields = append(fields, output.Field{Label: "Datasets", Value: strings.Join(detail.DatasetSlugs, ", ")})
 	}

--- a/cmd/trigger/list.go
+++ b/cmd/trigger/list.go
@@ -3,7 +3,6 @@ package trigger
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
@@ -12,17 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var triggerListTable = output.TableDef{
-	Columns: []output.Column{
-		{Header: "ID", Value: func(v any) string { return v.(triggerItem).ID }},
-		{Header: "Name", Value: func(v any) string { return v.(triggerItem).Name }},
-		{Header: "Description", Value: func(v any) string { return v.(triggerItem).Description }},
-		{Header: "Disabled", Value: func(v any) string { return strconv.FormatBool(v.(triggerItem).Disabled) }},
-		{Header: "Triggered", Value: func(v any) string { return strconv.FormatBool(v.(triggerItem).Triggered) }},
-		{Header: "Alert Type", Value: func(v any) string { return v.(triggerItem).AlertType }},
-		{Header: "Threshold", Value: func(v any) string { return v.(triggerItem).Threshold }},
-	},
-}
+var triggerListTable = output.TableFromTags[triggerItem]()
 
 func NewListCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	return &cobra.Command{

--- a/cmd/trigger/trigger.go
+++ b/cmd/trigger/trigger.go
@@ -2,7 +2,6 @@ package trigger
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
@@ -34,31 +33,31 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 type triggerItem struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
-	Disabled    bool   `json:"disabled"`
-	Triggered   bool   `json:"triggered"`
-	AlertType   string `json:"alert_type,omitempty"`
-	Threshold   string `json:"threshold,omitempty"`
+	ID          string `json:"id" col:"ID"`
+	Name        string `json:"name" col:"Name"`
+	Description string `json:"description,omitempty" col:"Description"`
+	Disabled    bool   `json:"disabled" col:"Disabled"`
+	Triggered   bool   `json:"triggered" col:"Triggered"`
+	AlertType   string `json:"alert_type,omitempty" col:"Alert Type"`
+	Threshold   string `json:"threshold,omitempty" col:"Threshold"`
 }
 
 type triggerDetail struct {
-	ID          string            `json:"id"`
-	Name        string            `json:"name"`
-	Description string            `json:"description,omitempty"`
-	DatasetSlug string            `json:"dataset_slug,omitempty"`
-	Disabled    bool              `json:"disabled"`
-	Triggered   bool              `json:"triggered"`
-	AlertType   string            `json:"alert_type,omitempty"`
-	Frequency   int               `json:"frequency,omitempty"`
+	ID          string            `json:"id" detail:"ID"`
+	Name        string            `json:"name" detail:"Name"`
+	Description string            `json:"description,omitempty" detail:"Description"`
+	DatasetSlug string            `json:"dataset_slug,omitempty" detail:"Dataset Slug"`
+	Disabled    bool              `json:"disabled" detail:"Disabled"`
+	Triggered   bool              `json:"triggered" detail:"Triggered"`
+	AlertType   string            `json:"alert_type,omitempty" detail:"Alert Type"`
+	Frequency   int               `json:"frequency,omitempty" detail:"Frequency"`
 	Threshold   *triggerThreshold `json:"threshold,omitempty"`
 	QueryID     string            `json:"query_id,omitempty"`
 	HasQuery    bool              `json:"has_query,omitempty"`
 	Recipients  []recipientItem   `json:"recipients,omitempty"`
 	Tags        []tagItem         `json:"tags,omitempty"`
-	CreatedAt   string            `json:"created_at,omitempty"`
-	UpdatedAt   string            `json:"updated_at,omitempty"`
+	CreatedAt   string            `json:"created_at,omitempty" detail:"Created At"`
+	UpdatedAt   string            `json:"updated_at,omitempty" detail:"Updated At"`
 }
 
 type triggerThreshold struct {
@@ -137,28 +136,15 @@ func toDetail(t api.TriggerResponse) triggerDetail {
 }
 
 func writeTriggerDetail(opts *options.RootOptions, detail triggerDetail) error {
-	fields := []output.Field{
-		{Label: "ID", Value: detail.ID},
-		{Label: "Name", Value: detail.Name},
-		{Label: "Description", Value: detail.Description},
-		{Label: "Disabled", Value: strconv.FormatBool(detail.Disabled)},
-		{Label: "Triggered", Value: strconv.FormatBool(detail.Triggered)},
-		{Label: "Alert Type", Value: detail.AlertType},
-		{Label: "Dataset Slug", Value: detail.DatasetSlug},
-		{Label: "Frequency", Value: strconv.Itoa(detail.Frequency)},
-		{Label: "Threshold", Value: formatThresholdDetail(detail.Threshold)},
-	}
+	fields := output.FieldsFromTags(detail)
+
+	fields = append(fields, output.Field{Label: "Threshold", Value: formatThresholdDetail(detail.Threshold)})
 
 	if detail.QueryID != "" {
 		fields = append(fields, output.Field{Label: "Query ID", Value: detail.QueryID})
 	} else if detail.HasQuery {
 		fields = append(fields, output.Field{Label: "Query ID", Value: "(inline)"})
 	}
-
-	fields = append(fields,
-		output.Field{Label: "Created At", Value: detail.CreatedAt},
-		output.Field{Label: "Updated At", Value: detail.UpdatedAt},
-	)
 
 	if len(detail.Recipients) > 0 {
 		targets := make([]string, len(detail.Recipients))

--- a/internal/output/tags.go
+++ b/internal/output/tags.go
@@ -1,0 +1,63 @@
+package output
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+)
+
+// TableFromTags derives a TableDef from the `col:"Header"` struct tags on T, in
+// field order. Each column reads its field by reflection and formats it the
+// same way the hand-written closures did (strings as-is, bools via FormatBool,
+// integers and floats via strconv). Fields without a `col` tag are skipped, so
+// computed columns can be appended to the returned TableDef explicitly.
+func TableFromTags[T any]() TableDef {
+	t := reflect.TypeFor[T]()
+	var columns []Column
+	for i := range t.NumField() {
+		header, ok := t.Field(i).Tag.Lookup("col")
+		if !ok {
+			continue
+		}
+		field := i
+		columns = append(columns, Column{
+			Header: header,
+			Value:  func(v any) string { return formatField(reflect.ValueOf(v).Field(field)) },
+		})
+	}
+	return TableDef{Columns: columns}
+}
+
+// FieldsFromTags derives detail Fields from the `detail:"Label"` struct tags on
+// v, in field order. Fields without a `detail` tag are skipped, so computed or
+// conditional fields can be appended by the caller.
+func FieldsFromTags(v any) []Field {
+	rv := reflect.ValueOf(v)
+	t := rv.Type()
+	var fields []Field
+	for i := range t.NumField() {
+		label, ok := t.Field(i).Tag.Lookup("detail")
+		if !ok {
+			continue
+		}
+		fields = append(fields, Field{Label: label, Value: formatField(rv.Field(i))})
+	}
+	return fields
+}
+
+func formatField(rv reflect.Value) string {
+	switch rv.Kind() {
+	case reflect.String:
+		return rv.String()
+	case reflect.Bool:
+		return strconv.FormatBool(rv.Bool())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return strconv.FormatInt(rv.Int(), 10)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return strconv.FormatUint(rv.Uint(), 10)
+	case reflect.Float32, reflect.Float64:
+		return strconv.FormatFloat(rv.Float(), 'g', -1, 64)
+	default:
+		return fmt.Sprint(rv.Interface())
+	}
+}

--- a/internal/output/tags_test.go
+++ b/internal/output/tags_test.go
@@ -1,0 +1,79 @@
+package output
+
+import (
+	"strings"
+	"testing"
+)
+
+type tagged struct {
+	ID      string `col:"ID" detail:"ID"`
+	Name    string `col:"Name" detail:"Name"`
+	Enabled bool   `col:"Enabled" detail:"Enabled"`
+	Count   int    `col:"Count" detail:"Count"`
+	Ratio   float64
+	Hidden  string
+}
+
+func TestTableFromTags(t *testing.T) {
+	td := TableFromTags[tagged]()
+
+	wantHeaders := []string{"ID", "Name", "Enabled", "Count"}
+	if len(td.Columns) != len(wantHeaders) {
+		t.Fatalf("got %d columns, want %d", len(td.Columns), len(wantHeaders))
+	}
+
+	item := tagged{ID: "abc", Name: "widget", Enabled: true, Count: 7, Ratio: 0.5, Hidden: "x"}
+	wantValues := []string{"abc", "widget", "true", "7"}
+	for i, col := range td.Columns {
+		if col.Header != wantHeaders[i] {
+			t.Errorf("column %d header = %q, want %q", i, col.Header, wantHeaders[i])
+		}
+		if got := col.Value(item); got != wantValues[i] {
+			t.Errorf("column %q value = %q, want %q", col.Header, got, wantValues[i])
+		}
+	}
+}
+
+func TestFieldsFromTags(t *testing.T) {
+	item := tagged{ID: "abc", Name: "widget", Enabled: false, Count: 0, Hidden: "x"}
+	fields := FieldsFromTags(item)
+
+	want := []Field{
+		{Label: "ID", Value: "abc"},
+		{Label: "Name", Value: "widget"},
+		{Label: "Enabled", Value: "false"},
+		{Label: "Count", Value: "0"},
+	}
+	if len(fields) != len(want) {
+		t.Fatalf("got %d fields, want %d", len(fields), len(want))
+	}
+	for i, f := range fields {
+		if f != want[i] {
+			t.Errorf("field %d = %+v, want %+v", i, f, want[i])
+		}
+	}
+}
+
+func TestFieldsFromTags_Float(t *testing.T) {
+	type floaty struct {
+		Ratio float64 `detail:"Ratio"`
+	}
+	fields := FieldsFromTags(floaty{Ratio: 99.5})
+	if len(fields) != 1 || fields[0].Value != "99.5" {
+		t.Errorf("got %+v, want Ratio=99.5", fields)
+	}
+}
+
+func TestTableFromTags_RendersThroughWrite(t *testing.T) {
+	var buf strings.Builder
+	w := New(&buf, FormatTable)
+	if err := w.Write([]tagged{{ID: "abc", Name: "widget", Enabled: true, Count: 7}}, TableFromTags[tagged]()); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	for _, want := range []string{"ID", "NAME", "abc", "widget", "true", "7"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table output missing %q:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
Add output.TableFromTags and output.FieldsFromTags, which read col:/detail:
struct tags to build list columns and detail fields, replacing the hand-written
TableDef closures and []Field slices. Columns/fields needing joins, pointer
derefs, conditionals, or custom formatting keep explicit handling appended
after the tag-derived base.