### PR TITLE
fix(output): reconcile table fields with JSON

### DIFF
--- a/cmd/board/board.go
+++ b/cmd/board/board.go
@@ -2,6 +2,8 @@ package board
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
@@ -46,8 +48,52 @@ type boardDetail struct {
 
 func writeBoardDetail(opts *options.RootOptions, detail boardDetail) error {
 	fields := output.FieldsFromTags(detail)
-	fields = append(fields, output.Field{Label: "Preset Filters", Value: string(detail.PresetFilters)})
+	fields = append(fields,
+		output.Field{Label: "Panels", Value: formatPanels(detail.Panels)},
+		output.Field{Label: "Preset Filters", Value: string(detail.PresetFilters)},
+	)
 	return opts.OutputWriter().WriteFields(detail, fields)
+}
+
+// formatPanels summarizes a board's panels as one line per panel, pairing each
+// panel's type with the query, SLO, or text it references. An empty raw message
+// (no panels) renders as an em-dash.
+func formatPanels(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return "—"
+	}
+
+	var panels []struct {
+		Type       string `json:"type"`
+		QueryPanel *struct {
+			QueryId string `json:"query_id"`
+		} `json:"query_panel"`
+		SLOPanel *struct {
+			SloId string `json:"slo_id"`
+		} `json:"slo_panel"`
+		TextPanel *struct {
+			Content string `json:"content"`
+		} `json:"text_panel"`
+	}
+	if err := json.Unmarshal(raw, &panels); err != nil {
+		return string(raw)
+	}
+	if len(panels) == 0 {
+		return "—"
+	}
+
+	lines := make([]string, len(panels))
+	for i, p := range panels {
+		switch {
+		case p.QueryPanel != nil:
+			lines[i] = fmt.Sprintf("%s (query %s)", p.Type, p.QueryPanel.QueryId)
+		case p.SLOPanel != nil:
+			lines[i] = fmt.Sprintf("%s (slo %s)", p.Type, p.SLOPanel.SloId)
+		default:
+			lines[i] = p.Type
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 func boardToDetail(b api.Board) boardDetail {

--- a/cmd/board/get_test.go
+++ b/cmd/board/get_test.go
@@ -75,6 +75,64 @@ func TestGet(t *testing.T) {
 	}
 }
 
+func TestGet_TablePanels(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":   "abc123",
+			"name": "My Board",
+			"type": "flexible",
+			"panels": []map[string]any{
+				{
+					"type":        "query",
+					"query_panel": map[string]any{"query_id": "q1", "query_annotation_id": "qa1"},
+				},
+				{
+					"type":       "text",
+					"text_panel": map[string]any{"content": "Hello world"},
+				},
+			},
+		})
+	}))
+	opts.Format = "table"
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"get", "abc123"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	out := ts.OutBuf.String()
+	for _, want := range []string{"Panels", "query (query q1)", "text"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestGet_TableNoPanels(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":   "abc123",
+			"name": "My Board",
+			"type": "flexible",
+		})
+	}))
+	opts.Format = "table"
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"get", "abc123"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	out := ts.OutBuf.String()
+	if !strings.Contains(out, "Panels") || !strings.Contains(out, "—") {
+		t.Errorf("table output should show Panels row with em-dash:\n%s", out)
+	}
+}
+
 func TestGet_NoPresetFilters(t *testing.T) {
 	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/cmd/board/view.go
+++ b/cmd/board/view.go
@@ -2,6 +2,8 @@ package board
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
@@ -43,7 +45,39 @@ func viewResponseToDetail(v api.BoardViewResponse) viewDetail {
 }
 
 func writeViewDetail(opts *options.RootOptions, detail viewDetail) error {
-	return opts.OutputWriter().WriteFields(detail, output.FieldsFromTags(detail))
+	fields := output.FieldsFromTags(detail)
+	fields = append(fields, output.Field{Label: "Filters", Value: formatFilters(detail.Filters)})
+	return opts.OutputWriter().WriteFields(detail, fields)
+}
+
+// formatFilters renders a view's filters as one "column operation value" line
+// per filter. An empty raw message (no filters) renders as an em-dash.
+func formatFilters(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return "—"
+	}
+
+	var filters []struct {
+		Column    string `json:"column"`
+		Operation string `json:"operation"`
+		Value     any    `json:"value,omitempty"`
+	}
+	if err := json.Unmarshal(raw, &filters); err != nil {
+		return string(raw)
+	}
+	if len(filters) == 0 {
+		return "—"
+	}
+
+	lines := make([]string, len(filters))
+	for i, f := range filters {
+		if f.Value != nil {
+			lines[i] = fmt.Sprintf("%s %s %v", f.Column, f.Operation, f.Value)
+		} else {
+			lines[i] = fmt.Sprintf("%s %s", f.Column, f.Operation)
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 func NewViewCmd(opts *options.RootOptions) *cobra.Command {

--- a/cmd/board/view_get_test.go
+++ b/cmd/board/view_get_test.go
@@ -43,6 +43,56 @@ func TestViewGet(t *testing.T) {
 	}
 }
 
+func TestViewGet_TableFilters(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":   "v1",
+			"name": "View One",
+			"filters": []map[string]any{
+				{"column": "env", "operation": "=", "value": "prod"},
+				{"column": "duration_ms", "operation": ">", "value": 100},
+			},
+		})
+	}))
+	opts.Format = "table"
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"view", "get", "v1", "--board", "board-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	out := ts.OutBuf.String()
+	for _, want := range []string{"Filters", "env = prod", "duration_ms > 100"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestViewGet_TableNoFilters(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":   "v1",
+			"name": "View One",
+		})
+	}))
+	opts.Format = "table"
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"view", "get", "v1", "--board", "board-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	out := ts.OutBuf.String()
+	if !strings.Contains(out, "Filters") || !strings.Contains(out, "—") {
+		t.Errorf("table output should show Filters row with em-dash:\n%s", out)
+	}
+}
+
 func TestViewGet_NotFound(t *testing.T) {
 	opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/cmd/dataset/definition_get.go
+++ b/cmd/dataset/definition_get.go
@@ -50,17 +50,20 @@ func writeDefinitions(opts *options.RootOptions, defs *api.DatasetDefinitions) e
 	var rows [][]string
 	for i := range rt.NumField() {
 		field := rv.Field(i)
-		if field.IsNil() {
-			continue
-		}
-		def := field.Interface().(*api.DatasetDefinition)
 		jsonTag := rt.Field(i).Tag.Get("json")
 		name, _, _ := strings.Cut(jsonTag, ",")
-		colType := ""
-		if def.ColumnType != nil {
-			colType = string(*def.ColumnType)
+
+		column, colType := "—", "—"
+		if !field.IsNil() {
+			def := field.Interface().(*api.DatasetDefinition)
+			if def.Name != "" {
+				column = def.Name
+			}
+			if def.ColumnType != nil {
+				colType = string(*def.ColumnType)
+			}
 		}
-		rows = append(rows, []string{name, def.Name, colType})
+		rows = append(rows, []string{name, column, colType})
 	}
 
 	return opts.OutputWriter().WriteDynamic(defs, output.DynamicTableDef{

--- a/cmd/dataset/definition_get_test.go
+++ b/cmd/dataset/definition_get_test.go
@@ -59,6 +59,56 @@ func TestDefinitionGet(t *testing.T) {
 	}
 }
 
+func TestDefinitionGet_TableAllFields(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"duration_ms": map[string]any{
+				"name":        "duration_ms",
+				"column_type": "column",
+			},
+		})
+	}))
+	opts.Format = "table"
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"definition", "get", "my-dataset"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	out := ts.OutBuf.String()
+	// The set field renders its column and type.
+	if !strings.Contains(out, "duration_ms") {
+		t.Errorf("table output missing set field:\n%s", out)
+	}
+	// Every other definition field renders a row with an em-dash for unset.
+	for _, want := range []string{"trace_id", "service_name", "error", "—"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table output missing unset field %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestDefinitionGet_TableEmpty(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	opts.Format = "table"
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"definition", "get", "my-dataset"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	out := ts.OutBuf.String()
+	if !strings.Contains(out, "duration_ms") || !strings.Contains(out, "—") {
+		t.Errorf("all-unset definition should still list every field with em-dashes:\n%s", out)
+	}
+}
+
 func TestDefinitionGet_NoKey(t *testing.T) {
 	ts := iostreams.Test(t)
 	opts := &options.RootOptions{

--- a/cmd/dataset/list.go
+++ b/cmd/dataset/list.go
@@ -18,7 +18,7 @@ type datasetItem struct {
 	Description string  `json:"description,omitempty" col:"Description"`
 	Columns     *int    `json:"columns,omitempty"`
 	LastWritten *string `json:"last_written,omitempty"`
-	CreatedAt   string  `json:"created_at"`
+	CreatedAt   string  `json:"created_at" col:"Created"`
 }
 
 var datasetListTable = func() output.TableDef {

--- a/cmd/dataset/list_test.go
+++ b/cmd/dataset/list_test.go
@@ -94,6 +94,33 @@ func TestList(t *testing.T) {
 	}
 }
 
+func TestList_TableCreated(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"name":       "production",
+				"slug":       "production",
+				"created_at": "2024-06-01T00:00:00Z",
+			},
+		})
+	}))
+	opts.Format = "table"
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"list"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	out := ts.OutBuf.String()
+	for _, want := range []string{"CREATED", "2024-06-01T00:00:00Z"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table output missing %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestList_Empty(t *testing.T) {
 	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/cmd/recipient/list.go
+++ b/cmd/recipient/list.go
@@ -11,7 +11,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var recipientListTable = output.TableFromTags[recipientItem]()
+var recipientListTable = output.TableDef{Columns: []output.Column{
+	{Header: "ID", Value: func(v any) string { return v.(recipientDetail).ID }},
+	{Header: "Type", Value: func(v any) string { return v.(recipientDetail).Type }},
+	{Header: "Target", Value: func(v any) string { return extractTarget(v.(recipientDetail)) }},
+}}
 
 func NewListCmd(opts *options.RootOptions) *cobra.Command {
 	return &cobra.Command{
@@ -43,10 +47,5 @@ func runList(ctx context.Context, opts *options.RootOptions) error {
 		return err
 	}
 
-	items := make([]recipientItem, len(details))
-	for i, d := range details {
-		items[i] = detailToItem(d)
-	}
-
-	return opts.OutputWriterList().Write(items, recipientListTable)
+	return opts.OutputWriterList().Write(details, recipientListTable)
 }

--- a/cmd/recipient/recipient.go
+++ b/cmd/recipient/recipient.go
@@ -26,12 +26,6 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 	return cmd
 }
 
-type recipientItem struct {
-	ID     string `json:"id" col:"ID"`
-	Type   string `json:"type" col:"Type"`
-	Target string `json:"target,omitempty" col:"Target"`
-}
-
 type recipientDetail struct {
 	ID        string         `json:"id" detail:"ID"`
 	Type      string         `json:"type" detail:"Type"`
@@ -94,15 +88,6 @@ func mapToDetail(raw map[string]any) recipientDetail {
 	}
 
 	return d
-}
-
-func detailToItem(d recipientDetail) recipientItem {
-	item := recipientItem{
-		ID:   d.ID,
-		Type: d.Type,
-	}
-	item.Target = extractTarget(d)
-	return item
 }
 
 func extractTarget(d recipientDetail) string {

--- a/cmd/recipient/recipient_test.go
+++ b/cmd/recipient/recipient_test.go
@@ -134,7 +134,7 @@ func TestList(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var items []recipientItem
+	var items []recipientDetail
 	if err := json.Unmarshal(ts.OutBuf.Bytes(), &items); err != nil {
 		t.Fatalf("unmarshal output: %v", err)
 	}
@@ -147,14 +147,47 @@ func TestList(t *testing.T) {
 	if items[0].Type != "email" {
 		t.Errorf("items[0].Type = %q, want %q", items[0].Type, "email")
 	}
-	if items[0].Target != "test@example.com" {
-		t.Errorf("items[0].Target = %q, want %q", items[0].Target, "test@example.com")
+	if got, _ := items[0].Details["email_address"].(string); got != "test@example.com" {
+		t.Errorf("items[0].Details[email_address] = %q, want %q", got, "test@example.com")
+	}
+	if items[0].CreatedAt != "2025-01-01T00:00:00Z" {
+		t.Errorf("items[0].CreatedAt = %q, want %q", items[0].CreatedAt, "2025-01-01T00:00:00Z")
+	}
+	if items[0].UpdatedAt != "2025-01-01T00:00:00Z" {
+		t.Errorf("items[0].UpdatedAt = %q, want %q", items[0].UpdatedAt, "2025-01-01T00:00:00Z")
 	}
 	if items[1].Type != "slack" {
 		t.Errorf("items[1].Type = %q, want %q", items[1].Type, "slack")
 	}
-	if items[1].Target != "#alerts" {
-		t.Errorf("items[1].Target = %q, want %q", items[1].Target, "#alerts")
+	if got, _ := items[1].Details["slack_channel"].(string); got != "#alerts" {
+		t.Errorf("items[1].Details[slack_channel] = %q, want %q", got, "#alerts")
+	}
+}
+
+func TestList_Table(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{
+				"id": "r1",
+				"type": "email",
+				"details": {"email_address": "test@example.com"}
+			}
+		]`))
+	}))
+	opts.Format = "table"
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"list"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	out := ts.OutBuf.String()
+	for _, want := range []string{"r1", "email", "test@example.com"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table output missing %q:\n%s", want, out)
+		}
 	}
 }
 
@@ -170,7 +203,7 @@ func TestList_Empty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var items []recipientItem
+	var items []recipientDetail
 	if err := json.Unmarshal(ts.OutBuf.Bytes(), &items); err != nil {
 		t.Fatalf("unmarshal output: %v", err)
 	}


### PR DESCRIPTION
Closes #174. Table and JSON output exposed different field sets for the same data, so a value visible in one format silently vanished in the other. Each change below reconciles a command's table projection with its JSON projection.

Board get now summarizes the board's panels in the table, appending a `Panels` field that pairs each panel's type with the query or SLO it references (one line per panel, an em-dash when there are none). JSON already carried the panels; the table caught up.

Board view get now renders the view's defining filters, appending a `Filters` field that prints one `column operation value` line per filter so the table stops hiding the filters that scope the view.

Dataset list tags `created_at` as a `Created` column so the table shows the creation timestamp the JSON list already included.

Recipient list now serializes the full recipient records for JSON, preserving each recipient's `details` plus `created_at` and `updated_at`, which matches the shape `recipient get` returns. It previously emitted a lossy flattened `{id, type, target}`. The table still shows a `Target` column derived from the recipient's details. This is a deliberate JSON shape change worth a reviewer's attention.

Dataset definition get now emits a row for every definition field instead of skipping unset ones, rendering an em-dash where a field has no mapping. An all-unset definition now lists every field, so the table doubles as a discoverable reference.

The output helpers are unchanged; each change stays local to its resource package. Tests cover the panels summary, the filters rendering, the `Created` column, the recipient list preserving details and timestamps in JSON, and definition get listing all fields with em-dashes for unset mappings.
