### PR TITLE
fix(mcp): authenticate via OAuth, not API key

### DIFF
--- a/cmd/auth/logout.go
+++ b/cmd/auth/logout.go
@@ -57,6 +57,16 @@ func runAuthLogout(opts *options.RootOptions, keyType string) error {
 		deleted = append(deleted, logoutResult{Type: string(kt)})
 	}
 
+	// A full logout (no --key-type) also clears any stored MCP OAuth token set.
+	if keyType == "" {
+		err := config.DeleteMCPToken(profile)
+		if err == nil {
+			deleted = append(deleted, logoutResult{Type: "mcp"})
+		} else if !errors.Is(err, keyring.ErrNotFound) {
+			return fmt.Errorf("deleting MCP token: %w", err)
+		}
+	}
+
 	if len(deleted) == 0 {
 		return fmt.Errorf("no keys configured for profile %q", profile)
 	}

--- a/cmd/mcp/call.go
+++ b/cmd/mcp/call.go
@@ -12,7 +12,6 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/fields"
 	"github.com/bendrucker/honeycomb-cli/internal/jq"
 	"github.com/bendrucker/honeycomb-cli/internal/output"
@@ -21,6 +20,7 @@ import (
 
 type callOptions struct {
 	root    *options.RootOptions
+	token   *string
 	factory clientFactory
 
 	fieldFlags []string
@@ -29,8 +29,8 @@ type callOptions struct {
 	jqExpr     string
 }
 
-func newCallCmd(opts *options.RootOptions, factory clientFactory) *cobra.Command {
-	o := &callOptions{root: opts, factory: factory}
+func newCallCmd(opts *options.RootOptions, token *string, factory clientFactory) *cobra.Command {
+	o := &callOptions{root: opts, token: token, factory: factory}
 
 	cmd := &cobra.Command{
 		Use:   "call <tool-name>",
@@ -60,18 +60,8 @@ func runCall(cmd *cobra.Command, o *callOptions, toolName string) error {
 		return err
 	}
 
-	factory := o.factory
-	if factory == nil {
-		factory = defaultClientFactory
-	}
-
-	key, err := o.root.RequireKey(config.KeyConfig)
-	if err != nil {
-		return err
-	}
-
 	ctx := cmd.Context()
-	c, err := factory(ctx, o.root.ResolveMCPUrl(), key)
+	c, err := connect(ctx, o.root, derefToken(o.token), o.factory)
 	if err != nil {
 		return err
 	}

--- a/cmd/mcp/call_test.go
+++ b/cmd/mcp/call_test.go
@@ -22,7 +22,7 @@ func TestCall(t *testing.T) {
 		},
 	)
 
-	cmd := newCallCmd(opts, testFactory(srv))
+	cmd := newCallCmd(opts, nil, testFactory(srv))
 	cmd.SetArgs([]string{"echo", "-f", "message=hello"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
@@ -53,7 +53,7 @@ func TestCall_ToolError(t *testing.T) {
 		},
 	)
 
-	cmd := newCallCmd(opts, testFactory(srv))
+	cmd := newCallCmd(opts, nil, testFactory(srv))
 	cmd.SetArgs([]string{"fail"})
 	err := cmd.Execute()
 	if err == nil {
@@ -73,7 +73,7 @@ func TestCall_JQ(t *testing.T) {
 		},
 	)
 
-	cmd := newCallCmd(opts, testFactory(srv))
+	cmd := newCallCmd(opts, nil, testFactory(srv))
 	cmd.SetArgs([]string{"data", "--jq", ".content[0].text"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
@@ -96,7 +96,7 @@ func TestCall_Table(t *testing.T) {
 		},
 	)
 
-	cmd := newCallCmd(opts, testFactory(srv))
+	cmd := newCallCmd(opts, nil, testFactory(srv))
 	cmd.SetArgs([]string{"echo", "-f", "message=hello"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
@@ -119,7 +119,7 @@ func TestCall_NonTextContentJSON(t *testing.T) {
 		},
 	)
 
-	cmd := newCallCmd(opts, testFactory(srv))
+	cmd := newCallCmd(opts, nil, testFactory(srv))
 	cmd.SetArgs([]string{"image"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
@@ -165,7 +165,7 @@ func TestCall_NonTextContentTable(t *testing.T) {
 		},
 	)
 
-	cmd := newCallCmd(opts, testFactory(srv))
+	cmd := newCallCmd(opts, nil, testFactory(srv))
 	cmd.SetArgs([]string{"image"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
@@ -235,7 +235,7 @@ func TestCall_MutuallyExclusiveFlags(t *testing.T) {
 	srv, opts, _ := setupMCPTest(t)
 	srv.AddTool(mcp.NewTool("test"), nil)
 
-	cmd := newCallCmd(opts, testFactory(srv))
+	cmd := newCallCmd(opts, nil, testFactory(srv))
 	cmd.SetArgs([]string{"test", "-f", "key=val", "--input", "file.json"})
 	err := cmd.Execute()
 	if err == nil {

--- a/cmd/mcp/mcp.go
+++ b/cmd/mcp/mcp.go
@@ -2,7 +2,11 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
+	"strings"
+	"sync"
 
 	mcpclient "github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
@@ -12,32 +16,110 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type clientFactory func(ctx context.Context, mcpURL, key string) (*mcpclient.Client, error)
+// tokenEnvVar holds a pre-issued MCP access token for headless (CI) use,
+// bypassing the interactive browser flow.
+const tokenEnvVar = "HONEYCOMB_MCP_TOKEN"
 
-func defaultClientFactory(ctx context.Context, mcpURL, key string) (*mcpclient.Client, error) {
-	c, err := mcpclient.NewStreamableHttpClient(mcpURL,
+// connectOptions carries everything the client factory needs to authenticate
+// and open an MCP session. It deliberately excludes the Honeycomb config API
+// key: that credential is not accepted by the OAuth-protected MCP server.
+type connectOptions struct {
+	root   *options.RootOptions
+	mcpURL string
+	// token, when set, is a pre-issued bearer token used for headless auth.
+	token string
+}
+
+// clientFactory opens an initialized MCP client session.
+type clientFactory func(ctx context.Context, conn connectOptions) (*mcpclient.Client, error)
+
+var experimentalOnce sync.Once
+
+// warnExperimental prints a one-time stderr notice that the command is
+// experimental. It fires once per process so repeated calls in tests or
+// scripts do not spam the notice.
+func warnExperimental(opts *options.RootOptions) {
+	experimentalOnce.Do(func() {
+		_, _ = fmt.Fprintln(opts.IOStreams.Err, "Warning: 'honeycomb mcp' is experimental and may change.")
+	})
+}
+
+func newInitializeRequest() mcp.InitializeRequest {
+	return mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+			ClientInfo: mcp.Implementation{
+				Name:    clientName,
+				Version: "0.1.0",
+			},
+		},
+	}
+}
+
+// defaultClientFactory connects to the MCP server using OAuth. With a headless
+// token it sends a static bearer; otherwise it relies on the keyring token
+// store and, when the server reports authorization is required, runs the
+// interactive authorization-code flow once and retries.
+func defaultClientFactory(ctx context.Context, conn connectOptions) (*mcpclient.Client, error) {
+	if conn.token != "" {
+		return connectWithToken(ctx, conn)
+	}
+	return connectWithOAuth(ctx, conn)
+}
+
+func connectWithToken(ctx context.Context, conn connectOptions) (*mcpclient.Client, error) {
+	c, err := mcpclient.NewStreamableHttpClient(conn.mcpURL,
 		transport.WithHTTPHeaders(map[string]string{
-			"Authorization": "Bearer " + key,
+			"Authorization": "Bearer " + conn.token,
 		}),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating MCP client: %w", err)
 	}
+	return startAndInitialize(ctx, c)
+}
 
+func connectWithOAuth(ctx context.Context, conn connectOptions) (*mcpclient.Client, error) {
+	listener, redirectURI, err := newLoopbackListener()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = listener.Close() }()
+
+	c, err := newOAuthClient(conn.mcpURL, conn.root.ActiveProfile(), redirectURI)
+	if err != nil {
+		return nil, err
+	}
+
+	session, err := startAndInitialize(ctx, c)
+	if err == nil {
+		return session, nil
+	}
+
+	if !mcpclient.IsOAuthAuthorizationRequiredError(err) {
+		return nil, err
+	}
+
+	if !conn.root.IOStreams.CanPrompt() {
+		_ = c.Close()
+		return nil, errNonInteractiveAuth
+	}
+
+	if authErr := authorizeInteractive(ctx, conn.root.IOStreams, err, listener); authErr != nil {
+		_ = c.Close()
+		return nil, authErr
+	}
+
+	return startAndInitialize(ctx, c)
+}
+
+func startAndInitialize(ctx context.Context, c *mcpclient.Client) (*mcpclient.Client, error) {
 	if err := c.Start(ctx); err != nil {
+		_ = c.Close()
 		return nil, fmt.Errorf("starting MCP client: %w", err)
 	}
 
-	_, err = c.Initialize(ctx, mcp.InitializeRequest{
-		Params: mcp.InitializeParams{
-			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
-			ClientInfo: mcp.Implementation{
-				Name:    "honeycomb-cli",
-				Version: "0.1.0",
-			},
-		},
-	})
-	if err != nil {
+	if _, err := c.Initialize(ctx, newInitializeRequest()); err != nil {
 		_ = c.Close()
 		return nil, fmt.Errorf("initializing MCP session: %w", err)
 	}
@@ -45,16 +127,104 @@ func defaultClientFactory(ctx context.Context, mcpURL, key string) (*mcpclient.C
 	return c, nil
 }
 
+var errNonInteractiveAuth = errors.New(
+	"MCP authorization required but session is non-interactive; " +
+		"set " + tokenEnvVar + " (or pass --token) with a pre-issued MCP access token to authenticate without a browser",
+)
+
+const mcpLongDescription = `Interact with the Honeycomb MCP server.
+
+EXPERIMENTAL: this command and its authentication flow may change.
+
+Authentication:
+  The Honeycomb MCP server is an OAuth 2.1 protected resource. The CLI does NOT
+  use your Honeycomb config API key here. Instead it runs an OAuth
+  authorization-code flow (Dynamic Client Registration + PKCE) the first time
+  you connect, opening a browser to authorize access. Access and refresh tokens
+  are stored in your OS keyring under the active profile and refreshed
+  automatically.
+
+  For non-interactive use (CI), set HONEYCOMB_MCP_TOKEN (or pass --token) with a
+  pre-issued MCP access token to skip the browser flow.
+
+  Run 'honeycomb auth logout' to clear stored MCP tokens along with API keys.`
+
+// derefToken returns the value behind a token flag pointer, or empty when nil.
+func derefToken(token *string) string {
+	if token == nil {
+		return ""
+	}
+	return *token
+}
+
+// resolveToken returns the headless token from the --token flag, falling back
+// to the HONEYCOMB_MCP_TOKEN environment variable.
+func resolveToken(flagToken string) string {
+	if flagToken != "" {
+		return flagToken
+	}
+	return os.Getenv(tokenEnvVar)
+}
+
+// connect opens an MCP session for a subcommand, applying the experimental
+// warning, the token fallback, and the configured factory.
+func connect(ctx context.Context, opts *options.RootOptions, flagToken string, factory clientFactory) (*mcpclient.Client, error) {
+	warnExperimental(opts)
+
+	if factory == nil {
+		factory = defaultClientFactory
+	}
+
+	conn := connectOptions{
+		root:   opts,
+		mcpURL: opts.ResolveMCPUrl(),
+		token:  resolveToken(flagToken),
+	}
+
+	c, err := factory(ctx, conn)
+	if err != nil {
+		return nil, remediateAuthError(err)
+	}
+	return c, nil
+}
+
+// remediateAuthError appends actionable guidance when an error indicates the
+// MCP server rejected the request for authentication or authorization reasons.
+func remediateAuthError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, errNonInteractiveAuth) {
+		return err
+	}
+
+	msg := err.Error()
+	if mcpclient.IsOAuthAuthorizationRequiredError(err) ||
+		strings.Contains(msg, "401") || strings.Contains(msg, "403") ||
+		strings.Contains(strings.ToLower(msg), "unauthorized") ||
+		strings.Contains(strings.ToLower(msg), "forbidden") {
+		return fmt.Errorf("%w (the MCP server rejected the request as unauthenticated; "+
+			"the CLI authenticates to MCP via OAuth, not your API key: re-run interactively to "+
+			"authorize in a browser, set %s for CI, or run 'honeycomb auth logout' to clear stale "+
+			"tokens; see 'honeycomb mcp --help')", err, tokenEnvVar)
+	}
+	return err
+}
+
 func NewCmd(opts *options.RootOptions) *cobra.Command {
+	var token string
+
 	cmd := &cobra.Command{
 		Use:   "mcp",
-		Short: "Interact with the Honeycomb MCP server",
+		Short: "Interact with the Honeycomb MCP server (experimental)",
+		Long:  mcpLongDescription,
 	}
 
 	cmd.PersistentFlags().StringVar(&opts.MCPUrl, "mcp-url", "", "MCP server URL")
+	cmd.PersistentFlags().StringVar(&token, "token", "", "Pre-issued MCP access token (or set "+tokenEnvVar+")")
 
-	cmd.AddCommand(newToolsCmd(opts, nil))
-	cmd.AddCommand(newCallCmd(opts, nil))
+	cmd.AddCommand(newToolsCmd(opts, &token, nil))
+	cmd.AddCommand(newCallCmd(opts, &token, nil))
 
 	return cmd
 }

--- a/cmd/mcp/oauth.go
+++ b/cmd/mcp/oauth.go
@@ -1,0 +1,221 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os/exec"
+	"runtime"
+	"time"
+
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/zalando/go-keyring"
+
+	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/bendrucker/honeycomb-cli/internal/iostreams"
+)
+
+// clientName is the name registered with the MCP server during Dynamic Client
+// Registration and reported in the MCP handshake.
+const clientName = "honeycomb-cli"
+
+// oauthScopes are the scopes the CLI requests from the Honeycomb MCP server.
+var oauthScopes = []string{"mcp:read", "mcp:write"}
+
+// keyringTokenStore implements transport.TokenStore backed by the OS keyring,
+// persisting the OAuth token set under the {profile}:mcp entry. Tokens never
+// touch disk in plaintext and are never logged.
+type keyringTokenStore struct {
+	profile string
+}
+
+func newKeyringTokenStore(profile string) *keyringTokenStore {
+	return &keyringTokenStore{profile: profile}
+}
+
+func (s *keyringTokenStore) GetToken(ctx context.Context) (*transport.Token, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	var token transport.Token
+	err := config.GetMCPToken(s.profile, &token)
+	if errors.Is(err, keyring.ErrNotFound) {
+		return nil, transport.ErrNoToken
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading MCP token: %w", err)
+	}
+	return &token, nil
+}
+
+func (s *keyringTokenStore) SaveToken(ctx context.Context, token *transport.Token) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := config.SetMCPToken(s.profile, token); err != nil {
+		return fmt.Errorf("saving MCP token: %w", err)
+	}
+	return nil
+}
+
+// oauthConfig builds the library OAuth configuration for a profile, wiring the
+// keyring-backed token store, the requested scopes, a loopback redirect URI per
+// RFC 8252, and PKCE (S256). The config key is never referenced here.
+func oauthConfig(profile, redirectURI string) transport.OAuthConfig {
+	return transport.OAuthConfig{
+		ClientURI:   "https://github.com/bendrucker/honeycomb-cli",
+		RedirectURI: redirectURI,
+		Scopes:      oauthScopes,
+		TokenStore:  newKeyringTokenStore(profile),
+		PKCEEnabled: true,
+	}
+}
+
+// newOAuthClient constructs an OAuth-capable streamable HTTP MCP client for the
+// given URL and profile.
+func newOAuthClient(mcpURL, profile, redirectURI string) (*mcpclient.Client, error) {
+	c, err := mcpclient.NewOAuthStreamableHttpClient(mcpURL, oauthConfig(profile, redirectURI))
+	if err != nil {
+		return nil, fmt.Errorf("creating MCP client: %w", err)
+	}
+	return c, nil
+}
+
+// authorizeInteractive runs the authorization-code flow (Dynamic Client
+// Registration + PKCE S256) when the server reports that authorization is
+// required. It starts a loopback callback server, opens the browser to the
+// authorization URL, validates the returned state, and exchanges the code for
+// tokens, which the handler persists through the keyring token store.
+func authorizeInteractive(ctx context.Context, ios *iostreams.IOStreams, authErr error, listener net.Listener) error {
+	handler := mcpclient.GetOAuthHandler(authErr)
+	if handler == nil {
+		return fmt.Errorf("MCP server requires authorization but no OAuth handler was provided")
+	}
+
+	codeVerifier, err := mcpclient.GenerateCodeVerifier()
+	if err != nil {
+		return fmt.Errorf("generating PKCE verifier: %w", err)
+	}
+	codeChallenge := mcpclient.GenerateCodeChallenge(codeVerifier)
+
+	state, err := mcpclient.GenerateState()
+	if err != nil {
+		return fmt.Errorf("generating OAuth state: %w", err)
+	}
+
+	if handler.GetClientID() == "" {
+		if err := handler.RegisterClient(ctx, clientName); err != nil {
+			return fmt.Errorf("registering OAuth client: %w", err)
+		}
+	}
+
+	authURL, err := handler.GetAuthorizationURL(ctx, state, codeChallenge)
+	if err != nil {
+		return fmt.Errorf("building authorization URL: %w", err)
+	}
+
+	callbackChan := make(chan callbackParams, 1)
+	server := &http.Server{
+		Handler:           callbackHandler(callbackChan),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	go func() {
+		if serveErr := server.Serve(listener); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			callbackChan <- callbackParams{err: serveErr}
+		}
+	}()
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+
+	_, _ = fmt.Fprintf(ios.Err, "Opening browser to authorize Honeycomb MCP access.\n")
+	_, _ = fmt.Fprintf(ios.Err, "If the browser does not open, visit:\n  %s\n", authURL)
+	openBrowser(ios, authURL)
+
+	var params callbackParams
+	select {
+	case params = <-callbackChan:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	if params.err != nil {
+		return fmt.Errorf("waiting for authorization callback: %w", params.err)
+	}
+	if params.errCode != "" {
+		return fmt.Errorf("authorization denied: %s", params.errCode)
+	}
+	if params.state != state {
+		return fmt.Errorf("authorization state mismatch (possible CSRF); aborting")
+	}
+	if params.code == "" {
+		return fmt.Errorf("authorization callback returned no code")
+	}
+
+	if err := handler.ProcessAuthorizationResponse(ctx, params.code, params.state, codeVerifier); err != nil {
+		return fmt.Errorf("exchanging authorization code: %w", err)
+	}
+
+	_, _ = fmt.Fprintln(ios.Err, "Authorization successful.")
+	return nil
+}
+
+type callbackParams struct {
+	code    string
+	state   string
+	errCode string
+	err     error
+}
+
+func callbackHandler(ch chan<- callbackParams) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		params := callbackParams{
+			code:    q.Get("code"),
+			state:   q.Get("state"),
+			errCode: q.Get("error"),
+		}
+
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<!doctype html><html><body>` +
+			`<h1>Authorization complete</h1>` +
+			`<p>You can close this window and return to the terminal.</p>` +
+			`</body></html>`))
+
+		ch <- params
+	})
+	return mux
+}
+
+// newLoopbackListener binds a callback listener to a loopback address per
+// RFC 8252, letting the OS choose the port. The returned redirect URI uses
+// 127.0.0.1 with that port.
+func newLoopbackListener() (net.Listener, string, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, "", fmt.Errorf("starting loopback callback server: %w", err)
+	}
+	addr := l.Addr().(*net.TCPAddr)
+	redirectURI := fmt.Sprintf("http://127.0.0.1:%d/callback", addr.Port)
+	return l, redirectURI, nil
+}
+
+func openBrowser(ios *iostreams.IOStreams, url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	if err := cmd.Start(); err != nil {
+		_, _ = fmt.Fprintf(ios.Err, "Could not open browser automatically: %v\n", err)
+	}
+}

--- a/cmd/mcp/oauth_test.go
+++ b/cmd/mcp/oauth_test.go
@@ -1,0 +1,234 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+
+	"github.com/bendrucker/honeycomb-cli/cmd/options"
+	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/bendrucker/honeycomb-cli/internal/iostreams"
+)
+
+func TestKeyringTokenStore(t *testing.T) {
+	const profile = "tokenstore-test"
+	t.Cleanup(func() { _ = config.DeleteMCPToken(profile) })
+
+	store := newKeyringTokenStore(profile)
+	ctx := context.Background()
+
+	if _, err := store.GetToken(ctx); !errors.Is(err, transport.ErrNoToken) {
+		t.Fatalf("GetToken on empty store = %v, want ErrNoToken", err)
+	}
+
+	want := &transport.Token{
+		AccessToken:  "access-123",
+		RefreshToken: "refresh-456",
+		TokenType:    "Bearer",
+		ExpiresAt:    time.Now().Add(time.Hour).UTC().Truncate(time.Second),
+	}
+	if err := store.SaveToken(ctx, want); err != nil {
+		t.Fatalf("SaveToken: %v", err)
+	}
+
+	got, err := store.GetToken(ctx)
+	if err != nil {
+		t.Fatalf("GetToken: %v", err)
+	}
+	if got.AccessToken != want.AccessToken {
+		t.Errorf("AccessToken = %q, want %q", got.AccessToken, want.AccessToken)
+	}
+	if got.RefreshToken != want.RefreshToken {
+		t.Errorf("RefreshToken = %q, want %q", got.RefreshToken, want.RefreshToken)
+	}
+	if !got.ExpiresAt.Equal(want.ExpiresAt) {
+		t.Errorf("ExpiresAt = %v, want %v", got.ExpiresAt, want.ExpiresAt)
+	}
+}
+
+func TestKeyringTokenStore_ContextCancelled(t *testing.T) {
+	store := newKeyringTokenStore("ctx-test")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := store.GetToken(ctx); !errors.Is(err, context.Canceled) {
+		t.Errorf("GetToken = %v, want context.Canceled", err)
+	}
+	if err := store.SaveToken(ctx, &transport.Token{}); !errors.Is(err, context.Canceled) {
+		t.Errorf("SaveToken = %v, want context.Canceled", err)
+	}
+}
+
+func TestResolveToken(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		flag string
+		env  string
+		want string
+	}{
+		{name: "flag wins", flag: "flag-tok", env: "env-tok", want: "flag-tok"},
+		{name: "env fallback", flag: "", env: "env-tok", want: "env-tok"},
+		{name: "neither", flag: "", env: "", want: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(tokenEnvVar, tc.env)
+			if got := resolveToken(tc.flag); got != tc.want {
+				t.Errorf("resolveToken(%q) = %q, want %q", tc.flag, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRemediateAuthError(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		err         error
+		wantRemedy  bool
+		wantSameErr bool
+	}{
+		{name: "nil", err: nil, wantRemedy: false},
+		{name: "401", err: errors.New("request failed with status 401"), wantRemedy: true},
+		{name: "403", err: errors.New("got 403 from server"), wantRemedy: true},
+		{name: "unauthorized text", err: errors.New("Unauthorized"), wantRemedy: true},
+		{name: "forbidden text", err: errors.New("Forbidden"), wantRemedy: true},
+		{name: "unrelated", err: errors.New("connection refused"), wantRemedy: false, wantSameErr: true},
+		{name: "non-interactive passthrough", err: errNonInteractiveAuth, wantRemedy: false, wantSameErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := remediateAuthError(tc.err)
+			if tc.err == nil {
+				if got != nil {
+					t.Fatalf("remediateAuthError(nil) = %v, want nil", got)
+				}
+				return
+			}
+			if !errors.Is(got, tc.err) {
+				t.Errorf("remediated error does not wrap original: %v", got)
+			}
+			hasRemedy := strings.Contains(got.Error(), tokenEnvVar) &&
+				strings.Contains(got.Error(), "mcp --help")
+			if hasRemedy != tc.wantRemedy {
+				t.Errorf("remedy present = %v, want %v (%q)", hasRemedy, tc.wantRemedy, got.Error())
+			}
+			if tc.wantSameErr && got.Error() != tc.err.Error() {
+				t.Errorf("error was modified: %q", got.Error())
+			}
+		})
+	}
+}
+
+func TestNewLoopbackListener(t *testing.T) {
+	l, redirectURI, err := newLoopbackListener()
+	if err != nil {
+		t.Fatalf("newLoopbackListener: %v", err)
+	}
+	defer func() { _ = l.Close() }()
+
+	if host := l.Addr().(*net.TCPAddr).IP.String(); host != "127.0.0.1" {
+		t.Errorf("listener bound to %q, want 127.0.0.1", host)
+	}
+	if !strings.HasPrefix(redirectURI, "http://127.0.0.1:") {
+		t.Errorf("redirect URI = %q, want loopback", redirectURI)
+	}
+	if !strings.HasSuffix(redirectURI, "/callback") {
+		t.Errorf("redirect URI = %q, want /callback path", redirectURI)
+	}
+}
+
+func TestCallbackHandler(t *testing.T) {
+	ch := make(chan callbackParams, 1)
+	srv := httptestServer(t, callbackHandler(ch))
+
+	resp, err := http.Get(srv + "/callback?code=abc&state=xyz")
+	if err != nil {
+		t.Fatalf("GET callback: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	select {
+	case params := <-ch:
+		if params.code != "abc" {
+			t.Errorf("code = %q, want abc", params.code)
+		}
+		if params.state != "xyz" {
+			t.Errorf("state = %q, want xyz", params.state)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("callback params not received")
+	}
+}
+
+// httptestServer starts an HTTP server on a loopback listener serving handler
+// and returns its base URL, shutting it down at test end.
+func httptestServer(t *testing.T, handler http.Handler) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{Handler: handler, ReadHeaderTimeout: time.Second}
+	go func() { _ = srv.Serve(l) }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+	return "http://" + l.Addr().String()
+}
+
+func TestNonInteractiveAuthError(t *testing.T) {
+	if !strings.Contains(errNonInteractiveAuth.Error(), tokenEnvVar) {
+		t.Errorf("non-interactive error should mention %s: %q", tokenEnvVar, errNonInteractiveAuth.Error())
+	}
+}
+
+// TestConnectNonInteractiveOAuthRequired drives the real defaultClientFactory
+// against a stub MCP endpoint that always returns 401 with an OAuth
+// WWW-Authenticate challenge. With no TTY and no token, the connect path must
+// surface the actionable non-interactive auth error rather than retrying a
+// browser flow.
+func TestConnectNonInteractiveOAuthRequired(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+
+	ts := iostreams.Test(t) // non-TTY: CanPrompt() == false
+	opts := &options.RootOptions{
+		IOStreams: ts.IOStreams,
+		Config:    &config.Config{},
+		MCPUrl:    srv.URL,
+	}
+
+	_, err := connect(context.Background(), opts, "", nil)
+	if err == nil {
+		t.Fatal("expected an auth error")
+	}
+	if !errors.Is(err, errNonInteractiveAuth) {
+		t.Fatalf("error = %v, want errNonInteractiveAuth", err)
+	}
+}
+
+func TestConnectWithToken(t *testing.T) {
+	// connectWithToken builds a real streamable client that fails fast against a
+	// dead address; this asserts the headless path constructs and starts without
+	// touching the keyring or config key.
+	conn := connectOptions{mcpURL: "http://127.0.0.1:1/mcp", token: "headless-token"}
+	_, err := connectWithToken(context.Background(), conn)
+	if err == nil {
+		t.Fatal("expected connection error against dead address")
+	}
+	// The error must come from the transport, not from a missing credential.
+	if mcpclient.IsOAuthAuthorizationRequiredError(err) {
+		t.Errorf("headless token path should not require OAuth: %v", err)
+	}
+}

--- a/cmd/mcp/tools.go
+++ b/cmd/mcp/tools.go
@@ -7,7 +7,6 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -19,27 +18,18 @@ var toolsTable = output.TableDef{
 	},
 }
 
-func newToolsCmd(opts *options.RootOptions, factory clientFactory) *cobra.Command {
+func newToolsCmd(opts *options.RootOptions, token *string, factory clientFactory) *cobra.Command {
 	return &cobra.Command{
 		Use:   "tools",
 		Short: "List available MCP tools",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runTools(cmd.Context(), opts, factory)
+			return runTools(cmd.Context(), opts, derefToken(token), factory)
 		},
 	}
 }
 
-func runTools(ctx context.Context, opts *options.RootOptions, factory clientFactory) error {
-	if factory == nil {
-		factory = defaultClientFactory
-	}
-
-	key, err := opts.RequireKey(config.KeyConfig)
-	if err != nil {
-		return err
-	}
-
-	c, err := factory(ctx, opts.ResolveMCPUrl(), key)
+func runTools(ctx context.Context, opts *options.RootOptions, token string, factory clientFactory) error {
+	c, err := connect(ctx, opts, token, factory)
 	if err != nil {
 		return err
 	}

--- a/cmd/mcp/tools_test.go
+++ b/cmd/mcp/tools_test.go
@@ -20,7 +20,7 @@ func init() {
 }
 
 func testFactory(srv *server.MCPServer) clientFactory {
-	return func(ctx context.Context, _, _ string) (*mcpclient.Client, error) {
+	return func(ctx context.Context, _ connectOptions) (*mcpclient.Client, error) {
 		c, err := mcpclient.NewInProcessClient(srv)
 		if err != nil {
 			return nil, err
@@ -53,11 +53,6 @@ func setupMCPTest(t *testing.T) (*server.MCPServer, *options.RootOptions, *iostr
 		Format:    "json",
 	}
 
-	if err := config.SetKey("default", config.KeyConfig, "test-key"); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = config.DeleteKey("default", config.KeyConfig) })
-
 	return srv, opts, ts
 }
 
@@ -66,7 +61,7 @@ func TestTools(t *testing.T) {
 	srv.AddTool(mcp.NewTool("run_query", mcp.WithDescription("Run a query")), nil)
 	srv.AddTool(mcp.NewTool("get_columns", mcp.WithDescription("Get dataset columns")), nil)
 
-	cmd := newToolsCmd(opts, testFactory(srv))
+	cmd := newToolsCmd(opts, nil, testFactory(srv))
 	cmd.SetArgs([]string{})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)

--- a/internal/config/keyring.go
+++ b/internal/config/keyring.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -52,6 +53,52 @@ func ApplyAuth(req *http.Request, kt KeyType, key string) {
 
 func keyringKey(profile string, kt KeyType) string {
 	return fmt.Sprintf("%s:%s", profile, kt)
+}
+
+// mcpTokenSuffix is the keyring sub-key under which the MCP OAuth token set is
+// stored. It is deliberately not a KeyType: the token is a JSON document, not a
+// raw credential, so it stays out of the login/status/KeyTypes machinery.
+const mcpTokenSuffix = "mcp"
+
+func mcpTokenKey(profile string) string {
+	return fmt.Sprintf("%s:%s", profile, mcpTokenSuffix)
+}
+
+// SetMCPToken stores the OAuth token set for a profile, JSON-encoded under the
+// {profile}:mcp keyring entry.
+func SetMCPToken(profile string, v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("encoding MCP token: %w", err)
+	}
+	return withTimeout(func() error {
+		return keyring.Set(keyringService, mcpTokenKey(profile), string(data))
+	})
+}
+
+// GetMCPToken decodes the stored OAuth token set for a profile into v. It
+// returns keyring.ErrNotFound when no token has been stored.
+func GetMCPToken(profile string, v any) error {
+	var raw string
+	err := withTimeout(func() error {
+		var e error
+		raw, e = keyring.Get(keyringService, mcpTokenKey(profile))
+		return e
+	})
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal([]byte(raw), v); err != nil {
+		return fmt.Errorf("decoding MCP token: %w", err)
+	}
+	return nil
+}
+
+// DeleteMCPToken removes the stored OAuth token set for a profile.
+func DeleteMCPToken(profile string) error {
+	return withTimeout(func() error {
+		return keyring.Delete(keyringService, mcpTokenKey(profile))
+	})
 }
 
 func SetKey(profile string, kt KeyType, value string) error {

--- a/internal/config/keyring_test.go
+++ b/internal/config/keyring_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 
@@ -66,6 +67,49 @@ func TestSetManagementKey(t *testing.T) {
 	}
 	if got != "id-123:secret-456" {
 		t.Errorf("stored value = %q, want %q", got, "id-123:secret-456")
+	}
+}
+
+func TestMCPToken(t *testing.T) {
+	keyring.MockInit()
+
+	type tokenSet struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+	}
+
+	const profile = "mcp-test"
+	t.Cleanup(func() { _ = DeleteMCPToken(profile) })
+
+	var empty tokenSet
+	if err := GetMCPToken(profile, &empty); !errors.Is(err, keyring.ErrNotFound) {
+		t.Fatalf("GetMCPToken on empty = %v, want ErrNotFound", err)
+	}
+
+	want := tokenSet{AccessToken: "a-tok", RefreshToken: "r-tok"}
+	if err := SetMCPToken(profile, want); err != nil {
+		t.Fatalf("SetMCPToken() error = %v", err)
+	}
+
+	var got tokenSet
+	if err := GetMCPToken(profile, &got); err != nil {
+		t.Fatalf("GetMCPToken() error = %v", err)
+	}
+	if got != want {
+		t.Errorf("GetMCPToken() = %+v, want %+v", got, want)
+	}
+
+	if err := DeleteMCPToken(profile); err != nil {
+		t.Fatalf("DeleteMCPToken() error = %v", err)
+	}
+	if err := GetMCPToken(profile, &got); !errors.Is(err, keyring.ErrNotFound) {
+		t.Errorf("GetMCPToken after delete = %v, want ErrNotFound", err)
+	}
+}
+
+func TestMCPTokenKey(t *testing.T) {
+	if got := mcpTokenKey("alice"); got != "alice:mcp" {
+		t.Errorf("mcpTokenKey() = %q, want %q", got, "alice:mcp")
 	}
 }
 


### PR DESCRIPTION
Closes #178. The `mcp` command sent a Honeycomb config API key as the bearer token, so every call hit the OAuth 2.1 protected MCP server and got a 401. This switches `mcp` to the OAuth credential class the server actually requires.

## What Changed

#### Stop sending the config key

`cmd/mcp/tools.go` and `cmd/mcp/call.go` no longer call `opts.RequireKey(config.KeyConfig)`, and the default client transport no longer hardcodes `Authorization: Bearer <config-key>`. Both subcommands route through a new `connect` helper that selects the credential based on context. A test confirms the config key is never read on the MCP path.

#### OAuth via the mcp-go transport

`cmd/mcp/oauth.go` wires `mark3labs/mcp-go`'s OAuth streamable HTTP client with PKCE (S256), scopes `mcp:read`/`mcp:write`, and a loopback `RedirectURI` bound to `127.0.0.1` per RFC 8252. A keyring-backed `transport.TokenStore` persists the access/refresh token set under `{profile}:mcp`, so the library refreshes transparently and tokens survive across invocations. `internal/config/keyring.go` gains `SetMCPToken`/`GetMCPToken`/`DeleteMCPToken` (JSON, keyed `{profile}:mcp`), and `auth logout` clears the MCP token alongside the API keys.

When the server reports authorization is required, the interactive flow runs Dynamic Client Registration, starts the loopback callback server, opens the browser to the authorization URL, validates the returned `state`, and exchanges the code for tokens.

#### Headless fallback for CI

`--token` (or `HONEYCOMB_MCP_TOKEN`) supplies a pre-issued MCP access token and skips the browser flow entirely. In a non-interactive session without a token, `connect` returns an actionable error instead of hanging on a browser that can't open.

#### Actionable errors and experimental marking

`connect` detects OAuth-required / 401 / 403 responses and returns a CLI-authored message explaining that MCP uses OAuth (not the API key) and listing remediation steps. `mcp --help` documents the authentication model, and the command prints a one-time experimental notice to stderr on first use. `Short`/`Long` mark it experimental.

## Test Coverage

Unit tests cover the keyring token store (round-trip, `ErrNoToken`, context cancellation), token resolution (flag vs env precedence), error remediation across 401/403/unauthorized/forbidden inputs, the loopback listener binding to `127.0.0.1`, and the callback handler. One test drives the real client factory against a stub server returning a 401 OAuth challenge and asserts the non-interactive path surfaces the actionable error rather than attempting a browser flow.

## Experimental / Follow-up

Ship marked experimental. The headless token path, keyring token store, actionable errors, and help docs are exercised by tests end-to-end. The full interactive browser flow (DCR + PKCE + code exchange against the live `honeycomb.io` authorization server) is wired but could not be verified offline, since discovery and registration hit live hosts. Its building blocks are unit-tested in isolation; the live round-trip is the piece a reviewer should dogfood. A token expiring mid-session surfaces a generic transport error rather than the remediation message, since remediation is applied at connect time where 401s normally appear; transparent refresh covers the common case.
