### PR TITLE
fix(cli): validate enum flags client-side

### DIFF
--- a/cmd/column/create.go
+++ b/cmd/column/create.go
@@ -3,12 +3,21 @@ package column
 import (
 	"fmt"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
+
+var columnTypes = []string{
+	string(api.String),
+	string(api.Float),
+	string(api.Integer),
+	string(api.Boolean),
+	string(api.Histogram),
+}
 
 func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	var (
@@ -46,7 +55,7 @@ func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&keyName, "key-name", "", "Column key name (required)")
-	cmd.Flags().StringVar(&colType, "type", "", "Column type: string, float, integer, boolean")
+	cmd.Flags().StringVar(&colType, "type", "", "Column type: string, float, integer, boolean, histogram")
 	cmd.Flags().StringVar(&description, "description", "", "Column description")
 	cmd.Flags().BoolVar(&hidden, "hidden", false, "Hide column from autocomplete")
 
@@ -56,6 +65,10 @@ func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 func runColumnCreate(cmd *cobra.Command, opts *options.RootOptions, dataset, keyName, colType, description string, hidden bool) error {
 	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
+		return err
+	}
+
+	if err := command.ValidateEnum("type", colType, columnTypes); err != nil {
 		return err
 	}
 

--- a/cmd/column/create_test.go
+++ b/cmd/column/create_test.go
@@ -54,6 +54,23 @@ func TestCreate(t *testing.T) {
 	}
 }
 
+func TestCreate_InvalidType(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("API should not be called for invalid type")
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"create", "--dataset", "my-dataset", "--key-name", "duration_ms", "--type", "bogus"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid type")
+	}
+	want := `invalid --type "bogus": must be one of string, float, integer, boolean, histogram`
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
 func TestCreate_MissingKeyName_NonInteractive(t *testing.T) {
 	opts, _ := setupTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	opts.IOStreams.SetNeverPrompt(true)

--- a/cmd/command/enum.go
+++ b/cmd/command/enum.go
@@ -1,0 +1,21 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidateEnum reports whether value is one of allowed, returning a consistent
+// error naming the flag and listing the accepted values otherwise. An empty
+// value passes; callers gate on presence separately.
+func ValidateEnum(flag, value string, allowed []string) error {
+	if value == "" {
+		return nil
+	}
+	for _, a := range allowed {
+		if value == a {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid --%s %q: must be one of %s", flag, value, strings.Join(allowed, ", "))
+}

--- a/cmd/command/enum_test.go
+++ b/cmd/command/enum_test.go
@@ -1,0 +1,43 @@
+package command
+
+import "testing"
+
+func TestValidateEnum(t *testing.T) {
+	allowed := []string{"ingest", "configuration"}
+
+	for _, tc := range []struct {
+		name    string
+		value   string
+		wantErr string
+	}{
+		{
+			name:  "empty passes",
+			value: "",
+		},
+		{
+			name:  "allowed value passes",
+			value: "ingest",
+		},
+		{
+			name:    "invalid value reports allowed set",
+			value:   "bogus",
+			wantErr: `invalid --key-type "bogus": must be one of ingest, configuration`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateEnum("key-type", tc.value, allowed)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error %q, got nil", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Errorf("error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/environment/create.go
+++ b/cmd/environment/create.go
@@ -3,6 +3,7 @@ package environment
 import (
 	"fmt"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
@@ -25,6 +26,9 @@ func NewCreateCmd(opts *options.RootOptions, team *string) *cobra.Command {
 			if err := opts.RequireTeam(team); err != nil {
 				return err
 			}
+			if err := command.ValidateEnum("color", color, environmentColors); err != nil {
+				return err
+			}
 			clearProtection := cmd.Flags().Changed("delete-protected") && !deleteProtected
 			return runEnvironmentCreate(cmd, opts, *team, name, desc, color, clearProtection)
 		},
@@ -32,7 +36,7 @@ func NewCreateCmd(opts *options.RootOptions, team *string) *cobra.Command {
 
 	cmd.Flags().StringVar(&name, "name", "", "Environment name")
 	cmd.Flags().StringVar(&desc, "description", "", "Environment description")
-	cmd.Flags().StringVar(&color, "color", "", "Environment color")
+	cmd.Flags().StringVar(&color, "color", "", colorFlagUsage())
 	cmd.Flags().BoolVar(&deleteProtected, "delete-protected", true, "Protect environment from deletion")
 
 	return cmd

--- a/cmd/environment/environment.go
+++ b/cmd/environment/environment.go
@@ -2,12 +2,30 @@ package environment
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/output"
 	"github.com/spf13/cobra"
 )
+
+var environmentColors = []string{
+	string(api.Blue),
+	string(api.Gold),
+	string(api.Green),
+	string(api.LightBlue),
+	string(api.LightGold),
+	string(api.LightGreen),
+	string(api.LightPurple),
+	string(api.LightRed),
+	string(api.Purple),
+	string(api.Red),
+}
+
+func colorFlagUsage() string {
+	return "Environment color: " + strings.Join(environmentColors, ", ")
+}
 
 func NewCmd(opts *options.RootOptions) *cobra.Command {
 	var team string

--- a/cmd/environment/environment_test.go
+++ b/cmd/environment/environment_test.go
@@ -377,6 +377,40 @@ func TestDelete_MissingArg(t *testing.T) {
 	}
 }
 
+func TestCreate_InvalidColor(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("API should not be called for invalid color")
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"create", "--team", "my-team", "--name", "prod", "--color", "magenta"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid color")
+	}
+	want := `invalid --color "magenta": must be one of blue, gold, green, lightBlue, lightGold, lightGreen, lightPurple, lightRed, purple, red`
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestUpdate_InvalidColor(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("API should not be called for invalid color")
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"update", "env-1", "--team", "my-team", "--color", "magenta"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid color")
+	}
+	want := `invalid --color "magenta": must be one of blue, gold, green, lightBlue, lightGold, lightGreen, lightPurple, lightRed, purple, red`
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
 func TestCreate(t *testing.T) {
 	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/2/teams/my-team/environments" {

--- a/cmd/environment/update.go
+++ b/cmd/environment/update.go
@@ -3,6 +3,7 @@ package environment
 import (
 	"fmt"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
@@ -24,12 +25,15 @@ func NewUpdateCmd(opts *options.RootOptions, team *string) *cobra.Command {
 			if err := opts.RequireTeam(team); err != nil {
 				return err
 			}
+			if err := command.ValidateEnum("color", color, environmentColors); err != nil {
+				return err
+			}
 			return runEnvironmentUpdate(cmd, opts, *team, args[0], desc, color, deleteProtected)
 		},
 	}
 
 	cmd.Flags().StringVar(&desc, "description", "", "Environment description")
-	cmd.Flags().StringVar(&color, "color", "", "Environment color")
+	cmd.Flags().StringVar(&color, "color", "", colorFlagUsage())
 	cmd.Flags().BoolVar(&deleteProtected, "delete-protected", false, "Protect environment from deletion")
 
 	return cmd

--- a/cmd/key/key_test.go
+++ b/cmd/key/key_test.go
@@ -129,6 +129,33 @@ func TestList_WithTypeFilter(t *testing.T) {
 	}
 }
 
+func TestList_InvalidKeyType(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		flag string
+	}{
+		{name: "key type flag", flag: "--key-type"},
+		{name: "deprecated type alias", flag: "--type"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts, _ := setupTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				t.Error("API should not be called for invalid key type")
+			}))
+
+			cmd := NewCmd(opts)
+			cmd.SetArgs([]string{"--team", "my-team", "list", tc.flag, "bogus"})
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("expected error for invalid key type")
+			}
+			want := `invalid --key-type "bogus": must be one of ingest, configuration`
+			if err.Error() != want {
+				t.Errorf("error = %q, want %q", err.Error(), want)
+			}
+		})
+	}
+}
+
 func TestList_Empty(t *testing.T) {
 	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/vnd.api+json")

--- a/cmd/key/list.go
+++ b/cmd/key/list.go
@@ -4,11 +4,17 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
+
+var keyTypes = []string{
+	string(api.Ingest),
+	string(api.Configuration),
+}
 
 func NewListCmd(opts *options.RootOptions, team *string) *cobra.Command {
 	var (
@@ -40,6 +46,10 @@ func NewListCmd(opts *options.RootOptions, team *string) *cobra.Command {
 }
 
 func runKeyList(ctx context.Context, opts *options.RootOptions, team, filterType string) error {
+	if err := command.ValidateEnum("key-type", filterType, keyTypes); err != nil {
+		return err
+	}
+
 	client, err := opts.Client(config.KeyManagement)
 	if err != nil {
 		return err

--- a/cmd/marker/create.go
+++ b/cmd/marker/create.go
@@ -42,6 +42,15 @@ func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 				message = v
 			}
 
+			if !opts.IOStreams.CanPrompt() {
+				if markerType == "" {
+					return fmt.Errorf("--type is required in non-interactive mode")
+				}
+				if message == "" {
+					return fmt.Errorf("--message is required in non-interactive mode")
+				}
+			}
+
 			if !cmd.Flags().Changed("start-time") {
 				startTime = int(time.Now().Unix())
 			}

--- a/cmd/marker/create_test.go
+++ b/cmd/marker/create_test.go
@@ -57,6 +57,42 @@ func TestCreate(t *testing.T) {
 	}
 }
 
+func TestCreate_RequiredFlags_NonInteractive(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "missing type",
+			args:    []string{"create", "--dataset", "test-dataset", "--message", "v2.0.0"},
+			wantErr: "--type is required in non-interactive mode",
+		},
+		{
+			name:    "missing message",
+			args:    []string{"create", "--dataset", "test-dataset", "--type", "deploy"},
+			wantErr: "--message is required in non-interactive mode",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts, _ := setupTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				t.Error("API should not be called when required flags are missing")
+			}))
+			opts.IOStreams.SetNeverPrompt(true)
+
+			cmd := NewCmd(opts)
+			cmd.SetArgs(tc.args)
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("expected error for missing required flag")
+			}
+			if err.Error() != tc.wantErr {
+				t.Errorf("error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestCreate_DefaultStartTime(t *testing.T) {
 	opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
@@ -79,7 +115,7 @@ func TestCreate_DefaultStartTime(t *testing.T) {
 	}))
 
 	cmd := NewCmd(opts)
-	cmd.SetArgs([]string{"create", "--dataset", "test-dataset", "--type", "deploy"})
+	cmd.SetArgs([]string{"create", "--dataset", "test-dataset", "--type", "deploy", "--message", "v2.0.0"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Closes #175.

Four commands deferred validation of constrained inputs to the server, so a bad `--type`, `--color`, or `--key-type` produced a confusing API error and an empty-but-valid `marker create` request silently POSTed nothing useful. This validates those flags against the known sets before the request goes out.

Adds `command.ValidateEnum(flag, value, allowed)` in `cmd/command/enum.go`, which returns a consistent `invalid --<flag> %q: must be one of <list>` error (and passes empty values, since presence is gated separately). Each call site sources its allowed set from the generated constants so the lists can't drift:

- `column create` validates `--type` against `CreateColumnType` (`string`, `float`, `integer`, `boolean`, `histogram`) and lists the full set in the flag help.
- `environment create` and `environment update` validate `--color` against `EnvironmentColor`, with the allowed colors in the `--color` help.
- `key list` validates `--key-type` (and the deprecated `--type` alias) against `ListApiKeysParamsFilterType`, mirroring `key create`.
- `marker create` requires `--type` and `--message` in non-interactive mode instead of POSTing an empty marker.

Table-driven tests cover each invalid-value path and the marker required-flag path.
