### PR TITLE
fix(cli): detect unset flags with Flags().Changed

### DIFF
--- a/cmd/column/update.go
+++ b/cmd/column/update.go
@@ -21,6 +21,9 @@ func NewUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 		Short: "Update a column",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if !cmd.Flags().Changed("description") && !cmd.Flags().Changed("hidden") {
+				return fmt.Errorf("provide at least one of --description, --hidden")
+			}
 			return runColumnUpdate(cmd, opts, *dataset, args[0], description, hidden)
 		},
 	}

--- a/cmd/column/update_test.go
+++ b/cmd/column/update_test.go
@@ -65,6 +65,19 @@ func TestUpdate(t *testing.T) {
 	}
 }
 
+func TestUpdate_NoFlags(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("unexpected API call")
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"update", "--dataset", "my-dataset", "abc123"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when no update flags provided")
+	}
+}
+
 func TestUpdate_NotFound(t *testing.T) {
 	opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/cmd/dataset/update.go
+++ b/cmd/dataset/update.go
@@ -1,7 +1,9 @@
 package dataset
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
@@ -51,22 +53,23 @@ func runDatasetUpdate(ctx context.Context, opts *options.RootOptions, slug strin
 		return err
 	}
 
-	body := api.DatasetUpdatePayload{}
+	body := map[string]any{}
 	if description != nil {
-		body.Description = *description
+		body["description"] = *description
 	}
 	if expandJsonDepth != nil {
-		body.ExpandJsonDepth = *expandJsonDepth
+		body["expand_json_depth"] = *expandJsonDepth
 	}
 	if deleteProtected != nil {
-		body.Settings = &struct {
-			DeleteProtected *bool `json:"delete_protected,omitempty"`
-		}{
-			DeleteProtected: deleteProtected,
-		}
+		body["settings"] = map[string]any{"delete_protected": *deleteProtected}
 	}
 
-	resp, err := client.UpdateDatasetWithResponse(ctx, slug, body)
+	data, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("encoding dataset: %w", err)
+	}
+
+	resp, err := client.UpdateDatasetWithBodyWithResponse(ctx, slug, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("updating dataset: %w", err)
 	}

--- a/cmd/dataset/update_test.go
+++ b/cmd/dataset/update_test.go
@@ -72,6 +72,40 @@ func TestUpdate(t *testing.T) {
 	}
 }
 
+func TestUpdate_PartialOmitsUnsetFields(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var raw map[string]any
+		if err := json.Unmarshal(body, &raw); err != nil {
+			t.Fatalf("unmarshal request body: %v", err)
+		}
+		if raw["description"] != "Updated description" {
+			t.Errorf("description = %v, want %q", raw["description"], "Updated description")
+		}
+		if _, ok := raw["expand_json_depth"]; ok {
+			t.Errorf("expand_json_depth present in body, want omitted: %v", raw)
+		}
+		if _, ok := raw["settings"]; ok {
+			t.Errorf("settings present in body, want omitted: %v", raw)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name":              "my-dataset",
+			"slug":              "my-dataset",
+			"description":       "Updated description",
+			"expand_json_depth": 5,
+			"created_at":        "2025-01-15T10:30:00Z",
+		})
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"update", "my-dataset", "--description", "Updated description"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestUpdate_NoKey(t *testing.T) {
 	ts := iostreams.Test(t)
 	opts := &options.RootOptions{

--- a/cmd/slo/burn_alert_create.go
+++ b/cmd/slo/burn_alert_create.go
@@ -32,7 +32,7 @@ func NewBurnAlertCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Co
 			if file != "" {
 				return runBurnAlertCreateFromFile(cmd.Context(), opts, *dataset, file)
 			}
-			return runBurnAlertCreateFromFlags(cmd.Context(), opts, *dataset, sloID, alertType, exhaustionMinutes, budgetRateWindowMin, budgetRateThreshold, recipients, description)
+			return runBurnAlertCreateFromFlags(cmd, opts, *dataset, sloID, alertType, exhaustionMinutes, budgetRateWindowMin, budgetRateThreshold, recipients, description)
 		},
 	}
 
@@ -84,7 +84,9 @@ func runBurnAlertCreateFromFile(ctx context.Context, opts *options.RootOptions, 
 	return writeBurnAlertDetail(opts, detail)
 }
 
-func runBurnAlertCreateFromFlags(ctx context.Context, opts *options.RootOptions, dataset, sloID, alertType string, exhaustionMinutes, budgetRateWindowMin, budgetRateThreshold int, recipients []string, description string) error {
+func runBurnAlertCreateFromFlags(cmd *cobra.Command, opts *options.RootOptions, dataset, sloID, alertType string, exhaustionMinutes, budgetRateWindowMin, budgetRateThreshold int, recipients []string, description string) error {
+	ctx := cmd.Context()
+
 	if sloID == "" {
 		return fmt.Errorf("--slo-id is required")
 	}
@@ -108,15 +110,15 @@ func runBurnAlertCreateFromFlags(ctx context.Context, opts *options.RootOptions,
 
 	switch alertType {
 	case "exhaustion_time":
-		if exhaustionMinutes == 0 {
+		if !cmd.Flags().Changed("exhaustion-minutes") {
 			return fmt.Errorf("--exhaustion-minutes is required when --alert-type=exhaustion_time")
 		}
 		body["exhaustion_minutes"] = exhaustionMinutes
 	case "budget_rate":
-		if budgetRateWindowMin == 0 {
+		if !cmd.Flags().Changed("budget-rate-window-minutes") {
 			return fmt.Errorf("--budget-rate-window-minutes is required when --alert-type=budget_rate")
 		}
-		if budgetRateThreshold == 0 {
+		if !cmd.Flags().Changed("budget-rate-threshold") {
 			return fmt.Errorf("--budget-rate-threshold is required when --alert-type=budget_rate")
 		}
 		body["budget_rate_window_minutes"] = budgetRateWindowMin

--- a/cmd/slo/burn_alert_test.go
+++ b/cmd/slo/burn_alert_test.go
@@ -261,6 +261,37 @@ func TestBurnAlertCreate_BudgetRate(t *testing.T) {
 	}
 }
 
+func TestBurnAlertCreate_ExplicitZeroExhaustionMinutes(t *testing.T) {
+	opts, _ := setupBurnAlertTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body["exhaustion_minutes"] != float64(0) {
+			t.Errorf("exhaustion_minutes = %v, want 0", body["exhaustion_minutes"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":                 "ba-new",
+			"alert_type":         "exhaustion_time",
+			"exhaustion_minutes": 0,
+			"slo_id":             "slo-1",
+		})
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{
+		"burn-alert", "create", "--dataset", "my-dataset",
+		"--slo-id", "slo-1",
+		"--alert-type", "exhaustion_time",
+		"--exhaustion-minutes", "0",
+		"--recipient", "r-1",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestBurnAlertCreate_Validation(t *testing.T) {
 	for _, tc := range []struct {
 		name    string

--- a/cmd/slo/create.go
+++ b/cmd/slo/create.go
@@ -60,7 +60,7 @@ func runSLOCreate(cmd *cobra.Command, opts *options.RootOptions, dataset, file, 
 			return err
 		}
 	} else {
-		if name == "" || sliAlias == "" || target == 0 || timePeriod == 0 {
+		if name == "" || sliAlias == "" || !cmd.Flags().Changed("target") || !cmd.Flags().Changed("time-period") {
 			return fmt.Errorf("--file or all of --name, --sli-alias, --target, --time-period are required")
 		}
 

--- a/cmd/slo/create_test.go
+++ b/cmd/slo/create_test.go
@@ -144,6 +144,39 @@ func TestCreate_FlagsWithDescription(t *testing.T) {
 	}
 }
 
+func TestCreate_ExplicitZeroTarget(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		if body["target_per_million"] != float64(0) {
+			t.Errorf("target_per_million = %v, want 0", body["target_per_million"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":                 "slo-new",
+			"name":               "Availability",
+			"target_per_million": 0,
+			"time_period_days":   30,
+			"sli":                map[string]any{"alias": "sli.availability"},
+		})
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"create", "--dataset", "test-dataset",
+		"--name", "Availability",
+		"--sli-alias", "sli.availability",
+		"--target", "0",
+		"--time-period", "30",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestCreate_MissingRequiredFlags(t *testing.T) {
 	for _, tc := range []struct {
 		name string


### PR DESCRIPTION
Closes #171.

Four commands used Go zero-value comparison to detect unset flags, conflating "flag not passed" with "flag passed an explicit zero". Each now uses `cmd.Flags().Changed(...)`, matching the sibling update commands that already do this.

- `slo create`: the required-flag check rejected an explicit `--target 0` / `--time-period 0`. It now keys off `Changed("target")` and `Changed("time-period")`, so a legitimate zero target is accepted.
- `slo burn-alert create`: `--exhaustion-minutes 0`, `--budget-rate-window-minutes 0`, and `--budget-rate-threshold 0` were rejected when explicitly set. `cmd` is threaded into `runBurnAlertCreateFromFlags` and the guards use `Changed(...)`.
- `column update`: a no-flag invocation did a pointless GET+PUT that bumped `updated_at`. It now requires at least one of `--description` / `--hidden`, mirroring `column calculated update`.
- `dataset update`: a partial update clobbered unspecified fields because `DatasetUpdatePayload` declares `Description` and `ExpandJsonDepth` without `omitempty`, so their zero values always serialized and the PATCH treated them as "set to empty". The request body is now a `map[string]any` containing only the changed keys, sent via `UpdateDatasetWithBodyWithResponse`, leaving the generated struct untouched.

Added tests covering each case: explicit `--target 0` accepted, explicit `--exhaustion-minutes 0` accepted, no-flag `column update` errors non-zero, and `dataset update --description x` omits `expand_json_depth` from the request body.
