### PR TITLE
refactor(output): replace WriteValue closure with WriteMessage

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
@@ -212,22 +211,23 @@ func confirmOverwrite(opts *options.RootOptions, keyType string) (abort bool, er
 }
 
 func writeLoginResult(opts *options.RootOptions, result loginResult) error {
-	return opts.OutputWriter().WriteValue(result, func(w io.Writer) error {
-		if result.Verified {
-			if result.Team != "" {
-				_, _ = fmt.Fprintf(w, "Authenticated as %s", result.Team)
-				if result.Environment != "" {
-					_, _ = fmt.Fprintf(w, " (%s)", result.Environment)
-				}
-				_, _ = fmt.Fprintln(w)
-			} else if result.Name != "" {
-				_, _ = fmt.Fprintf(w, "Authenticated with key %q\n", result.Name)
-			} else {
-				_, _ = fmt.Fprintln(w, "Key verified and stored.")
-			}
-		} else {
-			_, _ = fmt.Fprintln(w, "Key stored (unverified).")
+	return opts.OutputWriter().WriteMessage(result, loginMessage(result))
+}
+
+func loginMessage(result loginResult) string {
+	if !result.Verified {
+		return "Key stored (unverified)."
+	}
+	switch {
+	case result.Team != "":
+		msg := fmt.Sprintf("Authenticated as %s", result.Team)
+		if result.Environment != "" {
+			msg += fmt.Sprintf(" (%s)", result.Environment)
 		}
-		return nil
-	})
+		return msg
+	case result.Name != "":
+		return fmt.Sprintf("Authenticated with key %q", result.Name)
+	default:
+		return "Key verified and stored."
+	}
 }

--- a/cmd/mcp/call.go
+++ b/cmd/mcp/call.go
@@ -159,9 +159,7 @@ func writeCallResult(o *callOptions, result *mcp.CallToolResult) error {
 			return jq.Filter(bytes.NewReader(b), ios.Out, o.jqExpr)
 		}
 
-		return o.root.OutputWriter().WriteValue(out, func(w io.Writer) error {
-			return nil
-		})
+		return o.root.OutputWriter().WriteMessage(out, "")
 	}
 
 	for _, c := range result.Content {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -71,12 +71,20 @@ func (w *Writer) Write(data any, td TableDef) error {
 	}
 }
 
-func (w *Writer) WriteValue(data any, writeTable func(io.Writer) error) error {
+// WriteMessage emits data as JSON, or a single human-readable line in table
+// mode. An empty line writes nothing in table mode. It covers the "JSON
+// object, or one status line" shape that previously required callers to pass
+// a table-building closure.
+func (w *Writer) WriteMessage(data any, line string) error {
 	switch w.format {
 	case FormatJSON:
 		return w.writeJSON(data)
 	case FormatTable:
-		return writeTable(w.out)
+		if line == "" {
+			return nil
+		}
+		_, err := fmt.Fprintln(w.out, line)
+		return err
 	default:
 		return fmt.Errorf("unsupported format: %s", w.format)
 	}
@@ -180,8 +188,5 @@ func (w *Writer) writeDynamicTable(td DynamicTableDef) error {
 }
 
 func (w *Writer) WriteDeleted(id, msg string) error {
-	return w.WriteValue(map[string]string{"id": id}, func(out io.Writer) error {
-		_, err := fmt.Fprintln(out, msg)
-		return err
-	})
+	return w.WriteMessage(map[string]string{"id": id}, msg)
 }

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"strings"
 	"testing"
 )
@@ -105,12 +104,12 @@ func TestWrite_Table_NoColumns(t *testing.T) {
 	}
 }
 
-func TestWriteValue_JSON(t *testing.T) {
+func TestWriteMessage_JSON(t *testing.T) {
 	var buf bytes.Buffer
 	w := New(&buf, FormatJSON)
 
 	item := testItem{Name: "a", Count: 1}
-	if err := w.WriteValue(item, nil); err != nil {
+	if err := w.WriteMessage(item, "ignored in JSON mode"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -123,30 +122,37 @@ func TestWriteValue_JSON(t *testing.T) {
 	}
 }
 
-func TestWriteValue_Table(t *testing.T) {
+func TestWriteMessage_Table(t *testing.T) {
 	var buf bytes.Buffer
 	w := New(&buf, FormatTable)
 
-	item := testItem{Name: "a", Count: 1}
-	err := w.WriteValue(item, func(out io.Writer) error {
-		_, err := fmt.Fprintf(out, "Name:\t%s\nCount:\t%d\n", item.Name, item.Count)
-		return err
-	})
-	if err != nil {
+	if err := w.WriteMessage(testItem{Name: "a", Count: 1}, "Authenticated as acme"); err != nil {
 		t.Fatal(err)
 	}
 
-	out := buf.String()
-	if !strings.Contains(out, "Name:") || !strings.Contains(out, "a") {
-		t.Errorf("table output = %q", out)
+	if out := buf.String(); out != "Authenticated as acme\n" {
+		t.Errorf("table output = %q, want %q", out, "Authenticated as acme\n")
 	}
 }
 
-func TestWriteValue_UnsupportedFormat(t *testing.T) {
+func TestWriteMessage_TableEmptyLine(t *testing.T) {
+	var buf bytes.Buffer
+	w := New(&buf, FormatTable)
+
+	if err := w.WriteMessage(testItem{Name: "a", Count: 1}, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	if out := buf.String(); out != "" {
+		t.Errorf("table output = %q, want empty", out)
+	}
+}
+
+func TestWriteMessage_UnsupportedFormat(t *testing.T) {
 	var buf bytes.Buffer
 	w := New(&buf, "xml")
 
-	err := w.WriteValue(testItem{}, nil)
+	err := w.WriteMessage(testItem{}, "msg")
 	if err == nil || !strings.Contains(err.Error(), "unsupported format") {
 		t.Errorf("err = %v, want unsupported format", err)
 	}


### PR DESCRIPTION
Collapse the caller-supplied table-building closure into a declarative
WriteMessage(data, line) for the 'JSON object, or one human-readable line'
shape. An empty line writes nothing in table mode, preserving mcp call's
behavior. Re-point auth login and the internal WriteDeleted at it.