### PR TITLE
fix(environment): paginate list across all pages

### DIFF
--- a/cmd/environment/environment_test.go
+++ b/cmd/environment/environment_test.go
@@ -107,6 +107,58 @@ func TestList(t *testing.T) {
 	}
 }
 
+func TestList_Paginated(t *testing.T) {
+	var srvURL string
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		env := func(id, name string) map[string]any {
+			return map[string]any{
+				"id":   id,
+				"type": "environments",
+				"attributes": map[string]any{
+					"name":     name,
+					"slug":     name,
+					"settings": map[string]any{"delete_protected": false},
+				},
+			}
+		}
+
+		switch r.URL.Query().Get("page[after]") {
+		case "":
+			jsonapiEnvelope(t, w, http.StatusOK, map[string]any{
+				"data":  []map[string]any{env("env-1", "one"), env("env-2", "two")},
+				"links": map[string]any{"next": srvURL + "/2/teams/my-team/environments?page%5Bafter%5D=cursor-2"},
+			})
+		case "cursor-2":
+			jsonapiEnvelope(t, w, http.StatusOK, map[string]any{
+				"data":  []map[string]any{env("env-3", "three")},
+				"links": map[string]any{"next": nil},
+			})
+		default:
+			t.Errorf("unexpected page[after] = %q", r.URL.Query().Get("page[after]"))
+		}
+	}))
+	srvURL = opts.APIUrl
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"list", "--team", "my-team"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var items []environmentItem
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &items); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if len(items) != 3 {
+		t.Fatalf("got %d items, want 3", len(items))
+	}
+	for i, want := range []string{"env-1", "env-2", "env-3"} {
+		if items[i].ID != want {
+			t.Errorf("items[%d].ID = %q, want %q", i, items[i].ID, want)
+		}
+	}
+}
+
 func TestList_Empty(t *testing.T) {
 	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		jsonapiEnvelope(t, w, http.StatusOK, map[string]any{"data": []any{}})

--- a/cmd/environment/list.go
+++ b/cmd/environment/list.go
@@ -3,6 +3,7 @@ package environment
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
@@ -32,20 +33,55 @@ func runEnvironmentList(ctx context.Context, opts *options.RootOptions, team str
 		return err
 	}
 
-	resp, err := client.ListEnvironmentsWithResponse(ctx, team, nil)
-	if err != nil {
-		return fmt.Errorf("listing environments: %w", err)
-	}
+	var items []environmentItem
+	params := &api.ListEnvironmentsParams{}
+	for {
+		resp, err := client.ListEnvironmentsWithResponse(ctx, team, params)
+		if err != nil {
+			return fmt.Errorf("listing environments: %w", err)
+		}
 
-	list, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.ApplicationvndApiJSON200)
-	if err != nil {
-		return err
-	}
+		list, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.ApplicationvndApiJSON200)
+		if err != nil {
+			return err
+		}
 
-	items := make([]environmentItem, len(list.Data))
-	for i, e := range list.Data {
-		items[i] = envToItem(e)
+		for _, e := range list.Data {
+			items = append(items, envToItem(e))
+		}
+
+		cursor, err := nextPageCursor(list.Links)
+		if err != nil {
+			return err
+		}
+		if cursor == "" {
+			break
+		}
+		params.PageAfter = &cursor
 	}
 
 	return opts.OutputWriterList().Write(items, environmentListTable)
+}
+
+// nextPageCursor extracts the page[after] cursor from a links.next URL.
+// It returns an empty string when there is no further page.
+func nextPageCursor(links *api.PaginationLinks) (string, error) {
+	if links == nil || !links.Next.IsSpecified() || links.Next.IsNull() {
+		return "", nil
+	}
+
+	next, err := links.Next.Get()
+	if err != nil {
+		return "", fmt.Errorf("reading next page link: %w", err)
+	}
+	if next == "" {
+		return "", nil
+	}
+
+	parsed, err := url.Parse(next)
+	if err != nil {
+		return "", fmt.Errorf("parsing next page link: %w", err)
+	}
+
+	return parsed.Query().Get("page[after]"), nil
 }


### PR DESCRIPTION
Closes #193.

`environment list` now follows the cursor-paginated `ListEnvironments` endpoint to the end instead of returning only the first page. The run function loops `ListEnvironmentsWithResponse` with a `*ListEnvironmentsParams`, accumulating `list.Data` across pages. After each page it reads `list.Links.Next` (a nullable full URL), parses the `page[after]` query parameter with `net/url`, and sets `params.PageAfter` for the next request. When `Next` is null, empty, or unspecified, the loop stops.

Previously the command passed `nil` params and read a single page, silently truncating results for teams with more than one page of environments.

A new `TestList_Paginated` serves a two-page response from an `httptest` stub: page one returns a `links.next` cursor pointing back at the stub, page two returns a null `next`. The test asserts items from both pages accumulate in order.

No `--limit` flag was added. The fix is scoped to following the cursor, consistent with how `board list` handles its listing.
