### PR TITLE
fix(column): look up columns by key_name

### DIFF
--- a/cmd/column/get.go
+++ b/cmd/column/get.go
@@ -3,6 +3,7 @@ package column
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
@@ -10,10 +11,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// columnIDPattern matches Honeycomb base58 column IDs, which use the Bitcoin
+// base58 alphabet (no 0, O, I, or l, and no separators). Anything outside this
+// set, including key names with underscores or dots, is treated as a key name
+// and resolved via the list endpoint.
+var columnIDPattern = regexp.MustCompile(`^[1-9A-HJ-NP-Za-km-z]+$`)
+
 func NewGetCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	return &cobra.Command{
-		Use:   "get <column-id>",
-		Short: "Get a column",
+		Use:   "get <column-id-or-key-name>",
+		Short: "Get a column by ID or key name",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runColumnGet(cmd.Context(), opts, *dataset, args[0])
@@ -21,13 +28,17 @@ func NewGetCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	}
 }
 
-func runColumnGet(ctx context.Context, opts *options.RootOptions, dataset, columnID string) error {
+func runColumnGet(ctx context.Context, opts *options.RootOptions, dataset, column string) error {
 	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.GetColumnWithResponse(ctx, dataset, columnID)
+	if !columnIDPattern.MatchString(column) {
+		return getColumnByKeyName(ctx, opts, client, dataset, column)
+	}
+
+	resp, err := client.GetColumnWithResponse(ctx, dataset, column)
 	if err != nil {
 		return fmt.Errorf("getting column: %w", err)
 	}
@@ -38,4 +49,19 @@ func runColumnGet(ctx context.Context, opts *options.RootOptions, dataset, colum
 	}
 
 	return writeColumnDetail(opts, *col)
+}
+
+func getColumnByKeyName(ctx context.Context, opts *options.RootOptions, client api.ClientInterface, dataset, keyName string) error {
+	columns, err := listColumns(ctx, client, dataset, &api.ListColumnsParams{KeyName: &keyName})
+	if err != nil {
+		return err
+	}
+
+	for _, col := range columns {
+		if col.KeyName == keyName {
+			return writeColumnDetail(opts, col)
+		}
+	}
+
+	return fmt.Errorf("no column found with key name %q in dataset %q", keyName, dataset)
 }

--- a/cmd/column/get_test.go
+++ b/cmd/column/get_test.go
@@ -64,6 +64,59 @@ func TestGet_NotFound(t *testing.T) {
 	}
 }
 
+func TestGet_ByKeyName(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/1/columns/my-dataset" {
+			t.Errorf("path = %q, want /1/columns/my-dataset", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("key_name"); got != "qa162_test_col" {
+			t.Errorf("key_name = %q, want %q", got, "qa162_test_col")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"id":       "abc123",
+				"key_name": "qa162_test_col",
+				"type":     "string",
+			},
+		})
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"get", "--dataset", "my-dataset", "qa162_test_col"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var detail columnDetail
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &detail); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if detail.ID != "abc123" {
+		t.Errorf("ID = %q, want %q", detail.ID, "abc123")
+	}
+	if detail.KeyName != "qa162_test_col" {
+		t.Errorf("KeyName = %q, want %q", detail.KeyName, "qa162_test_col")
+	}
+}
+
+func TestGet_ByKeyNameNotFound(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"get", "--dataset", "my-dataset", "missing_col"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for unknown key name")
+	}
+	if !strings.Contains(err.Error(), "no column found with key name") {
+		t.Errorf("error = %q, want not-found message", err.Error())
+	}
+}
+
 func TestGet_MissingArg(t *testing.T) {
 	opts, _ := setupTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 

--- a/cmd/column/list.go
+++ b/cmd/column/list.go
@@ -14,42 +14,35 @@ import (
 )
 
 func NewListCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
-	return &cobra.Command{
+	var keyName string
+
+	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List columns in a dataset",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runColumnList(cmd.Context(), opts, *dataset)
+			return runColumnList(cmd.Context(), opts, *dataset, keyName)
 		},
 	}
+
+	cmd.Flags().StringVar(&keyName, "key-name", "", "Filter to the column with this key name")
+
+	return cmd
 }
 
-func runColumnList(ctx context.Context, opts *options.RootOptions, dataset string) error {
+func runColumnList(ctx context.Context, opts *options.RootOptions, dataset, keyName string) error {
 	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	// Use the raw ListColumns method because the generated ListColumnsWithResponse
-	// parser cannot unmarshal the response into its union type (JSON200 is
-	// struct { union json.RawMessage } which fails on the JSON array body).
-	resp, err := client.ListColumns(ctx, dataset, nil)
-	if err != nil {
-		return fmt.Errorf("listing columns: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("reading response: %w", err)
+	var params *api.ListColumnsParams
+	if keyName != "" {
+		params = &api.ListColumnsParams{KeyName: &keyName}
 	}
 
-	if err := api.CheckResponse(resp.StatusCode, body); err != nil {
+	columns, err := listColumns(ctx, client, dataset, params)
+	if err != nil {
 		return err
-	}
-
-	var columns []api.Column
-	if err := json.Unmarshal(body, &columns); err != nil {
-		return fmt.Errorf("parsing columns: %w", err)
 	}
 
 	items := make([]columnItem, len(columns))
@@ -65,4 +58,32 @@ func runColumnList(ctx context.Context, opts *options.RootOptions, dataset strin
 	}
 
 	return opts.OutputWriterList().Write(items, columnListTable)
+}
+
+// listColumns fetches columns via the raw ListColumns method because the
+// generated ListColumnsWithResponse parser cannot unmarshal the response into
+// its union type (JSON200 is struct { union json.RawMessage } which fails on
+// the JSON array body).
+func listColumns(ctx context.Context, client api.ClientInterface, dataset string, params *api.ListColumnsParams) ([]api.Column, error) {
+	resp, err := client.ListColumns(ctx, dataset, params)
+	if err != nil {
+		return nil, fmt.Errorf("listing columns: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if err := api.CheckResponse(resp.StatusCode, body); err != nil {
+		return nil, err
+	}
+
+	var columns []api.Column
+	if err := json.Unmarshal(body, &columns); err != nil {
+		return nil, fmt.Errorf("parsing columns: %w", err)
+	}
+
+	return columns, nil
 }

--- a/cmd/column/list_test.go
+++ b/cmd/column/list_test.go
@@ -89,6 +89,55 @@ func TestList(t *testing.T) {
 	}
 }
 
+func TestList_KeyNameFilter(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("key_name"); got != "duration_ms" {
+			t.Errorf("key_name = %q, want %q", got, "duration_ms")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"id":       "abc123",
+				"key_name": "duration_ms",
+				"type":     "float",
+			},
+		})
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"list", "--dataset", "my-dataset", "--key-name", "duration_ms"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var items []columnItem
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &items); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("got %d items, want 1", len(items))
+	}
+	if items[0].KeyName != "duration_ms" {
+		t.Errorf("items[0].KeyName = %q, want %q", items[0].KeyName, "duration_ms")
+	}
+}
+
+func TestList_NoKeyNameFilter(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.RawQuery != "" {
+			t.Errorf("query = %q, want empty (no key_name filter)", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"list", "--dataset", "my-dataset"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestList_Empty(t *testing.T) {
 	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
Closes #190.

Humans identify columns by `key_name`, but the CLI only fetched by opaque base58 ID, so `column get qa162_test_col` returned HTTP 400 and `column list` had no way to filter to a single column.

- `column list` now takes a `--key-name` flag that populates `ListColumnsParams{KeyName: ...}`. An empty flag sends no filter (the params pointer stays `nil`).
- `column get` accepts a key name or an ID. It checks the arg against the base58 alphabet client-side: a valid-looking ID hits `GetColumn` directly, anything carrying a `_`, `.`, or `-` resolves through the list endpoint's `key_name` filter and renders the matching column with the existing detail writer. A miss returns a clear not-found error.

The shared list-fetch logic moves into a `listColumns` helper reused by both commands.

For the `get` arg shape check I went with a client-side base58 regex rather than fallback-on-400, since key names reliably contain characters outside the base58 alphabet and this avoids a wasted request on the common case.
