### PR TITLE
fix(cli): align key/slo flag shapes across commands

### DIFF
--- a/cmd/key/key_test.go
+++ b/cmd/key/key_test.go
@@ -104,18 +104,28 @@ func TestList(t *testing.T) {
 }
 
 func TestList_WithTypeFilter(t *testing.T) {
-	opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got := r.URL.Query().Get("filter[type]"); got != "ingest" {
-			t.Errorf("filter[type] = %q, want %q", got, "ingest")
-		}
-		w.Header().Set("Content-Type", "application/vnd.api+json")
-		_, _ = w.Write([]byte(`{"data": []}`))
-	}))
+	for _, tc := range []struct {
+		name string
+		flag string
+	}{
+		{name: "key type flag", flag: "--key-type"},
+		{name: "deprecated type alias", flag: "--type"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.URL.Query().Get("filter[type]"); got != "ingest" {
+					t.Errorf("filter[type] = %q, want %q", got, "ingest")
+				}
+				w.Header().Set("Content-Type", "application/vnd.api+json")
+				_, _ = w.Write([]byte(`{"data": []}`))
+			}))
 
-	cmd := NewCmd(opts)
-	cmd.SetArgs([]string{"--team", "my-team", "list", "--type", "ingest"})
-	if err := cmd.Execute(); err != nil {
-		t.Fatal(err)
+			cmd := NewCmd(opts)
+			cmd.SetArgs([]string{"--team", "my-team", "list", tc.flag, "ingest"})
+			if err := cmd.Execute(); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }
 

--- a/cmd/key/list.go
+++ b/cmd/key/list.go
@@ -11,7 +11,10 @@ import (
 )
 
 func NewListCmd(opts *options.RootOptions, team *string) *cobra.Command {
-	var filterType string
+	var (
+		keyType    string
+		legacyType string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -20,11 +23,18 @@ func NewListCmd(opts *options.RootOptions, team *string) *cobra.Command {
 			if err := opts.RequireTeam(team); err != nil {
 				return err
 			}
+			filterType := keyType
+			if filterType == "" {
+				filterType = legacyType
+			}
 			return runKeyList(cmd.Context(), opts, *team, filterType)
 		},
 	}
 
-	cmd.Flags().StringVar(&filterType, "type", "", "Filter by key type (ingest, configuration)")
+	cmd.Flags().StringVar(&keyType, "key-type", "", "Filter by key type (ingest, configuration)")
+	cmd.Flags().StringVar(&legacyType, "type", "", "Filter by key type (ingest, configuration)")
+	_ = cmd.Flags().MarkHidden("type")
+	_ = cmd.Flags().MarkDeprecated("type", "use --key-type")
 
 	return cmd
 }

--- a/cmd/slo/history.go
+++ b/cmd/slo/history.go
@@ -20,22 +20,41 @@ func NewHistoryCmd(opts *options.RootOptions, _ *string) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "history",
+		Use:   "history [slo-id...]",
 		Short: "Get SLO historical compliance and budget data",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runHistory(cmd.Context(), opts, sloIDs, startTime, endTime)
+		Long: "Get SLO historical compliance and budget data.\n\n" +
+			"SLO IDs may be passed as positional arguments, via --slo-id (repeatable), or both. " +
+			"At least one SLO ID is required; the two sources are merged and de-duplicated.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ids := mergeSLOIDs(args, sloIDs)
+			if len(ids) == 0 {
+				return fmt.Errorf("at least one SLO ID is required (positional argument or --slo-id)")
+			}
+			return runHistory(cmd.Context(), opts, ids, startTime, endTime)
 		},
 	}
 
-	cmd.Flags().StringSliceVar(&sloIDs, "slo-id", nil, "SLO IDs to retrieve history for (required, repeatable)")
+	cmd.Flags().StringSliceVar(&sloIDs, "slo-id", nil, "SLO IDs to retrieve history for (repeatable; may also be passed as positional arguments)")
 	cmd.Flags().IntVar(&startTime, "start-time", 0, "Start time as Unix timestamp (required)")
 	cmd.Flags().IntVar(&endTime, "end-time", 0, "End time as Unix timestamp (required)")
 
-	_ = cmd.MarkFlagRequired("slo-id")
 	_ = cmd.MarkFlagRequired("start-time")
 	_ = cmd.MarkFlagRequired("end-time")
 
 	return cmd
+}
+
+func mergeSLOIDs(args, flagIDs []string) []string {
+	seen := make(map[string]bool, len(args)+len(flagIDs))
+	var ids []string
+	for _, id := range append(append([]string{}, args...), flagIDs...) {
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, id)
+	}
+	return ids
 }
 
 func runHistory(ctx context.Context, opts *options.RootOptions, sloIDs []string, startTime, endTime int) error {

--- a/cmd/slo/history_test.go
+++ b/cmd/slo/history_test.go
@@ -51,8 +51,8 @@ func TestHistory(t *testing.T) {
 	cmd := NewCmd(opts)
 	cmd.SetArgs([]string{
 		"history",
+		"slo-1",
 		"--dataset", "ignored",
-		"--slo-id", "slo-1",
 		"--slo-id", "slo-2",
 		"--start-time", "1700000000",
 		"--end-time", "1700100000",
@@ -76,6 +76,91 @@ func TestHistory(t *testing.T) {
 	}
 	if result["slo-1"][0].Compliance == nil || *result["slo-1"][0].Compliance != 99.5 {
 		t.Errorf("slo-1[0].Compliance = %v, want 99.5", result["slo-1"][0].Compliance)
+	}
+}
+
+func TestHistory_MergeSLOIDs(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		args    []string
+		flagIDs []string
+		want    []string
+	}{
+		{name: "positional only", args: []string{"a", "b"}, want: []string{"a", "b"}},
+		{name: "flags only", flagIDs: []string{"a", "b"}, want: []string{"a", "b"}},
+		{name: "merged", args: []string{"a"}, flagIDs: []string{"b"}, want: []string{"a", "b"}},
+		{name: "dedup across sources", args: []string{"a", "b"}, flagIDs: []string{"b", "c"}, want: []string{"a", "b", "c"}},
+		{name: "empty", want: nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeSLOIDs(tc.args, tc.flagIDs)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("got %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func TestHistory_PositionalOnly(t *testing.T) {
+	opts, ts := setupBurnAlertTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("reading request body: %v", err)
+		}
+		var req api.SLOHistoryRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("unmarshalling request body: %v", err)
+		}
+		if len(req.Ids) != 1 {
+			t.Fatalf("ids length = %d, want 1", len(req.Ids))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"slo-1": []map[string]any{{"timestamp": 1700000000, "compliance": 99.5, "budget_remaining": 0.8}},
+		})
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{
+		"history",
+		"slo-1",
+		"--dataset", "ignored",
+		"--start-time", "1700000000",
+		"--end-time", "1700100000",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var result api.SLOHistoryResponse
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("got %d SLOs, want 1", len(result))
+	}
+}
+
+func TestHistory_NoSLOID(t *testing.T) {
+	opts, _ := setupBurnAlertTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("unexpected API call")
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{
+		"history",
+		"--dataset", "ds",
+		"--start-time", "1700000000",
+		"--end-time", "1700100000",
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when no SLO ID is provided")
 	}
 }
 


### PR DESCRIPTION
Closes #176. The same concept took different flag shapes across sibling commands. This aligns two families.

## `key list` Key Type Filter

`key create` registers `--key-type`, but `key list` registered `--type` for the same concept. `key list` now registers `--key-type` to match. `--type` stays as a hidden, deprecated alias so existing scripts keep working. The run path reads `--key-type` and falls back to `--type` when only the alias is set.

## `slo history` SLO IDs

`slo history` accepts an array of SLO IDs (the API takes an `Ids` array), so `--slo-id` stays repeatable. It now also accepts positional arguments as SLO IDs, merged and de-duplicated with `--slo-id` values, matching the positional shape used by `slo get` and `slo burn-alert get`. At least one ID is required from either source, and the usage text documents the split. `slo get`, `slo burn-alert get` (positional), and `slo burn-alert list --slo-id` (single) are unchanged.

## Tests

- `key list` filters correctly via both `--key-type` and the deprecated `--type` alias.
- `slo history` accepts positional IDs, `--slo-id`, and both merged. `mergeSLOIDs` dedups across sources, and missing IDs errors.
