### PR TITLE
fix(output): render closing bottom border on detail tables

### DIFF
--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -135,10 +135,12 @@ func (w *Writer) writeTable(data any, td TableDef) error {
 }
 
 func (w *Writer) writeFieldsTable(fields []Field) error {
+	// This table sets no Headers, so the default BorderHeader has no separator
+	// to draw. Leaving it enabled is also what makes lipgloss render the closing
+	// bottom rule; BorderHeader(false) suppresses the bottom border entirely.
 	t := table.New().
 		Border(lipgloss.RoundedBorder()).
-		StyleFunc(fieldsStyleFunc).
-		BorderHeader(false)
+		StyleFunc(fieldsStyleFunc)
 
 	for _, f := range fields {
 		t.Row(f.Label, f.Value)

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -204,6 +204,42 @@ func TestWriteFields_Table(t *testing.T) {
 	}
 }
 
+func TestWriteFields_TableClosingBorder(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		fields []Field
+	}{
+		{
+			name:   "single row",
+			fields: []Field{{"Name", "a"}},
+		},
+		{
+			name:   "multiple rows",
+			fields: []Field{{"Name", "a"}, {"Count", "1"}},
+		},
+		{
+			name:   "multi line value",
+			fields: []Field{{"Name", "a"}, {"Body", "line one\nline two"}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := New(&buf, FormatTable)
+			if err := w.WriteFields(testItem{}, tc.fields); err != nil {
+				t.Fatal(err)
+			}
+
+			out := strings.TrimRight(buf.String(), "\n")
+			if !strings.HasPrefix(out, "╭") {
+				t.Errorf("expected top border, got:\n%s", out)
+			}
+			if !strings.HasSuffix(out, "╯") {
+				t.Errorf("expected closing bottom border, got:\n%s", out)
+			}
+		})
+	}
+}
+
 func TestWriteFields_UnsupportedFormat(t *testing.T) {
 	var buf bytes.Buffer
 	w := New(&buf, "xml")


### PR DESCRIPTION
Fixes detail tables (`honeycomb <resource> get`) rendering without a closing bottom border across every resource.

## Issue

`writeFieldsTable` set `BorderHeader(false)`. With no `Headers` configured on the lipgloss table, that flag suppresses the bottom border entirely, so detail output ended at the last row with no `╰───┴───╯` rule.

## Changes

Drops the `BorderHeader(false)` call. The detail table sets no `Headers`, so the default `BorderHeader` draws no separator row but does restore the closing bottom rule.

## Testing

Adds `TestWriteFields_TableClosingBorder` asserting the rendered output opens with `╭` and ends with `╯` across single-row, multi-row, and multi-line-cell cases.

Closes #169
