### PR TITLE
fix(board): drop write-only layout_generation from read output

### DIFF
--- a/cmd/board/board.go
+++ b/cmd/board/board.go
@@ -28,11 +28,10 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 type boardListItem struct {
-	ID           string `json:"id"`
-	Name         string `json:"name"`
-	Description  string `json:"description,omitempty"`
-	ColumnLayout string `json:"column_layout,omitempty"`
-	URL          string `json:"url,omitempty"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	URL         string `json:"url,omitempty"`
 }
 
 type boardDetail struct {
@@ -40,7 +39,6 @@ type boardDetail struct {
 	Name          string          `json:"name" detail:"Name"`
 	Description   string          `json:"description,omitempty" detail:"Description"`
 	Type          string          `json:"type" detail:"Type"`
-	ColumnLayout  string          `json:"column_layout,omitempty" detail:"Column Layout"`
 	URL           string          `json:"url,omitempty" detail:"URL"`
 	PresetFilters json.RawMessage `json:"preset_filters,omitempty"`
 	Panels        json.RawMessage `json:"panels,omitempty"`
@@ -54,11 +52,10 @@ func writeBoardDetail(opts *options.RootOptions, detail boardDetail) error {
 
 func boardToDetail(b api.Board) boardDetail {
 	d := boardDetail{
-		ID:           deref.String(b.Id),
-		Name:         b.Name,
-		Type:         string(b.Type),
-		Description:  deref.String(b.Description),
-		ColumnLayout: deref.Enum(b.LayoutGeneration),
+		ID:          deref.String(b.Id),
+		Name:        b.Name,
+		Type:        string(b.Type),
+		Description: deref.String(b.Description),
 	}
 	if b.Links != nil {
 		d.URL = deref.String(b.Links.BoardUrl)

--- a/cmd/board/list.go
+++ b/cmd/board/list.go
@@ -24,7 +24,6 @@ var boardListTable = output.TableDef{
 		{Header: "ID", Value: func(v any) string { return v.(boardListItem).ID }},
 		{Header: "Name", Value: func(v any) string { return v.(boardListItem).Name }},
 		{Header: "Description", Value: func(v any) string { return truncate(v.(boardListItem).Description, 40) }},
-		{Header: "Column Layout", Value: func(v any) string { return v.(boardListItem).ColumnLayout }},
 		{Header: "URL", Value: func(v any) string { return v.(boardListItem).URL }},
 	},
 }
@@ -58,10 +57,9 @@ func runBoardList(ctx context.Context, opts *options.RootOptions) error {
 	items := make([]boardListItem, len(*boards))
 	for i, b := range *boards {
 		item := boardListItem{
-			ID:           deref.String(b.Id),
-			Name:         b.Name,
-			Description:  deref.String(b.Description),
-			ColumnLayout: deref.Enum(b.LayoutGeneration),
+			ID:          deref.String(b.Id),
+			Name:        b.Name,
+			Description: deref.String(b.Description),
 		}
 		if b.Links != nil {
 			item.URL = deref.String(b.Links.BoardUrl)

--- a/cmd/board/list_test.go
+++ b/cmd/board/list_test.go
@@ -88,6 +88,28 @@ func TestList(t *testing.T) {
 	}
 }
 
+func TestList_OmitsColumnLayoutColumn(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"id": "abc123", "name": "My Board", "type": "flexible"},
+		})
+	}))
+	opts.Format = "table"
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"list"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	// layout_generation is write-only, so reads never populate it; the column
+	// was always blank and mislabeled "Column Layout".
+	if out := ts.OutBuf.String(); strings.Contains(out, "LAYOUT") {
+		t.Errorf("table output still renders a layout column:\n%s", out)
+	}
+}
+
 func TestList_Empty(t *testing.T) {
 	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
Removes the always-empty, mislabeled `Column Layout` column/field from board read output.

## Issue

`layout_generation` is `writeOnly` in the Board schema, so a read never returns it. The board `list` column and board `get` detail field built from it (`deref.Enum(b.LayoutGeneration)`) were always blank, and "Column Layout" did not match the underlying `layout_generation` field name either.

## Changes

Drops `ColumnLayout` from `boardListItem`, `boardDetail`, and `boardListTable`. The create/update path in `update.go` still sets `LayoutGeneration` on the request, so writing layout mode is unaffected.

## Testing

Adds `TestList_OmitsColumnLayoutColumn` asserting the rendered table no longer contains a layout column. Existing board tests pass unchanged.

Closes #187
