### PR TITLE
fix(trigger): drop inline query when query_id is set on update

### DIFF
--- a/cmd/trigger/update.go
+++ b/cmd/trigger/update.go
@@ -122,6 +122,13 @@ func runUpdate(ctx context.Context, opts *options.RootOptions, dataset, triggerI
 		}
 	}
 
+	// A GET returns both query_id and the resolved inline query, but the update
+	// endpoint rejects a body carrying both (HTTP 400). When query_id is set it
+	// is authoritative, so drop the redundant inline query before sending.
+	if body.QueryId != nil {
+		body.Query = nil
+	}
+
 	data, err := api.MarshalStrippingReadOnly(body, "TriggerResponse")
 	if err != nil {
 		return fmt.Errorf("encoding trigger: %w", err)

--- a/cmd/trigger/update_test.go
+++ b/cmd/trigger/update_test.go
@@ -178,6 +178,49 @@ func TestUpdate_EnabledFlag(t *testing.T) {
 	}
 }
 
+func TestUpdate_DropsInlineQueryWhenQueryIDPresent(t *testing.T) {
+	var sawQuery, sawQueryID bool
+	opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			// The API returns both query_id and the resolved inline query.
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "trigger-1",
+				"name":     "Old Name",
+				"disabled": false,
+				"query_id": "abc123",
+				"query":    map[string]any{"calculations": []any{map[string]any{"op": "COUNT"}}},
+			})
+		case http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			var parsed map[string]any
+			_ = json.Unmarshal(body, &parsed)
+			_, sawQuery = parsed["query"]
+			_, sawQueryID = parsed["query_id"]
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "trigger-1",
+				"name":     "New Name",
+				"disabled": false,
+				"query_id": "abc123",
+			})
+		}
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"update", "--dataset", "test-dataset", "trigger-1", "--name", "New Name"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if sawQuery {
+		t.Error("PUT body included inline query alongside query_id (API rejects this with HTTP 400)")
+	}
+	if !sawQueryID {
+		t.Error("PUT body dropped query_id, which must be preserved")
+	}
+}
+
 func TestUpdate_NoFlags(t *testing.T) {
 	opts, _ := setupTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 


### PR DESCRIPTION
Fixes `trigger update` with flags (`--name`/`--description`/`--disabled`/`--enabled`) always failing with `HTTP 400`.

## Issue

The flag path fetches the trigger, applies the flag changes, and PUTs the result. A `GET` returns both `query_id` and the resolved inline `query`, but the update endpoint rejects a body carrying both. `MarshalStrippingReadOnly` does not remove either field, so every flag-based update sent both and got a 400 query conflict.

## Changes

Drops the redundant inline `query` before marshaling whenever `query_id` is set (it is authoritative when present). Placed before the marshal step so it also protects a file-based body that includes both.

## Testing

Adds `TestUpdate_DropsInlineQueryWhenQueryIDPresent`: the stub `GET` returns both `query` and `query_id`, and the test asserts the `PUT` body omits `query` while preserving `query_id`.

Closes #197
