### PR TITLE
fix(auth): validate login --key-secret and --verify flags

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -40,7 +40,8 @@ func NewLoginCmd(opts *options.RootOptions) *cobra.Command {
 			if cmd.Flags().Changed("no-verify") {
 				verify = false
 			}
-			return runAuthLogin(cmd.Context(), opts, keyType, keyID, keySecret, team, verify)
+			keySecretSet := cmd.Flags().Changed("key-secret")
+			return runAuthLogin(cmd.Context(), opts, keyType, keyID, keySecret, keySecretSet, team, verify)
 		},
 	}
 
@@ -51,11 +52,12 @@ func NewLoginCmd(opts *options.RootOptions) *cobra.Command {
 	cmd.Flags().BoolVar(&verify, "verify", true, "Verify key against the API before storing")
 	cmd.Flags().BoolVar(&noVerify, "no-verify", false, "Skip API verification")
 	cmd.Flags().Lookup("no-verify").Hidden = true
+	cmd.MarkFlagsMutuallyExclusive("verify", "no-verify")
 
 	return cmd
 }
 
-func runAuthLogin(ctx context.Context, opts *options.RootOptions, keyType, keyID, keySecret, team string, verify bool) error {
+func runAuthLogin(ctx context.Context, opts *options.RootOptions, keyType, keyID, keySecret string, keySecretSet bool, team string, verify bool) error {
 	ios := opts.IOStreams
 
 	if ios.CanPrompt() {
@@ -117,7 +119,10 @@ func runAuthLogin(ctx context.Context, opts *options.RootOptions, keyType, keyID
 		if keyType == "management" && keyID == "" {
 			return fmt.Errorf("--key-id is required for management keys")
 		}
-		if keySecret == "" {
+		if keySecretSet && keySecret == "" {
+			return fmt.Errorf("key secret cannot be empty")
+		}
+		if !keySecretSet {
 			line, err := prompt.ReadLine(ios.In)
 			if err != nil {
 				return fmt.Errorf("reading key secret from stdin: %w", err)

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -140,7 +140,7 @@ func TestAuthLogin_Success(t *testing.T) {
 			kt := config.KeyType(tt.keyType)
 			t.Cleanup(func() { _ = config.DeleteKey("default", kt) })
 
-			err := runAuthLogin(t.Context(), opts, tt.keyType, tt.keyID, tt.keySecret, tt.team, tt.verify)
+			err := runAuthLogin(t.Context(), opts, tt.keyType, tt.keyID, tt.keySecret, true, tt.team, tt.verify)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -195,7 +195,7 @@ func TestAuthLogin_InvalidKey(t *testing.T) {
 		Format:    output.FormatJSON,
 	}
 
-	err := runAuthLogin(t.Context(), opts, "config", "", "badsecret", "", true)
+	err := runAuthLogin(t.Context(), opts, "config", "", "badsecret", true, "", true)
 	if err == nil {
 		t.Fatal("expected error for invalid key")
 	}
@@ -218,7 +218,7 @@ func TestAuthLogin_MissingKeyType(t *testing.T) {
 		Format:    output.FormatJSON,
 	}
 
-	err := runAuthLogin(t.Context(), opts, "", "", "mysecret", "", false)
+	err := runAuthLogin(t.Context(), opts, "", "", "mysecret", true, "", false)
 	if err == nil {
 		t.Fatal("expected error for missing key type")
 	}
@@ -236,7 +236,7 @@ func TestAuthLogin_MissingKeyID(t *testing.T) {
 		Format:    output.FormatJSON,
 	}
 
-	err := runAuthLogin(t.Context(), opts, "management", "", "mysecret", "", false)
+	err := runAuthLogin(t.Context(), opts, "management", "", "mysecret", true, "", false)
 	if err == nil {
 		t.Fatal("expected error for missing key ID")
 	}
@@ -259,7 +259,7 @@ func TestAuthLogin_OverwriteSilentNonInteractive(t *testing.T) {
 		Format:    output.FormatJSON,
 	}
 
-	err := runAuthLogin(t.Context(), opts, "config", "", "new-secret", "", false)
+	err := runAuthLogin(t.Context(), opts, "config", "", "new-secret", true, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -270,6 +270,47 @@ func TestAuthLogin_OverwriteSilentNonInteractive(t *testing.T) {
 	}
 	if stored != "new-secret" {
 		t.Errorf("stored key = %q, want %q", stored, "new-secret")
+	}
+}
+
+func TestAuthLogin_EmptyKeySecret(t *testing.T) {
+	ts := iostreams.Test(t)
+	opts := &options.RootOptions{
+		IOStreams: ts.IOStreams,
+		Config:    &config.Config{},
+		Format:    output.FormatJSON,
+	}
+
+	err := runAuthLogin(t.Context(), opts, "config", "", "", true, "", false)
+	if err == nil {
+		t.Fatal("expected error for explicitly empty key secret")
+	}
+	want := "key secret cannot be empty"
+	if err.Error() != want {
+		t.Errorf("got error %q, want %q", err.Error(), want)
+	}
+}
+
+func TestAuthLogin_VerifyMutuallyExclusive(t *testing.T) {
+	ts := iostreams.Test(t)
+	opts := &options.RootOptions{
+		IOStreams: ts.IOStreams,
+		Config:    &config.Config{},
+		Format:    output.FormatJSON,
+	}
+
+	cmd := NewLoginCmd(opts)
+	cmd.SetArgs([]string{"--verify", "--no-verify"})
+	cmd.SetOut(ts.OutBuf)
+	cmd.SetErr(ts.ErrBuf)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when both --verify and --no-verify are set")
+	}
+	want := "if any flags in the group [verify no-verify] are set none of the others can be; [no-verify verify] were all set"
+	if err.Error() != want {
+		t.Errorf("got error %q, want %q", err.Error(), want)
 	}
 }
 
@@ -285,7 +326,7 @@ func TestAuthLogin_StdinSecret(t *testing.T) {
 
 	t.Cleanup(func() { _ = config.DeleteKey("default", config.KeyConfig) })
 
-	err := runAuthLogin(t.Context(), opts, "config", "", "", "", false)
+	err := runAuthLogin(t.Context(), opts, "config", "", "", false, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Closes #181.

Two flag-validation gaps in `auth login` produced confusing or unsafe behavior:

- `--key-secret ""` (explicitly empty) was indistinguishable from an unset flag, so the command fell through to reading stdin and failed with an opaque EOF error. The non-interactive path now checks `cmd.Flags().Changed("key-secret")`: an explicitly empty value returns `key secret cannot be empty`, and stdin is only read when the flag is absent.
- Passing both `--verify` and `--no-verify` was silently accepted, with `--no-verify` winning and storing the key unverified. `MarkFlagsMutuallyExclusive("verify", "no-verify")` now rejects the contradiction at parse time.

Adds table-driven tests for the empty-secret error and the mutual-exclusion error, and confirms an unset `--key-secret` still reads from stdin.
