### PR TITLE
feat(marker): add get subcommand

### DIFF
--- a/cmd/marker/get.go
+++ b/cmd/marker/get.go
@@ -1,0 +1,47 @@
+package marker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/internal/api"
+	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func NewGetCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <marker-id>",
+		Short: "Get a marker",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runMarkerGet(cmd.Context(), opts, *dataset, args[0])
+		},
+	}
+}
+
+func runMarkerGet(ctx context.Context, opts *options.RootOptions, dataset, markerID string) error {
+	client, err := opts.Client(config.KeyConfig)
+	if err != nil {
+		return err
+	}
+
+	// No individual GET: list and filter.
+	resp, err := client.GetMarkerWithResponse(ctx, dataset)
+	if err != nil {
+		return fmt.Errorf("listing markers: %w", err)
+	}
+
+	markers, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
+		return err
+	}
+
+	marker, err := findMarker(*markers, markerID)
+	if err != nil {
+		return err
+	}
+
+	return writeDetail(opts, markerToItem(marker))
+}

--- a/cmd/marker/get_test.go
+++ b/cmd/marker/get_test.go
@@ -1,0 +1,65 @@
+package marker
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestGet(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/1/markers/test-dataset" {
+			t.Errorf("path = %q, want /1/markers/test-dataset", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"id":      "abc123",
+				"type":    "deploy",
+				"message": "v1.0.0",
+			},
+			{
+				"id":      "def456",
+				"type":    "incident",
+				"message": "outage",
+			},
+		})
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"get", "--dataset", "test-dataset", "def456"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var item markerItem
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &item); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if item.ID != "def456" {
+		t.Errorf("id = %q, want %q", item.ID, "def456")
+	}
+	if item.Type != "incident" {
+		t.Errorf("type = %q, want %q", item.Type, "incident")
+	}
+}
+
+func TestGet_NotFound(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"id": "abc123", "type": "deploy"},
+		})
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"get", "--dataset", "test-dataset", "missing"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing marker")
+	}
+	if !strings.Contains(err.Error(), `marker "missing" not found`) {
+		t.Errorf("error = %q, want not found message", err.Error())
+	}
+}

--- a/cmd/marker/marker.go
+++ b/cmd/marker/marker.go
@@ -90,6 +90,7 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 	_ = cmd.MarkPersistentFlagRequired("dataset")
 
 	cmd.AddCommand(NewListCmd(opts, &dataset))
+	cmd.AddCommand(NewGetCmd(opts, &dataset))
 	cmd.AddCommand(NewCreateCmd(opts, &dataset))
 	cmd.AddCommand(NewUpdateCmd(opts, &dataset))
 	cmd.AddCommand(NewDeleteCmd(opts, &dataset))


### PR DESCRIPTION
Closes #192. Adds a `marker get <marker-id>` subcommand so a single marker can be fetched and rendered, matching `board get`, `column get`, and `dataset get`.

The markers API exposes only a list endpoint (`GET /1/markers/{dataset}`), so `get` lists and filters via `GetMarkerWithResponse` and the existing `findMarker` helper, the same approach `marker update` and `marker delete` already use. It reuses `markerToItem` and `writeDetail` for output and returns a clear not-found error when no marker matches the ID.

Added tests covering the found and not-found cases against an `httptest` stub of the list endpoint.
