### PR TITLE
fix(board): clarify view create --filter help and validate ops

### DIFF
--- a/cmd/board/view_create.go
+++ b/cmd/board/view_create.go
@@ -24,6 +24,10 @@ func NewViewCreateCmd(opts *options.RootOptions, board *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a board view",
+		Long: "Create a board view.\n\n" +
+			"Each --filter is column:operation:value. The value is omitted for " +
+			"operations that take no operand (e.g. exists). Valid operations:\n\n  " +
+			strings.Join(validFilterOperationStrings(), ", "),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runViewCreate(cmd, opts, *board, file, name, filterArgs)
 		},
@@ -31,7 +35,7 @@ func NewViewCreateCmd(opts *options.RootOptions, board *string) *cobra.Command {
 
 	cmd.Flags().StringVarP(&file, "file", "f", "", "Path to JSON file (- for stdin)")
 	cmd.Flags().StringVar(&name, "name", "", "View name")
-	cmd.Flags().StringArrayVar(&filterArgs, "filter", nil, "Filter: column:operation:value (repeatable, required)")
+	cmd.Flags().StringArrayVar(&filterArgs, "filter", nil, "Filter: column:operation:value (repeatable; required unless --file)")
 
 	cmd.MarkFlagsMutuallyExclusive("file", "name")
 	cmd.MarkFlagsMutuallyExclusive("file", "filter")
@@ -91,6 +95,45 @@ func runViewCreate(cmd *cobra.Command, opts *options.RootOptions, boardID, file,
 	return writeViewDetail(opts, viewResponseToDetail(*created))
 }
 
+// validFilterOperations lists every board view filter operation the API
+// accepts. It is the single source of truth for both validation in
+// parseViewFilters and the operations enumerated in the command's help.
+var validFilterOperations = []api.BoardViewFilterOperation{
+	api.BoardViewFilterOperationContains,
+	api.BoardViewFilterOperationDoesNotContain,
+	api.BoardViewFilterOperationDoesNotEndWith,
+	api.BoardViewFilterOperationDoesNotExist,
+	api.BoardViewFilterOperationDoesNotStartWith,
+	api.BoardViewFilterOperationEmpty,
+	api.BoardViewFilterOperationEndsWith,
+	api.BoardViewFilterOperationEqual,
+	api.BoardViewFilterOperationExists,
+	api.BoardViewFilterOperationGreaterThan,
+	api.BoardViewFilterOperationGreaterThanEqual,
+	api.BoardViewFilterOperationIn,
+	api.BoardViewFilterOperationLessThan,
+	api.BoardViewFilterOperationLessThanEqual,
+	api.BoardViewFilterOperationNotIn,
+	api.BoardViewFilterOperationStartsWith,
+}
+
+func validFilterOperationStrings() []string {
+	ops := make([]string, len(validFilterOperations))
+	for i, op := range validFilterOperations {
+		ops[i] = string(op)
+	}
+	return ops
+}
+
+func validFilterOperation(op api.BoardViewFilterOperation) bool {
+	for _, valid := range validFilterOperations {
+		if op == valid {
+			return true
+		}
+	}
+	return false
+}
+
 func parseViewFilters(args []string) ([]api.BoardViewFilter, error) {
 	filters := make([]api.BoardViewFilter, 0, len(args))
 	for _, arg := range args {
@@ -98,9 +141,13 @@ func parseViewFilters(args []string) ([]api.BoardViewFilter, error) {
 		if len(parts) < 2 {
 			return nil, fmt.Errorf("invalid filter %q: expected column:operation or column:operation:value", arg)
 		}
+		op := api.BoardViewFilterOperation(parts[1])
+		if !validFilterOperation(op) {
+			return nil, fmt.Errorf("invalid filter %q: unknown operation %q, valid operations: %s", arg, parts[1], strings.Join(validFilterOperationStrings(), ", "))
+		}
 		f := api.BoardViewFilter{
 			Column:    parts[0],
-			Operation: api.BoardViewFilterOperation(parts[1]),
+			Operation: op,
 		}
 		if len(parts) == 3 {
 			f.Value = parts[2]

--- a/cmd/board/view_create_test.go
+++ b/cmd/board/view_create_test.go
@@ -208,6 +208,11 @@ func TestParseViewFilters(t *testing.T) {
 			args:    []string{"nocolon"},
 			wantErr: "invalid filter",
 		},
+		{
+			name:    "unknown operation",
+			args:    []string{"status:equals:error"},
+			wantErr: "unknown operation",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			filters, err := parseViewFilters(tc.args)
@@ -227,5 +232,17 @@ func TestParseViewFilters(t *testing.T) {
 				t.Errorf("filter count = %d, want %d", len(filters), tc.wantCount)
 			}
 		})
+	}
+}
+
+func TestParseViewFilters_UnknownOperationListsAllValid(t *testing.T) {
+	_, err := parseViewFilters([]string{"status:equals:error"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	for _, op := range validFilterOperations {
+		if !strings.Contains(err.Error(), string(op)) {
+			t.Errorf("error %q missing valid operation %q", err.Error(), op)
+		}
 	}
 }


### PR DESCRIPTION
Closes #188.

`board view create` validates each `--filter` operation against the `api.BoardViewFilterOperation` constants and rejects unknown values with an error that lists every valid operation, so users no longer have to trigger a 422 to discover them. A shared `validFilterOperations` slice drives both the validation and the operations enumerated in the command's `Long` help, keeping them from drifting.

The `--filter` flag usage now reads `(repeatable; required unless --file)` to reflect that it is mutually exclusive with `--file`, rather than always required.
