### PR TITLE
fix(mcp): render all call result content types

### DIFF
--- a/cmd/mcp/call.go
+++ b/cmd/mcp/call.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -14,6 +15,7 @@ import (
 	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/fields"
 	"github.com/bendrucker/honeycomb-cli/internal/jq"
+	"github.com/bendrucker/honeycomb-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -130,42 +132,82 @@ func readInputArgs(path string, stdin io.Reader) (map[string]any, error) {
 	return args, nil
 }
 
+type callResult struct {
+	Content []mcp.Content `json:"content"`
+	IsError bool          `json:"is_error"`
+}
+
 func writeCallResult(o *callOptions, result *mcp.CallToolResult) error {
 	ios := o.root.IOStreams
-	format := o.root.ResolveFormat()
 
-	if format == "json" || o.jqExpr != "" {
-		type contentItem struct {
-			Type string `json:"type"`
-			Text string `json:"text,omitempty"`
-		}
-		type callResult struct {
-			Content []contentItem `json:"content"`
-			IsError bool          `json:"isError"`
-		}
+	out := callResult{Content: result.Content, IsError: result.IsError}
 
-		out := callResult{IsError: result.IsError}
-		for _, c := range result.Content {
-			if tc, ok := mcp.AsTextContent(c); ok {
-				out.Content = append(out.Content, contentItem{Type: "text", Text: tc.Text})
-			}
+	if o.jqExpr != "" {
+		b, err := json.Marshal(out)
+		if err != nil {
+			return fmt.Errorf("encoding result: %w", err)
 		}
-
-		if o.jqExpr != "" {
-			b, err := json.Marshal(out)
-			if err != nil {
-				return fmt.Errorf("encoding result: %w", err)
-			}
-			return jq.Filter(bytes.NewReader(b), ios.Out, o.jqExpr)
-		}
-
-		return o.root.OutputWriter().WriteMessage(out, "")
+		return jq.Filter(bytes.NewReader(b), ios.Out, o.jqExpr)
 	}
 
-	for _, c := range result.Content {
-		if tc, ok := mcp.AsTextContent(c); ok {
-			_, _ = fmt.Fprintln(ios.Out, tc.Text)
-		}
+	td := output.DynamicTableDef{
+		Headers: []string{"Index", "Type", "Content"},
+		Rows:    make([][]string, len(out.Content)),
 	}
-	return nil
+	for i, c := range out.Content {
+		td.Rows[i] = []string{strconv.Itoa(i), contentType(c), contentSummary(c)}
+	}
+
+	return o.root.OutputWriter().WriteDynamic(out, td)
+}
+
+// contentType returns the MCP content type discriminator for a content item,
+// falling back to the Go type name for content that carries no type field.
+func contentType(c mcp.Content) string {
+	switch v := c.(type) {
+	case mcp.TextContent:
+		return v.Type
+	case mcp.ImageContent:
+		return v.Type
+	case mcp.AudioContent:
+		return v.Type
+	case mcp.ResourceLink:
+		return v.Type
+	case mcp.EmbeddedResource:
+		return v.Type
+	default:
+		return fmt.Sprintf("%T", c)
+	}
+}
+
+// contentSummary renders a single-line summary of a content item for table
+// output. Text content shows its text; binary and resource content show a
+// bracketed descriptor (e.g. "[image image/png]") so non-text results are
+// visible instead of silently dropped.
+func contentSummary(c mcp.Content) string {
+	switch v := c.(type) {
+	case mcp.TextContent:
+		return v.Text
+	case mcp.ImageContent:
+		return fmt.Sprintf("[image %s]", v.MIMEType)
+	case mcp.AudioContent:
+		return fmt.Sprintf("[audio %s]", v.MIMEType)
+	case mcp.ResourceLink:
+		return fmt.Sprintf("[resource_link %s]", v.URI)
+	case mcp.EmbeddedResource:
+		return fmt.Sprintf("[resource %s]", embeddedResourceURI(v))
+	default:
+		return fmt.Sprintf("[%s]", contentType(c))
+	}
+}
+
+func embeddedResourceURI(r mcp.EmbeddedResource) string {
+	switch res := r.Resource.(type) {
+	case mcp.TextResourceContents:
+		return res.URI
+	case mcp.BlobResourceContents:
+		return res.URI
+	default:
+		return ""
+	}
 }

--- a/cmd/mcp/call_test.go
+++ b/cmd/mcp/call_test.go
@@ -85,6 +85,152 @@ func TestCall_JQ(t *testing.T) {
 	}
 }
 
+func TestCall_Table(t *testing.T) {
+	srv, opts, ts := setupMCPTest(t)
+	opts.Format = "table"
+	srv.AddTool(
+		mcp.NewTool("echo", mcp.WithString("message")),
+		func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			msg, _ := req.GetArguments()["message"].(string)
+			return mcp.NewToolResultText(msg), nil
+		},
+	)
+
+	cmd := newCallCmd(opts, testFactory(srv))
+	cmd.SetArgs([]string{"echo", "-f", "message=hello"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	out := ts.OutBuf.String()
+	for _, want := range []string{"INDEX", "TYPE", "CONTENT", "text", "hello"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table output missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestCall_NonTextContentJSON(t *testing.T) {
+	srv, opts, ts := setupMCPTest(t)
+	srv.AddTool(
+		mcp.NewTool("image"),
+		func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return mcp.NewToolResultImage("here", "ZGF0YQ==", "image/png"), nil
+		},
+	)
+
+	cmd := newCallCmd(opts, testFactory(srv))
+	cmd.SetArgs([]string{"image"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var result struct {
+		Content []struct {
+			Type     string `json:"type"`
+			Text     string `json:"text"`
+			Data     string `json:"data"`
+			MIMEType string `json:"mimeType"`
+		} `json:"content"`
+		IsError bool `json:"is_error"`
+	}
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, ts.OutBuf.String())
+	}
+	if len(result.Content) != 2 {
+		t.Fatalf("got %d content items, want 2 (text + image)\n%s", len(result.Content), ts.OutBuf.String())
+	}
+	img := result.Content[1]
+	if img.Type != "image" {
+		t.Errorf("content[1].type = %q, want image", img.Type)
+	}
+	if img.Data != "ZGF0YQ==" {
+		t.Errorf("content[1].data = %q, want base64 image data", img.Data)
+	}
+	if img.MIMEType != "image/png" {
+		t.Errorf("content[1].mimeType = %q, want image/png", img.MIMEType)
+	}
+	if strings.Contains(ts.OutBuf.String(), "isError") {
+		t.Errorf("envelope used camelCase isError, want is_error\n%s", ts.OutBuf.String())
+	}
+}
+
+func TestCall_NonTextContentTable(t *testing.T) {
+	srv, opts, ts := setupMCPTest(t)
+	opts.Format = "table"
+	srv.AddTool(
+		mcp.NewTool("image"),
+		func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return mcp.NewToolResultImage("here", "ZGF0YQ==", "image/png"), nil
+		},
+	)
+
+	cmd := newCallCmd(opts, testFactory(srv))
+	cmd.SetArgs([]string{"image"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	out := ts.OutBuf.String()
+	for _, want := range []string{"image", "[image image/png]", "here"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table output missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestContentSummary(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		content  mcp.Content
+		wantType string
+		wantText string
+	}{
+		{
+			name:     "text",
+			content:  mcp.TextContent{Type: "text", Text: "hello"},
+			wantType: "text",
+			wantText: "hello",
+		},
+		{
+			name:     "image",
+			content:  mcp.ImageContent{Type: "image", MIMEType: "image/png"},
+			wantType: "image",
+			wantText: "[image image/png]",
+		},
+		{
+			name:     "audio",
+			content:  mcp.AudioContent{Type: "audio", MIMEType: "audio/wav"},
+			wantType: "audio",
+			wantText: "[audio audio/wav]",
+		},
+		{
+			name:     "resource link",
+			content:  mcp.ResourceLink{Type: "resource_link", URI: "hny://dataset/x"},
+			wantType: "resource_link",
+			wantText: "[resource_link hny://dataset/x]",
+		},
+		{
+			name: "embedded resource",
+			content: mcp.EmbeddedResource{
+				Type:     "resource",
+				Resource: mcp.TextResourceContents{URI: "hny://query/1"},
+			},
+			wantType: "resource",
+			wantText: "[resource hny://query/1]",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := contentType(tc.content); got != tc.wantType {
+				t.Errorf("contentType = %q, want %q", got, tc.wantType)
+			}
+			if got := contentSummary(tc.content); got != tc.wantText {
+				t.Errorf("contentSummary = %q, want %q", got, tc.wantText)
+			}
+		})
+	}
+}
+
 func TestCall_MutuallyExclusiveFlags(t *testing.T) {
 	srv, opts, _ := setupMCPTest(t)
 	srv.AddTool(mcp.NewTool("test"), nil)


### PR DESCRIPTION
Closes #184

Rewrites the `mcp call` result-rendering block in `cmd/mcp/call.go` to handle every MCP content type and fix the output envelope, so non-text tool results are no longer silently dropped.

## Changes

- **Marshal `result.Content` directly.** The JSON path dropped the text-only `contentItem` struct that only captured `{type, text}`. It now marshals the native `mcp.Content` slice, so image, audio, resource-link, and embedded-resource items round-trip with their own fields (`data`, `mimeType`, `uri`, ...) instead of collapsing to `{"content": null}`.
- **Rename the envelope tag to `is_error`.** The camelCase `json:"isError"` was the lone exception to the CLI's snake_case payloads. The value still comes from `result.IsError`.
- **Build a real table.** `--format table` previously `Fprintln`'d raw text and rendered nothing for non-text content. It now emits an `output.DynamicTableDef` (`Index`, `Type`, `Content`) via `WriteDynamic`, summarizing text inline and non-text items as bracketed descriptors like `[image image/png]`.

## Tests

- `TestCall_Table`: text results render as a table with the text in the summary column.
- `TestCall_NonTextContentJSON` / `TestCall_NonTextContentTable`: an image tool result (via the in-process MCP test server) preserves `data`/`mimeType` in JSON, uses `is_error`, and shows `[image image/png]` in the table.
- `TestContentSummary`: unit-covers the `contentType`/`contentSummary` helpers for text, image, audio, resource-link, and embedded-resource content.
