### PR TITLE
refactor(output): add shared rune-safe Truncate helper

### DIFF
--- a/cmd/board/list.go
+++ b/cmd/board/list.go
@@ -12,18 +12,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func truncate(s string, max int) string {
-	if len(s) <= max {
-		return s
-	}
-	return s[:max-1] + "…"
-}
-
 var boardListTable = output.TableDef{
 	Columns: []output.Column{
 		{Header: "ID", Value: func(v any) string { return v.(boardListItem).ID }},
 		{Header: "Name", Value: func(v any) string { return v.(boardListItem).Name }},
-		{Header: "Description", Value: func(v any) string { return truncate(v.(boardListItem).Description, 40) }},
+		{Header: "Description", Value: func(v any) string { return output.Truncate(v.(boardListItem).Description, 40) }},
 		{Header: "URL", Value: func(v any) string { return v.(boardListItem).URL }},
 	},
 }

--- a/cmd/slo/format.go
+++ b/cmd/slo/format.go
@@ -19,14 +19,6 @@ func formatTimePeriod(days int) string {
 	return fmt.Sprintf("%dd", days)
 }
 
-func truncate(s string, max int) string {
-	r := []rune(s)
-	if len(r) <= max {
-		return s
-	}
-	return string(r[:max-3]) + "..."
-}
-
 type sloItem struct {
 	ID               string `json:"id"`
 	Name             string `json:"name"`

--- a/cmd/slo/list.go
+++ b/cmd/slo/list.go
@@ -19,7 +19,7 @@ var sloListTable = output.TableDef{
 		{Header: "Target", Value: func(v any) string { return formatTarget(v.(sloItem).TargetPerMillion) }},
 		{Header: "Time Period", Value: func(v any) string { return formatTimePeriod(v.(sloItem).TimePeriodDays) }},
 		{Header: "SLI Alias", Value: func(v any) string { return v.(sloItem).SLIAlias }},
-		{Header: "Description", Value: func(v any) string { return truncate(v.(sloItem).Description, 40) }},
+		{Header: "Description", Value: func(v any) string { return output.Truncate(v.(sloItem).Description, 40) }},
 	},
 }
 

--- a/internal/output/truncate.go
+++ b/internal/output/truncate.go
@@ -1,0 +1,17 @@
+package output
+
+// Truncate shortens s to at most max runes, appending "..." when it must cut.
+// It slices on rune boundaries, so the result is always valid UTF-8 even when s
+// contains multibyte characters.
+func Truncate(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	const ellipsis = "..."
+	keep := max - len(ellipsis)
+	if keep < 0 {
+		keep = 0
+	}
+	return string(r[:keep]) + ellipsis
+}

--- a/internal/output/truncate_test.go
+++ b/internal/output/truncate_test.go
@@ -1,0 +1,94 @@
+package output
+
+import (
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTruncate(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		input     string
+		max       int
+		expected  string
+		truncated bool
+	}{
+		{
+			name:     "short ascii",
+			input:    "hello",
+			max:      10,
+			expected: "hello",
+		},
+		{
+			name:     "exact max",
+			input:    "hello",
+			max:      5,
+			expected: "hello",
+		},
+		{
+			name:      "truncated ascii",
+			input:     "hello world",
+			max:       8,
+			expected:  "hello...",
+			truncated: true,
+		},
+		{
+			name:     "multibyte within limit",
+			input:    "αβγδ",
+			max:      10,
+			expected: "αβγδ",
+		},
+		{
+			name:      "multibyte truncated",
+			input:     "αβγδεζηθ",
+			max:       5,
+			expected:  "αβ...",
+			truncated: true,
+		},
+		{
+			name:      "emoji truncated",
+			input:     "🎉🎊🎈🎁🎀",
+			max:       4,
+			expected:  "🎉...",
+			truncated: true,
+		},
+		{
+			name:      "mixed truncated",
+			input:     "hello αβγ world",
+			max:       10,
+			expected:  "hello α...",
+			truncated: true,
+		},
+		{
+			name:      "max zero",
+			input:     "hello world",
+			max:       0,
+			expected:  "...",
+			truncated: true,
+		},
+		{
+			name:      "max one",
+			input:     "hello world",
+			max:       1,
+			expected:  "...",
+			truncated: true,
+		},
+		{
+			name:      "max three",
+			input:     "hello world",
+			max:       3,
+			expected:  "...",
+			truncated: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := Truncate(tc.input, tc.max)
+			if result != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, result)
+			}
+			if tc.truncated && !utf8.ValidString(result) {
+				t.Errorf("result %q is not valid UTF-8", result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a shared `output.Truncate` helper and routes the `board` and `slo` list Description columns through it.

## Issue

`board`'s `truncate` cut strings with byte slicing (`s[:max-1]`). When a description contained a multibyte character at the boundary, that split a rune and produced invalid UTF-8.

## Changes

- Added `output.Truncate`: rune-based, appends a `"..."` ellipsis, and guards the keep length so a small `max` cannot panic.
- Removed the duplicate `truncate` from `cmd/board/list.go` and `cmd/slo/format.go`.
- Both Description columns now call `output.Truncate`.

## Testing

`TestTruncate` covers:

- Short ASCII and exact-`max` input (no cut).
- Truncated ASCII (`"hello world"`, 8 → `"hello..."`).
- Multibyte within the limit (`"αβγδ"`, 10 → unchanged).
- Multibyte truncated (`"αβγδεζηθ"`, 5 → `"αβ..."`).
- Single-rune emoji truncated (`"🎉🎊🎈🎁🎀"`, 4 → `"🎉..."`).
- Mixed ASCII and multibyte (`"hello αβγ world"`, 10 → `"hello α..."`).
- Boundary widths `max` 0, 1, and 3 on a long string to prove no panic.
- `utf8.ValidString` on every truncated result.

Closes #186

## References

Closes #199 by @toller892, which fixed `board`'s copy directly. I took the shared-helper route so the fix also covers `slo` and removes a latent panic. Thanks @toller892 for the report/approach.
