### PR TITLE
fix(key): show permissions, drop duplicate secret

### DIFF
--- a/cmd/key/create.go
+++ b/cmd/key/create.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
@@ -247,6 +248,45 @@ func setPermissions(attrs *api.ConfigurationKeyAttributes, permissions []string)
 	}
 }
 
+func grantedPermissions(perms *struct {
+	CreateDatasets      *bool `json:"create_datasets,omitempty"`
+	ManageBoards        *bool `json:"manage_boards,omitempty"`
+	ManageColumns       *bool `json:"manage_columns,omitempty"`
+	ManageMarkers       *bool `json:"manage_markers,omitempty"`
+	ManagePrivateBoards *bool `json:"manage_privateBoards,omitempty"`
+	ManageRecipients    *bool `json:"manage_recipients,omitempty"`
+	ManageSlos          *bool `json:"manage_slos,omitempty"`
+	ManageTriggers      *bool `json:"manage_triggers,omitempty"`
+	ReadServiceMaps     *bool `json:"read_service_maps,omitempty"`
+	RunQueries          *bool `json:"run_queries,omitempty"`
+	SendEvents          *bool `json:"send_events,omitempty"`
+	VisibleTeamMembers  *bool `json:"visible_team_members,omitempty"`
+}) []string {
+	if perms == nil {
+		return nil
+	}
+	var granted []string
+	for name, flag := range map[string]*bool{
+		"create_datasets":       perms.CreateDatasets,
+		"manage_boards":         perms.ManageBoards,
+		"manage_columns":        perms.ManageColumns,
+		"manage_markers":        perms.ManageMarkers,
+		"manage_private_boards": perms.ManagePrivateBoards,
+		"manage_recipients":     perms.ManageRecipients,
+		"manage_slos":           perms.ManageSlos,
+		"manage_triggers":       perms.ManageTriggers,
+		"read_service_maps":     perms.ReadServiceMaps,
+		"run_queries":           perms.RunQueries,
+		"send_events":           perms.SendEvents,
+	} {
+		if deref.Bool(flag) {
+			granted = append(granted, name)
+		}
+	}
+	slices.Sort(granted)
+	return granted
+}
+
 func handleCreateResponse(opts *options.RootOptions, resp *api.CreateApiKeyResp) error {
 	created, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.ApplicationvndApiJSON201)
 	if err != nil {
@@ -264,8 +304,9 @@ func handleCreateResponse(opts *options.RootOptions, resp *api.CreateApiKeyResp)
 
 func createResponseToDetail(resp *api.ApiKeyCreateResponse) keyDetail {
 	detail := keyDetail{
-		ID:     deref.String(resp.Data.Id),
-		Secret: deref.String(resp.Data.Attributes.Secret),
+		ID:          deref.String(resp.Data.Id),
+		Secret:      deref.String(resp.Data.Attributes.Secret),
+		Environment: resp.Data.Relationships.Environment.Data.Id,
 	}
 
 	if ingest, err := resp.Data.Attributes.AsIngestKeyAttributes(); err == nil {
@@ -276,6 +317,7 @@ func createResponseToDetail(resp *api.ApiKeyCreateResponse) keyDetail {
 		detail.Name = cfg.Name
 		detail.KeyType = string(cfg.KeyType)
 		detail.Disabled = deref.Bool(cfg.Disabled)
+		detail.Permissions = grantedPermissions(cfg.Permissions)
 	} else {
 		var raw struct {
 			Name     string `json:"name"`
@@ -287,10 +329,6 @@ func createResponseToDetail(resp *api.ApiKeyCreateResponse) keyDetail {
 		detail.Name = raw.Name
 		detail.KeyType = raw.KeyType
 		detail.Disabled = raw.Disabled
-	}
-
-	if detail.Secret != "" {
-		detail.Key = detail.Secret
 	}
 
 	return detail

--- a/cmd/key/key.go
+++ b/cmd/key/key.go
@@ -1,6 +1,8 @@
 package key
 
 import (
+	"strings"
+
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
@@ -36,23 +38,27 @@ type keyItem struct {
 }
 
 type keyDetail struct {
-	ID       string `json:"id" detail:"ID"`
-	Name     string `json:"name" detail:"Name"`
-	KeyType  string `json:"key_type" detail:"Key Type"`
-	Disabled bool   `json:"disabled" detail:"Disabled"`
-	Secret   string `json:"secret,omitempty"`
-	Key      string `json:"key,omitempty"`
+	ID          string   `json:"id" detail:"ID"`
+	Name        string   `json:"name" detail:"Name"`
+	KeyType     string   `json:"key_type" detail:"Key Type"`
+	Disabled    bool     `json:"disabled" detail:"Disabled"`
+	Environment string   `json:"environment,omitempty"`
+	Permissions []string `json:"permissions,omitempty"`
+	Secret      string   `json:"secret,omitempty"`
 }
 
 var keyListTable = output.TableFromTags[keyItem]()
 
 func writeKeyDetail(opts *options.RootOptions, detail keyDetail) error {
 	fields := output.FieldsFromTags(detail)
+	if detail.Environment != "" {
+		fields = append(fields, output.Field{Label: "Environment", Value: detail.Environment})
+	}
+	if len(detail.Permissions) > 0 {
+		fields = append(fields, output.Field{Label: "Permissions", Value: strings.Join(detail.Permissions, ", ")})
+	}
 	if detail.Secret != "" {
 		fields = append(fields, output.Field{Label: "Secret", Value: detail.Secret})
-	}
-	if detail.Key != "" {
-		fields = append(fields, output.Field{Label: "Key", Value: detail.Key})
 	}
 	return opts.OutputWriter().WriteFields(detail, fields)
 }
@@ -73,6 +79,12 @@ func objectToDetail(obj api.ApiKeyObject) keyDetail {
 	}
 	if obj.Attributes != nil {
 		fillFromAttributes(&detail.Name, &detail.KeyType, &detail.Disabled, *obj.Attributes)
+		if cfg, err := obj.Attributes.AsConfigurationKeyAttributes(); err == nil {
+			detail.Permissions = grantedPermissions(cfg.Permissions)
+		}
+	}
+	if obj.Relationships != nil {
+		detail.Environment = obj.Relationships.Environment.Data.Id
 	}
 	return detail
 }

--- a/cmd/key/key_test.go
+++ b/cmd/key/key_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -210,6 +211,86 @@ func TestGet(t *testing.T) {
 	}
 }
 
+func TestGet_ConfigurationKey(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"id": "hcxlk_02def",
+				"type": "api-keys",
+				"attributes": {
+					"name": "My Config Key",
+					"key_type": "configuration",
+					"disabled": false,
+					"permissions": {
+						"manage_boards": true,
+						"run_queries": true,
+						"send_events": false
+					}
+				},
+				"relationships": {
+					"environment": {"data": {"id": "production", "type": "environments"}}
+				}
+			}
+		}`))
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"--team", "my-team", "get", "hcxlk_02def"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var detail keyDetail
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &detail); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if detail.Environment != "production" {
+		t.Errorf("Environment = %q, want %q", detail.Environment, "production")
+	}
+	wantPermissions := []string{"manage_boards", "run_queries"}
+	if !slices.Equal(detail.Permissions, wantPermissions) {
+		t.Errorf("Permissions = %v, want %v", detail.Permissions, wantPermissions)
+	}
+}
+
+func TestGet_IngestKeyNoPermissions(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"id": "hcxik_01abc",
+				"type": "api-keys",
+				"attributes": {
+					"name": "My Ingest Key",
+					"key_type": "ingest",
+					"disabled": false
+				},
+				"relationships": {
+					"environment": {"data": {"id": "staging", "type": "environments"}}
+				}
+			}
+		}`))
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"--team", "my-team", "get", "hcxik_01abc"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var detail keyDetail
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &detail); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if len(detail.Permissions) != 0 {
+		t.Errorf("Permissions = %v, want empty", detail.Permissions)
+	}
+	if detail.Environment != "staging" {
+		t.Errorf("Environment = %q, want %q", detail.Environment, "staging")
+	}
+}
+
 func TestCreate_File(t *testing.T) {
 	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -258,8 +339,8 @@ func TestCreate_File(t *testing.T) {
 	if detail.Secret != "hcxik_01new_secret_value" {
 		t.Errorf("Secret = %q, want %q", detail.Secret, "hcxik_01new_secret_value")
 	}
-	if detail.Key != "hcxik_01new_secret_value" {
-		t.Errorf("Key = %q, want %q", detail.Key, "hcxik_01new_secret_value")
+	if detail.Environment != "env1" {
+		t.Errorf("Environment = %q, want %q", detail.Environment, "env1")
 	}
 	if detail.Name != "New Key" {
 		t.Errorf("Name = %q, want %q", detail.Name, "New Key")
@@ -275,17 +356,14 @@ func TestCreate_Flags(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		keyType string
-		wantKey string
 	}{
 		{
 			name:    "ingest key",
 			keyType: "ingest",
-			wantKey: "secret123",
 		},
 		{
 			name:    "configuration key",
 			keyType: "configuration",
-			wantKey: "secret123",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -358,9 +436,6 @@ func TestCreate_Flags(t *testing.T) {
 			}
 			if detail.Secret != "secret123" {
 				t.Errorf("Secret = %q, want %q", detail.Secret, "secret123")
-			}
-			if detail.Key != tc.wantKey {
-				t.Errorf("Key = %q, want %q", detail.Key, tc.wantKey)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #182. Fixes two `key` output defects.

## Duplicate Secret

`key create` printed the new secret twice: once as `secret` and again as `key`. `createResponseToDetail` copied the secret into `detail.Key`, and `keyDetail` serialized both. This drops the `Key` field, its render block, and the copy, leaving only `Secret`.

## Missing Permissions and Environment

`key get` and `key create` never surfaced a configuration key's granted permissions or its bound environment. `objectToDetail` and `createResponseToDetail` now populate `Environment` from the API key's environment relationship and `Permissions` from `ConfigurationKeyAttributes.Permissions`.

Permissions render as a sorted `[]string` in JSON and a comma-joined list in the table, listing only the permissions set to `true`. Ingest keys carry no permissions, so the field is omitted and nothing panics.

## Tests

Updated the `key` assertions that referenced the removed field and added `get` cases for a configuration key with permissions and an ingest key without them.
