### PR TITLE
fix: use rune-based truncation in board list to avoid invalid UTF-8

### DIFF
--- a/cmd/board/list.go
+++ b/cmd/board/list.go
@@ -13,10 +13,11 @@ import (
 )
 
 func truncate(s string, max int) string {
-	if len(s) <= max {
+	r := []rune(s)
+	if len(r) <= max {
 		return s
 	}
-	return s[:max-1] + "…"
+	return string(r[:max-3]) + "..."
 }
 
 var boardListTable = output.TableDef{

--- a/cmd/board/truncate_test.go
+++ b/cmd/board/truncate_test.go
@@ -1,0 +1,29 @@
+package board
+
+import "testing"
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		max   int
+		want  string
+	}{
+		{"short ASCII", "hello", 10, "hello"},
+		{"exact max", "hello", 5, "hello"},
+		{"truncated ASCII", "hello world", 8, "hello..."},
+		{"multibyte within limit", "αβγδ", 10, "αβγδ"},
+		{"multibyte truncated", "αβγδεζηθ", 5, "αβ..."},
+		{"emoji truncated", "🎉🎊🎈🎁🎀", 4, "🎉..."},
+		{"mixed ASCII and multibyte", "hello αβγ world", 10, "hello α..."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncate(tt.input, tt.max)
+			if got != tt.want {
+				t.Errorf("truncate(%q, %d) = %q, want %q", tt.input, tt.max, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The `truncate` function in `cmd/board/list.go` uses byte-based slicing (`len(s)` and `s[:max-1]`), which breaks multibyte UTF-8 characters (Greek, emoji, accented Latin) by cutting mid-rune and producing invalid byte sequences on stdout.

Fixes #186

## Root Cause

```go
// Before (byte-based — breaks multibyte UTF-8)
func truncate(s string, max int) string {
    if len(s) <= max {
        return s
    }
    return s[:max-1] + "…"
}
```

When a description contains multibyte UTF-8 (e.g., Greek α = 2 bytes), the byte-based cut at `max-1` can land mid-rune, producing a dangling byte followed by the ellipsis.

## Fix

Convert to rune-based slicing, matching the existing pattern in `cmd/slo/format.go`:

```go
// After (rune-based — safe for all Unicode)
func truncate(s string, max int) string {
    r := []rune(s)
    if len(r) <= max {
        return s
    }
    return string(r[:max-3]) + "..."
}
```

## Testing

Added table-driven tests covering:
- Short ASCII (no truncation)
- Exact max length (no truncation)
- ASCII truncation
- Multibyte within limit (Greek)
- Multibyte truncated (Greek)
- Emoji truncated
- Mixed ASCII and multibyte

All existing tests continue to pass (`go test ./...`).