### PR TITLE
fix(cmd): validate --format at flag-parse time

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	"github.com/bendrucker/honeycomb-cli/internal/agent"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/iostreams"
+	"github.com/bendrucker/honeycomb-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -31,6 +32,10 @@ func NewRootCmd(ios *iostreams.IOStreams) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+			if err := output.ValidateFormat(opts.Format); err != nil {
+				return err
+			}
+
 			opts.ConfigPath = config.DefaultPath()
 			cfg, err := config.Load(opts.ConfigPath)
 			if err != nil {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -16,6 +16,21 @@ const (
 	FormatTable = "table"
 )
 
+// ValidFormats lists the output formats accepted by the --format flag.
+var ValidFormats = []string{FormatJSON, FormatTable}
+
+// ValidateFormat reports whether format is an accepted --format value. The
+// empty string is allowed: it represents the unset flag, which callers resolve
+// to a concrete format based on TTY detection and command type.
+func ValidateFormat(format string) error {
+	switch format {
+	case "", FormatJSON, FormatTable:
+		return nil
+	default:
+		return fmt.Errorf("invalid --format %q: must be one of %s", format, strings.Join(ValidFormats, ", "))
+	}
+}
+
 var cellStyle = lipgloss.NewStyle().Padding(0, 1)
 
 var styleFunc = func(row, col int) lipgloss.Style {

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -20,6 +20,30 @@ var testTable = TableDef{
 	},
 }
 
+func TestValidateFormat(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		format  string
+		wantErr bool
+	}{
+		{name: "json", format: "json", wantErr: false},
+		{name: "table", format: "table", wantErr: false},
+		{name: "empty is unset default", format: "", wantErr: false},
+		{name: "unknown", format: "xml", wantErr: true},
+		{name: "case sensitive", format: "JSON", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateFormat(tc.format)
+			if tc.wantErr && err == nil {
+				t.Errorf("ValidateFormat(%q) = nil, want error", tc.format)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("ValidateFormat(%q) = %v, want nil", tc.format, err)
+			}
+		})
+	}
+}
+
 func TestWrite_JSON(t *testing.T) {
 	var buf bytes.Buffer
 	w := New(&buf, FormatJSON)


### PR DESCRIPTION
Validates `--format` in the root command's `PersistentPreRunE`, so an unknown value (e.g. `--format xml`) fails immediately with the valid choices instead of authenticating, calling the API, and only then erroring in the output writer.

## Changes

- Adds `output.ValidateFormat` (and `output.ValidFormats`) as the shared source of truth for accepted formats. The empty string stays valid because `ResolveFormat`/`OutputWriterList` apply TTY and list defaulting.
- Calls `ValidateFormat` first in the root `PersistentPreRunE`, before config load or any request.

## Testing

- `TestValidateFormat` covers `json`, `table`, empty (unset default), an unknown value, and case sensitivity.
- Verified the built binary: `board list --format xml` exits 1 with `invalid --format "xml": must be one of json, table` before any API call; a valid `--format json` proceeds normally.

Closes #170

## References

Stacked on #200 (#169). Base branch is `fix/169-detail-table-border`; review after #200 merges.
