### PR TITLE
fix(cli): add --delete-protected to create commands

### DIFF
--- a/cmd/dataset/create.go
+++ b/cmd/dataset/create.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/bendrucker/honeycomb-cli/internal/deref"
 	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
@@ -16,6 +17,7 @@ func NewCreateCmd(opts *options.RootOptions) *cobra.Command {
 		name            string
 		description     string
 		expandJsonDepth int
+		deleteProtected bool
 	)
 
 	cmd := &cobra.Command{
@@ -26,18 +28,23 @@ func NewCreateCmd(opts *options.RootOptions) *cobra.Command {
 			if cmd.Flags().Changed("expand-json-depth") {
 				ejd = &expandJsonDepth
 			}
-			return runDatasetCreate(cmd.Context(), opts, name, description, ejd)
+			var clearProtection bool
+			if cmd.Flags().Changed("delete-protected") && !deleteProtected {
+				clearProtection = true
+			}
+			return runDatasetCreate(cmd.Context(), opts, name, description, ejd, clearProtection)
 		},
 	}
 
 	cmd.Flags().StringVar(&name, "name", "", "Dataset name (required)")
 	cmd.Flags().StringVar(&description, "description", "", "Dataset description")
 	cmd.Flags().IntVar(&expandJsonDepth, "expand-json-depth", 0, "Maximum unpacking depth of nested JSON fields")
+	cmd.Flags().BoolVar(&deleteProtected, "delete-protected", true, "Protect dataset from deletion")
 
 	return cmd
 }
 
-func runDatasetCreate(ctx context.Context, opts *options.RootOptions, name, description string, expandJsonDepth *int) error {
+func runDatasetCreate(ctx context.Context, opts *options.RootOptions, name, description string, expandJsonDepth *int, clearProtection bool) error {
 	ios := opts.IOStreams
 
 	if ios.CanPrompt() {
@@ -94,6 +101,39 @@ func runDatasetCreate(ctx context.Context, opts *options.RootOptions, name, desc
 		return fmt.Errorf("unexpected response: %s", resp.Status())
 	}
 
+	if clearProtection {
+		dataset, err = clearDatasetProtection(ctx, client, dataset)
+		if err != nil {
+			return err
+		}
+	}
+
 	detail := mapDatasetDetail(dataset)
 	return writeDatasetDetail(opts, detail)
+}
+
+func clearDatasetProtection(ctx context.Context, client *api.ClientWithResponses, created *api.Dataset) (*api.Dataset, error) {
+	protected := false
+	body := api.DatasetUpdatePayload{
+		Description: deref.String(created.Description),
+		Settings: &struct {
+			DeleteProtected *bool `json:"delete_protected,omitempty"`
+		}{
+			DeleteProtected: &protected,
+		},
+	}
+	if created.ExpandJsonDepth != nil {
+		body.ExpandJsonDepth = *created.ExpandJsonDepth
+	}
+
+	resp, err := client.UpdateDatasetWithResponse(ctx, deref.String(created.Slug), body)
+	if err != nil {
+		return nil, fmt.Errorf("clearing delete protection: %w", err)
+	}
+
+	dataset, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON200)
+	if err != nil {
+		return nil, fmt.Errorf("clearing delete protection: %w", err)
+	}
+	return dataset, nil
 }

--- a/cmd/dataset/create_test.go
+++ b/cmd/dataset/create_test.go
@@ -94,6 +94,88 @@ func TestCreate_200(t *testing.T) {
 	}
 }
 
+func TestCreate_DeleteProtectedFalse(t *testing.T) {
+	var posted, patched bool
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodPost:
+			posted = true
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"name":       "my-dataset",
+				"slug":       "my-dataset",
+				"created_at": "2025-01-15T10:30:00Z",
+				"settings":   map[string]any{"delete_protected": true},
+			})
+		case http.MethodPut:
+			patched = true
+			if r.URL.Path != "/1/datasets/my-dataset" {
+				t.Errorf("path = %q, want /1/datasets/my-dataset", r.URL.Path)
+			}
+			body, _ := io.ReadAll(r.Body)
+			var payload api.DatasetUpdatePayload
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Fatalf("unmarshal request body: %v", err)
+			}
+			if payload.Settings == nil || payload.Settings.DeleteProtected == nil || *payload.Settings.DeleteProtected {
+				t.Errorf("Settings.DeleteProtected = %v, want false", payload.Settings)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"name":       "my-dataset",
+				"slug":       "my-dataset",
+				"created_at": "2025-01-15T10:30:00Z",
+				"settings":   map[string]any{"delete_protected": false},
+			})
+		default:
+			t.Errorf("unexpected method %q", r.Method)
+		}
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"create", "--name", "my-dataset", "--delete-protected=false"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !posted {
+		t.Error("create request not made")
+	}
+	if !patched {
+		t.Error("follow-up update request not made")
+	}
+
+	var detail datasetDetail
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &detail); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if detail.DeleteProtected {
+		t.Errorf("DeleteProtected = true, want false")
+	}
+}
+
+func TestCreate_NoFollowUpWhenDefault(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected %s request to %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name":       "my-dataset",
+			"slug":       "my-dataset",
+			"created_at": "2025-01-15T10:30:00Z",
+			"settings":   map[string]any{"delete_protected": true},
+		})
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"create", "--name", "my-dataset"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestCreate_MissingName(t *testing.T) {
 	opts, _ := setupTest(t, http.NotFoundHandler())
 

--- a/cmd/environment/create.go
+++ b/cmd/environment/create.go
@@ -12,9 +12,10 @@ import (
 
 func NewCreateCmd(opts *options.RootOptions, team *string) *cobra.Command {
 	var (
-		name  string
-		desc  string
-		color string
+		name            string
+		desc            string
+		color           string
+		deleteProtected bool
 	)
 
 	cmd := &cobra.Command{
@@ -24,18 +25,20 @@ func NewCreateCmd(opts *options.RootOptions, team *string) *cobra.Command {
 			if err := opts.RequireTeam(team); err != nil {
 				return err
 			}
-			return runEnvironmentCreate(cmd, opts, *team, name, desc, color)
+			clearProtection := cmd.Flags().Changed("delete-protected") && !deleteProtected
+			return runEnvironmentCreate(cmd, opts, *team, name, desc, color, clearProtection)
 		},
 	}
 
 	cmd.Flags().StringVar(&name, "name", "", "Environment name")
 	cmd.Flags().StringVar(&desc, "description", "", "Environment description")
 	cmd.Flags().StringVar(&color, "color", "", "Environment color")
+	cmd.Flags().BoolVar(&deleteProtected, "delete-protected", true, "Protect environment from deletion")
 
 	return cmd
 }
 
-func runEnvironmentCreate(cmd *cobra.Command, opts *options.RootOptions, team, name, desc, color string) error {
+func runEnvironmentCreate(cmd *cobra.Command, opts *options.RootOptions, team, name, desc, color string, clearProtection bool) error {
 	client, err := opts.Client(config.KeyManagement)
 	if err != nil {
 		return err
@@ -81,5 +84,36 @@ func runEnvironmentCreate(cmd *cobra.Command, opts *options.RootOptions, team, n
 		return err
 	}
 
-	return writeEnvironmentDetail(opts, envToDetail(env.Data))
+	data := env.Data
+	if clearProtection {
+		data, err = clearEnvironmentProtection(cmd, client, team, data.Id)
+		if err != nil {
+			return err
+		}
+	}
+
+	return writeEnvironmentDetail(opts, envToDetail(data))
+}
+
+func clearEnvironmentProtection(cmd *cobra.Command, client *api.ClientWithResponses, team, envID string) (api.Environment, error) {
+	protected := false
+	body := api.UpdateEnvironmentRequest{}
+	body.Data.Id = envID
+	body.Data.Type = api.UpdateEnvironmentRequestDataTypeEnvironments
+	body.Data.Attributes.Settings = &struct {
+		DeleteProtected *bool `json:"delete_protected,omitempty"`
+	}{
+		DeleteProtected: &protected,
+	}
+
+	resp, err := client.UpdateEnvironmentWithApplicationVndAPIPlusJSONBodyWithResponse(cmd.Context(), team, envID, body)
+	if err != nil {
+		return api.Environment{}, fmt.Errorf("clearing delete protection: %w", err)
+	}
+
+	env, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.ApplicationvndApiJSON200)
+	if err != nil {
+		return api.Environment{}, fmt.Errorf("clearing delete protection: %w", err)
+	}
+	return env.Data, nil
 }

--- a/cmd/environment/environment_test.go
+++ b/cmd/environment/environment_test.go
@@ -373,6 +373,99 @@ func TestCreate(t *testing.T) {
 	}
 }
 
+func TestCreate_DeleteProtectedFalse(t *testing.T) {
+	var posted, patched bool
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			posted = true
+			jsonapiEnvelope(t, w, http.StatusCreated, map[string]any{
+				"data": map[string]any{
+					"id":   "env-new",
+					"type": "environments",
+					"attributes": map[string]any{
+						"name":     "Test Env",
+						"slug":     "test-env",
+						"settings": map[string]any{"delete_protected": true},
+					},
+				},
+			})
+		case http.MethodPatch:
+			patched = true
+			if r.URL.Path != "/2/teams/my-team/environments/env-new" {
+				t.Errorf("path = %q, want /2/teams/my-team/environments/env-new", r.URL.Path)
+			}
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			data, _ := body["data"].(map[string]any)
+			attrs, _ := data["attributes"].(map[string]any)
+			settings, _ := attrs["settings"].(map[string]any)
+			if settings["delete_protected"] != false {
+				t.Errorf("delete_protected = %v, want false", settings["delete_protected"])
+			}
+			jsonapiEnvelope(t, w, http.StatusOK, map[string]any{
+				"data": map[string]any{
+					"id":   "env-new",
+					"type": "environments",
+					"attributes": map[string]any{
+						"name":     "Test Env",
+						"slug":     "test-env",
+						"settings": map[string]any{"delete_protected": false},
+					},
+				},
+			})
+		default:
+			t.Errorf("unexpected method %q", r.Method)
+		}
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"create", "--team", "my-team", "--name", "Test Env", "--delete-protected=false"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !posted {
+		t.Error("create request not made")
+	}
+	if !patched {
+		t.Error("follow-up update request not made")
+	}
+
+	var detail environmentDetail
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &detail); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if detail.DeleteProtected {
+		t.Errorf("DeleteProtected = true, want false")
+	}
+}
+
+func TestCreate_NoFollowUpWhenDefault(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected %s request to %s", r.Method, r.URL.Path)
+		}
+		jsonapiEnvelope(t, w, http.StatusCreated, map[string]any{
+			"data": map[string]any{
+				"id":   "env-new",
+				"type": "environments",
+				"attributes": map[string]any{
+					"name":     "Test Env",
+					"slug":     "test-env",
+					"settings": map[string]any{"delete_protected": true},
+				},
+			},
+		})
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"create", "--team", "my-team", "--name", "Test Env"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestCreate_NoNameNonInteractive(t *testing.T) {
 	opts, _ := setupTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	opts.IOStreams.SetNeverPrompt(true)


### PR DESCRIPTION
Closes #177.

Adds a `--delete-protected` bool flag (default `true`) to `dataset create` and `environment create`, mirroring the sibling `update` commands. The API delete-protects new datasets and environments by default, so a scripted create-then-delete always failed, with no way to opt out.

The generated create payloads (`DatasetCreationPayload` and `CreateEnvironmentRequest`) carry no settings block, so the flag can't disable protection in the create request itself. When `--delete-protected=false` is passed explicitly, the command chains a follow-up update after creation (`UpdateDatasetWithResponse` for datasets, the JSON:API update call for environments) to clear protection, then renders the detail from the updated resource so the displayed `delete_protected` is accurate. The dataset follow-up re-sends the created description and expand depth to avoid clobbering them.

The follow-up only fires when the flag is explicitly set to `false`. The default `true` preserves current behavior with no extra request.
