### PR TITLE
fix(api): accept gh-style method positional

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	clientapi "github.com/bendrucker/honeycomb-cli/internal/api"
@@ -34,12 +35,16 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 	o := &apiOptions{root: opts}
 
 	cmd := &cobra.Command{
-		Use:   "api <path>",
+		Use:   "api [method] <path>",
 		Short: "Make an authenticated API request",
 		Long:  "Make an authenticated API request to Honeycomb and print the response.",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return run(cmd, o, args[0])
+			path, err := parsePositionalMethod(cmd, o, args)
+			if err != nil {
+				return err
+			}
+			return run(cmd, o, path)
 		},
 	}
 
@@ -187,6 +192,38 @@ func writeBody(w io.Writer, body []byte) {
 	_, _ = w.Write(body)
 	if len(body) > 0 && body[len(body)-1] != '\n' {
 		_, _ = w.Write([]byte{'\n'})
+	}
+}
+
+// parsePositionalMethod supports the gh-style `api <method> <path>` form. With a
+// single positional, it is treated as the path and the method comes from -X or
+// auto-detection. With two positionals, the first must be a known HTTP method,
+// which sets o.method (uppercased), and the second is the path. Passing both a
+// positional method and -X is a conflict.
+func parsePositionalMethod(cmd *cobra.Command, o *apiOptions, args []string) (string, error) {
+	if len(args) == 1 {
+		return args[0], nil
+	}
+
+	method := args[0]
+	if !knownMethod(method) {
+		return "", fmt.Errorf("unknown HTTP method %q: expected GET, POST, PUT, PATCH, DELETE, or HEAD", method)
+	}
+	if cmd.Flags().Changed("method") {
+		return "", fmt.Errorf("cannot set the method via both a positional argument and -X/--method")
+	}
+
+	o.method = strings.ToUpper(method)
+	return args[1], nil
+}
+
+// knownMethod reports whether s is a recognized HTTP method, ignoring case.
+func knownMethod(s string) bool {
+	switch strings.ToUpper(s) {
+	case http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete, http.MethodHead:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/cmd/api/api_test.go
+++ b/cmd/api/api_test.go
@@ -706,6 +706,88 @@ func TestNewCmd_FormatFlagHidden(t *testing.T) {
 	}
 }
 
+func TestRun_PositionalMethod(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantMethod string
+	}{
+		{
+			name:       "gh-style method positional",
+			args:       []string{"GET", "/1/auth"},
+			wantMethod: http.MethodGet,
+		},
+		{
+			name:       "lowercase method is normalized",
+			args:       []string{"get", "/1/auth"},
+			wantMethod: http.MethodGet,
+		},
+		{
+			name:       "single positional path with -X",
+			args:       []string{"/1/auth", "-X", "DELETE"},
+			wantMethod: http.MethodDelete,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != tt.wantMethod {
+					t.Errorf("method = %q, want %q", r.Method, tt.wantMethod)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{}`))
+			}), config.KeyConfig, "test-key")
+
+			cmd := NewCmd(opts)
+			cmd.SetArgs(tt.args)
+			if err := cmd.Execute(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestRun_PositionalMethodErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "unknown first token",
+			args:    []string{"NOTAMETHOD", "/1/auth"},
+			wantErr: "unknown HTTP method",
+		},
+		{
+			name:    "method positional conflicts with -X",
+			args:    []string{"GET", "/1/auth", "-X", "POST"},
+			wantErr: "both a positional argument and -X/--method",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := iostreams.Test(t)
+			opts := &options.RootOptions{
+				IOStreams: ts.IOStreams,
+				Config:    &config.Config{},
+				APIUrl:    "http://localhost",
+			}
+
+			cmd := NewCmd(opts)
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want substring %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
 func writeTestFile(path, content string) error {
 	return os.WriteFile(path, []byte(content), 0o644)
 }


### PR DESCRIPTION
Closes #185.

`api` now accepts the method as a leading positional, matching `gh api <method> <path>` and the form shown in this project's own docs. `Args` becomes `cobra.RangeArgs(1, 2)`: with two positionals, the first must be a known HTTP method (GET/POST/PUT/PATCH/DELETE/HEAD, case-insensitive) and sets the method (uppercased) for the request, while the second is the path. A single positional keeps the existing path-only behavior with the method from `-X`/auto-detection.

Previously `honeycomb api GET /1/boards` failed with cobra's generic `accepts 1 arg(s), received 2`, which never mentioned `-X/--method`. The new path also returns clear errors when the first token is not a known method and when a positional method is combined with an explicit `-X/--method`.
