### PR TITLE
fix(api): route errors to stderr, normalize output

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -54,7 +54,27 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 	cmd.Flags().StringVar(&o.input, "input", "", "Read body from file (- for stdin)")
 	cmd.Flags().BoolVar(&o.raw, "raw", false, "Output the full JSON:API envelope instead of flattened attributes")
 
+	hideFormatFlag(cmd)
+
 	return cmd
+}
+
+// hideFormatFlag hides the inherited persistent --format flag for the api
+// command, which streams responses verbatim and never applies output
+// formatting. The flag is registered on the root command, so it can only be
+// resolved from the inherited flag set, which cobra populates lazily. Hiding it
+// in the help function keeps it out of `api --help` without disabling the flag
+// for parsing.
+func hideFormatFlag(cmd *cobra.Command) {
+	help := cmd.HelpFunc()
+	cmd.SetHelpFunc(func(c *cobra.Command, args []string) {
+		if c == cmd {
+			if flag := c.InheritedFlags().Lookup("format"); flag != nil {
+				flag.Hidden = true
+			}
+		}
+		help(c, args)
+	})
 }
 
 func run(cmd *cobra.Command, o *apiOptions, path string) error {
@@ -122,6 +142,11 @@ func run(cmd *cobra.Command, o *apiOptions, path string) error {
 			return fmt.Errorf("reading response: %w", err)
 		}
 
+		if err := clientapi.CheckResponse(resp.StatusCode, respBody); err != nil {
+			writeBody(ios.Err, respBody)
+			return fmt.Errorf("%s %s: %w", method, path, err)
+		}
+
 		if !o.raw && isV2Path(path) {
 			respBody, err = unwrapJSONAPI(respBody)
 			if err != nil {
@@ -134,11 +159,7 @@ func run(cmd *cobra.Command, o *apiOptions, path string) error {
 				return err
 			}
 		} else {
-			_, _ = ios.Out.Write(respBody)
-		}
-
-		if err := clientapi.CheckResponse(resp.StatusCode, respBody); err != nil {
-			return fmt.Errorf("%s %s: %w", method, path, err)
+			writeBody(ios.Out, respBody)
 		}
 
 		if !o.paginate {
@@ -156,6 +177,17 @@ func run(cmd *cobra.Command, o *apiOptions, path string) error {
 	}
 
 	return nil
+}
+
+// writeBody writes the response body to w, appending a trailing newline when
+// the body lacks one. Re-marshaled JSON:API output has no newline, so this
+// keeps it from running into the next shell prompt; bodies that already end in
+// a newline (v1 responses, --raw passthrough) are written unchanged.
+func writeBody(w io.Writer, body []byte) {
+	_, _ = w.Write(body)
+	if len(body) > 0 && body[len(body)-1] != '\n' {
+		_, _ = w.Write([]byte{'\n'})
+	}
 }
 
 func resolveMethod(o *apiOptions, hasBody bool) string {

--- a/cmd/api/api_test.go
+++ b/cmd/api/api_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/iostreams"
+	"github.com/spf13/cobra"
 	"github.com/zalando/go-keyring"
 )
 
@@ -160,8 +161,11 @@ func TestRun_NonSuccess(t *testing.T) {
 	if !strings.Contains(err.Error(), "GET /1/boards/missing") {
 		t.Errorf("error = %q, want method and path", err.Error())
 	}
-	if !strings.Contains(ts.OutBuf.String(), "not found") {
-		t.Errorf("output = %q, want body written despite error", ts.OutBuf.String())
+	if ts.OutBuf.Len() != 0 {
+		t.Errorf("stdout = %q, want empty on error", ts.OutBuf.String())
+	}
+	if !strings.Contains(ts.ErrBuf.String(), "not found") {
+		t.Errorf("stderr = %q, want error body written", ts.ErrBuf.String())
 	}
 }
 
@@ -373,9 +377,11 @@ func TestRun_JQ_NonSuccess(t *testing.T) {
 		t.Errorf("error = %q, want HTTP 400", err.Error())
 	}
 
-	got := strings.TrimSpace(ts.OutBuf.String())
-	if got != "bad request" {
-		t.Errorf("jq output = %q, want %q", got, "bad request")
+	if ts.OutBuf.Len() != 0 {
+		t.Errorf("stdout = %q, want empty (jq skipped on error)", ts.OutBuf.String())
+	}
+	if !strings.Contains(ts.ErrBuf.String(), "missing field") {
+		t.Errorf("stderr = %q, want raw error body", ts.ErrBuf.String())
 	}
 }
 
@@ -613,9 +619,11 @@ func TestRun_V2_ErrorResponse(t *testing.T) {
 	if !strings.Contains(err.Error(), "HTTP 422") {
 		t.Errorf("error = %q, want HTTP 422", err.Error())
 	}
-	// Error body should be written to output even on failure
-	if !strings.Contains(ts.OutBuf.String(), "name is required") {
-		t.Errorf("output = %q, want error body written", ts.OutBuf.String())
+	if ts.OutBuf.Len() != 0 {
+		t.Errorf("stdout = %q, want empty on error", ts.OutBuf.String())
+	}
+	if !strings.Contains(ts.ErrBuf.String(), "name is required") {
+		t.Errorf("stderr = %q, want error body written", ts.ErrBuf.String())
 	}
 }
 
@@ -634,6 +642,67 @@ func TestRun_V2_JQ_Unwrap(t *testing.T) {
 	got := strings.TrimSpace(ts.OutBuf.String())
 	if got != "prod" {
 		t.Errorf("jq output = %q, want %q (should operate on unwrapped data)", got, "prod")
+	}
+}
+
+func TestRun_V2_TrailingNewline(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		_, _ = w.Write([]byte(`{"data":{"id":"abc","type":"environments","attributes":{"name":"prod"}}}`))
+	}), config.KeyManagement, "mgmt-key")
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"/2/teams/my-team/environments/abc"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	out := ts.OutBuf.String()
+	if !strings.HasSuffix(out, "\n") {
+		t.Errorf("output = %q, want trailing newline on re-marshaled body", out)
+	}
+	if strings.HasSuffix(out, "\n\n") {
+		t.Errorf("output = %q, want exactly one trailing newline", out)
+	}
+}
+
+func TestRun_V1_NewlinePreserved(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{\"status\":\"ok\"}\n"))
+	}), config.KeyConfig, "test-key")
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"/1/auth"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if out := ts.OutBuf.String(); out != "{\"status\":\"ok\"}\n" {
+		t.Errorf("output = %q, want server body unchanged with single newline", out)
+	}
+}
+
+func TestNewCmd_FormatFlagHidden(t *testing.T) {
+	opts := &options.RootOptions{
+		IOStreams: iostreams.Test(t).IOStreams,
+		Config:    &config.Config{},
+	}
+
+	root := &cobra.Command{Use: "honeycomb"}
+	root.PersistentFlags().String("format", "", "Output format: json, table")
+
+	apiCmd := NewCmd(opts)
+	root.AddCommand(apiCmd)
+
+	apiCmd.HelpFunc()(apiCmd, nil)
+
+	flag := apiCmd.InheritedFlags().Lookup("format")
+	if flag == nil {
+		t.Fatal("format flag not inherited")
+	}
+	if !flag.Hidden {
+		t.Error("format flag should be hidden for the api command")
 	}
 }
 


### PR DESCRIPTION
Closes #180.

The `api` command mishandled responses three ways. This reorders the write seam and adjusts flag wiring to fix all three.

## Route Errors to Stderr

`run` now calls `CheckResponse` before writing anything. On a non-2xx response it writes the raw body to `ios.Err` and returns the wrapped error, so a consumer piping stdout never receives the error envelope as a result. The previous order wrote the body (and ran `--jq` over it) to `ios.Out` first, leaking error payloads into the success channel and running `--jq` against data that was about to be reported as an error.

## Hide the Inherited `--format` Flag

The `api` command streams responses verbatim and never applies `--format`, but it advertised the inherited persistent flag and accepted bogus values with exit 0. `--format` is registered on the root command, so the `api` command resolves it only from its inherited flag set, which cobra populates lazily. `hideFormatFlag` wraps the command's help function to mark the inherited `format` flag hidden, keeping it out of `api --help` without disabling it for parsing elsewhere.

## Normalize the Success-Path Newline

Unwrapped v2 (JSON:API) responses are re-marshaled and previously emitted with no trailing newline, running into the next prompt. `writeBody` appends a newline only when the body lacks one, so re-marshaled output gets a single newline while v1 responses and `--raw` passthrough keep the server's bytes unchanged.

Added tests covering stderr error routing, `--jq` skipped on error, trailing-newline normalization, v1 newline preservation, and the hidden `--format` flag.
