### PR TITLE
fix(key): derive update key type from the API, not the ID prefix

### DIFF
--- a/cmd/key/key_test.go
+++ b/cmd/key/key_test.go
@@ -679,6 +679,15 @@ func TestUpdate_Flags(t *testing.T) {
 			wantName:     "New Name",
 			wantDisabled: true,
 		},
+		{
+			// Real key IDs do not carry the hcxik_/hcxlk_ prefixes the old code
+			// keyed on; the key type must come from the GET response instead.
+			name:         "rename key with no recognizable prefix",
+			id:           "01J8XYZABCDEF",
+			args:         []string{"--name", "Renamed Realistic Key"},
+			wantName:     "Renamed Realistic Key",
+			wantDisabled: false,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			keyType := "ingest"
@@ -784,20 +793,20 @@ func TestUpdate_MutuallyExclusive(t *testing.T) {
 	}
 }
 
-func TestUpdate_UnrecognizedKeyPrefix(t *testing.T) {
+func TestUpdate_UnrecognizedKeyType(t *testing.T) {
 	opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/vnd.api+json")
-		_, _ = fmt.Fprintf(w, `{"data":{"id":"unknown_01abc","type":"api-keys","attributes":{"name":"Test","key_type":"ingest","disabled":false}}}`)
+		_, _ = fmt.Fprintf(w, `{"data":{"id":"hcaik_01abc","type":"api-keys","attributes":{"name":"Test","key_type":"mystery","disabled":false}}}`)
 	}))
 
 	cmd := NewCmd(opts)
-	cmd.SetArgs([]string{"--team", "my-team", "update", "unknown_01abc", "--name", "New Name"})
+	cmd.SetArgs([]string{"--team", "my-team", "update", "hcaik_01abc", "--name", "New Name"})
 	err := cmd.Execute()
 	if err == nil {
-		t.Fatal("expected error for unrecognized key prefix")
+		t.Fatal("expected error for unrecognized key type")
 	}
-	if !strings.Contains(err.Error(), "unrecognized key ID prefix") {
-		t.Errorf("error = %q, want unrecognized prefix message", err.Error())
+	if !strings.Contains(err.Error(), "unrecognized key type") {
+		t.Errorf("error = %q, want unrecognized key type message", err.Error())
 	}
 }
 

--- a/cmd/key/update.go
+++ b/cmd/key/update.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
@@ -106,7 +105,7 @@ func runKeyUpdateFromFlags(cmd *cobra.Command, opts *options.RootOptions, team, 
 		current.Disabled = false
 	}
 
-	body, err := buildKeyUpdateRequest(id, current.Name, current.Disabled)
+	body, err := buildKeyUpdateRequest(id, current.KeyType, current.Name, current.Disabled)
 	if err != nil {
 		return err
 	}
@@ -124,10 +123,11 @@ func runKeyUpdateFromFlags(cmd *cobra.Command, opts *options.RootOptions, team, 
 	return writeKeyDetail(opts, objectToDetail(updated.Data))
 }
 
-func buildKeyUpdateRequest(id, name string, disabled bool) (api.ApiKeyUpdateRequest, error) {
+func buildKeyUpdateRequest(id, keyType, name string, disabled bool) (api.ApiKeyUpdateRequest, error) {
 	var body api.ApiKeyUpdateRequest
 
-	if strings.HasPrefix(id, "hcxik_") {
+	switch keyType {
+	case string(api.IngestKeyAttributesKeyTypeIngest):
 		req := api.IngestKeyRequest{
 			Id:   id,
 			Type: api.IngestKeyRequestTypeApiKeys,
@@ -137,7 +137,7 @@ func buildKeyUpdateRequest(id, name string, disabled bool) (api.ApiKeyUpdateRequ
 		if err := body.Data.FromIngestKeyRequest(req); err != nil {
 			return body, fmt.Errorf("building request: %w", err)
 		}
-	} else if strings.HasPrefix(id, "hcxlk_") {
+	case string(api.ConfigurationKeyAttributesKeyTypeConfiguration):
 		req := api.ConfigurationKeyRequest{
 			Id:   id,
 			Type: api.ConfigurationKeyRequestTypeApiKeys,
@@ -147,8 +147,8 @@ func buildKeyUpdateRequest(id, name string, disabled bool) (api.ApiKeyUpdateRequ
 		if err := body.Data.FromConfigurationKeyRequest(req); err != nil {
 			return body, fmt.Errorf("building request: %w", err)
 		}
-	} else {
-		return body, fmt.Errorf("unrecognized key ID prefix: %s (expected hcxik_ or hcxlk_)", id)
+	default:
+		return body, fmt.Errorf("unrecognized key type: %q", keyType)
 	}
 
 	return body, nil


### PR DESCRIPTION
Fixes `key update` with flags rejecting every real key ID.

## Issue

`buildKeyUpdateRequest` chose the request shape by matching the ID against `hcxik_`/`hcxlk_` prefixes. Real key IDs do not carry those prefixes, so the function always fell through to `unrecognized key ID prefix` and no flag-based update could succeed.

## Changes

Passes the `key_type` already returned by the `GET` (`ingest`/`configuration`) into `buildKeyUpdateRequest` and switches on it, using the generated `api.IngestKeyAttributesKeyTypeIngest` / `api.ConfigurationKeyAttributesKeyTypeConfiguration` constants. The error branch now reports an unrecognized key *type* rather than prefix. Drops the now-unused `strings` import.

## Testing

- Adds a `TestUpdate_Flags` case with a realistic, non-prefixed ID to prove updates now work.
- Rewrites the former prefix test as `TestUpdate_UnrecognizedKeyType`, returning an unknown `key_type` to exercise the error branch.

Closes #191
