### PR TITLE
fix(query): clarify annotation create input contract

### DIFF
--- a/cmd/query/annotation_create.go
+++ b/cmd/query/annotation_create.go
@@ -24,6 +24,21 @@ func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a query annotation",
+		Long: `Create a query annotation using one of two input modes:
+
+Flag mode: pass --name and --query-id together (--description is optional) to
+build the annotation from flags.
+
+File mode: pass --file with a path to a JSON definition (- for stdin). The file
+flag is mutually exclusive with the flag-mode inputs.`,
+		Example: `  # Flag mode
+  honeycomb query annotation create --dataset my-dataset \
+    --name "Latency Query" --query-id q-abc --description "p99 latency"
+
+  # File mode
+  honeycomb query annotation create --dataset my-dataset --file annotation.json
+  echo '{"name":"...","query_id":"..."}' | honeycomb query annotation create \
+    --dataset my-dataset --file -`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runAnnotationCreate(cmd, opts, *dataset, file, name, desc, queryID)
 		},
@@ -37,6 +52,7 @@ func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	cmd.MarkFlagsMutuallyExclusive("file", "name")
 	cmd.MarkFlagsMutuallyExclusive("file", "description")
 	cmd.MarkFlagsMutuallyExclusive("file", "query-id")
+	cmd.MarkFlagsRequiredTogether("name", "query-id")
 
 	return cmd
 }
@@ -55,7 +71,7 @@ func runAnnotationCreate(cmd *cobra.Command, opts *options.RootOptions, dataset,
 		if err != nil {
 			return err
 		}
-	} else if cmd.Flags().Changed("name") || cmd.Flags().Changed("query-id") {
+	} else if cmd.Flags().Changed("name") || cmd.Flags().Changed("query-id") || cmd.Flags().Changed("description") {
 		if name == "" {
 			return fmt.Errorf("--name is required")
 		}

--- a/cmd/query/annotation_create_test.go
+++ b/cmd/query/annotation_create_test.go
@@ -107,8 +107,8 @@ func TestCreate_Flags_MissingQueryID(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing --query-id")
 	}
-	if !strings.Contains(err.Error(), "--query-id is required") {
-		t.Errorf("error = %q, want --query-id required message", err.Error())
+	if !strings.Contains(err.Error(), "query-id") {
+		t.Errorf("error = %q, want missing query-id message", err.Error())
 	}
 }
 
@@ -121,8 +121,25 @@ func TestCreate_Flags_MissingName(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing --name")
 	}
+	if !strings.Contains(err.Error(), "name") {
+		t.Errorf("error = %q, want missing name message", err.Error())
+	}
+}
+
+func TestCreate_Flags_DescriptionOnly(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"annotation", "create", "--dataset", "test-dataset", "--description", "A description"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing --name")
+	}
 	if !strings.Contains(err.Error(), "--name is required") {
 		t.Errorf("error = %q, want --name required message", err.Error())
+	}
+	if strings.Contains(err.Error(), "--file is required") {
+		t.Errorf("error = %q, should not route to file branch", err.Error())
 	}
 }
 


### PR DESCRIPTION
Closes #183.

`query annotation create` had an undiscoverable input contract: a flag-based create needs both `--name` and `--query-id`, mutually exclusive with `--file`, but neither the help text nor the errors said so.

This routes `--description` into the flag-based branch (it was previously gated only on `--name`/`--query-id`, so passing `--description` alone fell through to the file branch and reported the misleading `--file is required in non-interactive mode`). It now reports the genuinely missing `--name`.

It also adds `MarkFlagsRequiredTogether("name", "query-id")` so cobra validates and surfaces the pairing, and documents the two input modes (flag mode vs file mode) via `Long` and `Example` text.

Added tests covering the corrected error routing for `--description` alone and the cobra-enforced `--name`/`--query-id` pairing.
