### PR TITLE
refactor(auth): seal management key encoding in config

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -132,11 +132,6 @@ func runAuthLogin(ctx context.Context, opts *options.RootOptions, keyType, keyID
 		return err
 	}
 
-	value := keySecret
-	if kt == config.KeyManagement {
-		value = keyID + ":" + keySecret
-	}
-
 	result := loginResult{
 		Type: keyType,
 	}
@@ -145,6 +140,11 @@ func runAuthLogin(ctx context.Context, opts *options.RootOptions, keyType, keyID
 		client, err := api.NewClientWithResponses(opts.ResolveAPIUrl())
 		if err != nil {
 			return fmt.Errorf("creating API client: %w", err)
+		}
+
+		value := keySecret
+		if kt == config.KeyManagement {
+			value = config.ManagementKey(keyID, keySecret)
 		}
 
 		ks, err := verifyKey(ctx, client, kt, value)
@@ -166,7 +166,12 @@ func runAuthLogin(ctx context.Context, opts *options.RootOptions, keyType, keyID
 	}
 
 	profile := opts.ActiveProfile()
-	if err := config.SetKey(profile, kt, value); err != nil {
+	if kt == config.KeyManagement {
+		err = config.SetManagementKey(profile, keyID, keySecret)
+	} else {
+		err = config.SetKey(profile, kt, keySecret)
+	}
+	if err != nil {
 		return fmt.Errorf("storing key: %w", err)
 	}
 

--- a/cmd/auth/logout.go
+++ b/cmd/auth/logout.go
@@ -42,7 +42,7 @@ func runAuthLogout(opts *options.RootOptions, keyType string) error {
 		}
 		targets = []config.KeyType{kt}
 	} else {
-		targets = keyTypes
+		targets = config.KeyTypes()
 	}
 
 	var deleted []logoutResult

--- a/cmd/auth/profile.go
+++ b/cmd/auth/profile.go
@@ -66,7 +66,7 @@ func runProfileList(opts *options.RootOptions) error {
 			Active: name == active,
 		}
 
-		for _, kt := range keyTypes {
+		for _, kt := range config.KeyTypes() {
 			_, err := config.GetKey(name, kt)
 			if errors.Is(err, keyring.ErrNotFound) {
 				continue

--- a/cmd/auth/status.go
+++ b/cmd/auth/status.go
@@ -50,8 +50,6 @@ func NewStatusCmd(opts *options.RootOptions) *cobra.Command {
 	return cmd
 }
 
-var keyTypes = []config.KeyType{config.KeyConfig, config.KeyIngest, config.KeyManagement}
-
 func runAuthStatus(ctx context.Context, opts *options.RootOptions, offline bool) error {
 	profile := opts.ActiveProfile()
 
@@ -61,7 +59,7 @@ func runAuthStatus(ctx context.Context, opts *options.RootOptions, offline bool)
 	}
 
 	var keys []storedKey
-	for _, kt := range keyTypes {
+	for _, kt := range config.KeyTypes() {
 		val, err := config.GetKey(profile, kt)
 		if errors.Is(err, keyring.ErrNotFound) {
 			continue

--- a/internal/config/keyring.go
+++ b/internal/config/keyring.go
@@ -21,6 +21,13 @@ const (
 	KeyManagement KeyType = "management"
 )
 
+// KeyTypes returns every key type, in storage order. Callers that act on all
+// key types (logout, status, profile listing) range over this rather than
+// hand-listing the constants, so adding a key type updates them all.
+func KeyTypes() []KeyType {
+	return []KeyType{KeyConfig, KeyIngest, KeyManagement}
+}
+
 func ParseKeyType(s string) (KeyType, error) {
 	switch s {
 	case "config":
@@ -51,6 +58,19 @@ func SetKey(profile string, kt KeyType, value string) error {
 	return withTimeout(func() error {
 		return keyring.Set(keyringService, keyringKey(profile, kt), value)
 	})
+}
+
+// ManagementKey encodes a management key's ID and secret into the single
+// credential string the keyring stores and ApplyAuth sends as the bearer
+// token. The id:secret wire format lives only here.
+func ManagementKey(id, secret string) string {
+	return id + ":" + secret
+}
+
+// SetManagementKey stores a management key, encoding its ID and secret so
+// callers never assemble the id:secret wire format themselves.
+func SetManagementKey(profile, id, secret string) error {
+	return SetKey(profile, KeyManagement, ManagementKey(id, secret))
 }
 
 func GetKey(profile string, kt KeyType) (string, error) {

--- a/internal/config/keyring_test.go
+++ b/internal/config/keyring_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"net/http"
 	"testing"
+
+	"github.com/zalando/go-keyring"
 )
 
 func TestParseKeyType(t *testing.T) {
@@ -28,6 +30,42 @@ func TestParseKeyType(t *testing.T) {
 				t.Errorf("ParseKeyType(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestKeyTypes(t *testing.T) {
+	want := []KeyType{KeyConfig, KeyIngest, KeyManagement}
+	got := KeyTypes()
+	if len(got) != len(want) {
+		t.Fatalf("KeyTypes() len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("KeyTypes()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestManagementKey(t *testing.T) {
+	if got := ManagementKey("id-123", "secret-456"); got != "id-123:secret-456" {
+		t.Errorf("ManagementKey() = %q, want %q", got, "id-123:secret-456")
+	}
+}
+
+func TestSetManagementKey(t *testing.T) {
+	keyring.MockInit()
+
+	if err := SetManagementKey("test-profile", "id-123", "secret-456"); err != nil {
+		t.Fatalf("SetManagementKey() error = %v", err)
+	}
+	t.Cleanup(func() { _ = DeleteKey("test-profile", KeyManagement) })
+
+	got, err := GetKey("test-profile", KeyManagement)
+	if err != nil {
+		t.Fatalf("GetKey() error = %v", err)
+	}
+	if got != "id-123:secret-456" {
+		t.Errorf("stored value = %q, want %q", got, "id-123:secret-456")
 	}
 }
 


### PR DESCRIPTION
Move the id:secret management wire format behind config.ManagementKey /
SetManagementKey so auth login no longer assembles it inline, and add
config.KeyTypes() so logout, status, and profile listing stop hand-listing
the key type constants.