### PR TITLE
fix(recipient): reject flags not matching --type

### DIFF
--- a/cmd/recipient/create.go
+++ b/cmd/recipient/create.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
@@ -15,6 +17,17 @@ import (
 )
 
 var recipientTypes = []string{"email", "slack", "pagerduty", "msteams", "msteams_workflow", "webhook"}
+
+// detailFlags lists every type-specific detail flag and the recipient types it
+// applies to. Flags set for a type not listed here are rejected before the body
+// is built, so they cannot be silently dropped.
+var detailFlags = map[string][]string{
+	"target":          {"email"},
+	"channel":         {"slack"},
+	"integration-key": {"pagerduty"},
+	"name":            {"pagerduty", "msteams", "msteams_workflow", "webhook"},
+	"url":             {"msteams", "msteams_workflow", "webhook"},
+}
 
 func NewCreateCmd(opts *options.RootOptions) *cobra.Command {
 	var (
@@ -34,6 +47,11 @@ func NewCreateCmd(opts *options.RootOptions) *cobra.Command {
 			if file != "" {
 				return createFromFile(cmd.Context(), opts, file)
 			}
+			if recipientType != "" {
+				if err := validateDetailFlags(cmd, recipientType); err != nil {
+					return err
+				}
+			}
 			return runCreate(cmd.Context(), opts, recipientType, target, channel, integrationKey, name, url)
 		},
 	}
@@ -51,6 +69,22 @@ func NewCreateCmd(opts *options.RootOptions) *cobra.Command {
 	}
 
 	return cmd
+}
+
+// validateDetailFlags rejects any explicitly-set detail flag that does not
+// apply to recipientType, so mismatched flags surface an error instead of being
+// silently dropped.
+func validateDetailFlags(cmd *cobra.Command, recipientType string) error {
+	for flag, types := range detailFlags {
+		if !cmd.Flags().Changed(flag) {
+			continue
+		}
+		if slices.Contains(types, recipientType) {
+			continue
+		}
+		return fmt.Errorf("--%s is not valid for %s recipients (valid for: %s)", flag, recipientType, strings.Join(types, ", "))
+	}
+	return nil
 }
 
 func runCreate(ctx context.Context, opts *options.RootOptions, recipientType, target, channel, integrationKey, name, url string) error {

--- a/cmd/recipient/recipient_test.go
+++ b/cmd/recipient/recipient_test.go
@@ -528,6 +528,61 @@ func TestCreate_MissingDetailNonInteractive(t *testing.T) {
 	}
 }
 
+func TestCreate_MismatchedFlags(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "email with channel",
+			args:    []string{"create", "--type", "email", "--target", "test@example.com", "--channel", "#foo"},
+			wantErr: "--channel is not valid for email recipients",
+		},
+		{
+			name:    "email with url",
+			args:    []string{"create", "--type", "email", "--target", "test@example.com", "--url", "https://example.com"},
+			wantErr: "--url is not valid for email recipients",
+		},
+		{
+			name:    "slack with target",
+			args:    []string{"create", "--type", "slack", "--channel", "#alerts", "--target", "test@example.com"},
+			wantErr: "--target is not valid for slack recipients",
+		},
+		{
+			name:    "pagerduty with channel",
+			args:    []string{"create", "--type", "pagerduty", "--integration-key", "abc123", "--channel", "#foo"},
+			wantErr: "--channel is not valid for pagerduty recipients",
+		},
+		{
+			name:    "webhook with integration-key",
+			args:    []string{"create", "--type", "webhook", "--url", "https://example.com", "--name", "hook", "--integration-key", "abc123"},
+			wantErr: "--integration-key is not valid for webhook recipients",
+		},
+		{
+			name:    "error names valid types",
+			args:    []string{"create", "--type", "email", "--target", "test@example.com", "--url", "https://example.com"},
+			wantErr: "valid for: msteams, msteams_workflow, webhook",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts, _ := setupTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				t.Error("request should not be sent for mismatched flags")
+			}))
+
+			cmd := NewCmd(opts)
+			cmd.SetArgs(tc.args)
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("expected error for mismatched flags")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestCreate_FileMutuallyExclusive(t *testing.T) {
 	opts, _ := setupTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 


### PR DESCRIPTION
Closes #196.

`recipient create` validates type-specific detail flags against the chosen `--type` before building the request body, rejecting any flag that does not apply. Previously the body builder switched on the recipient type and read only the flags relevant to that branch, so a mismatched flag like `--channel` on an `email` recipient was silently dropped and the command failed only on the missing required flag.

The `RunE` handler now iterates the detail flags using `cmd.Flags().Changed` and returns an error naming the offending flag and the types it is valid for, e.g. `--channel is not valid for email recipients (valid for: slack)`. A `detailFlags` map declares which recipient types each flag (`--target`, `--channel`, `--integration-key`, `--name`, `--url`) applies to.

Table-driven tests cover mismatched flags across the email, slack, pagerduty, and webhook types.
