### PR TITLE
fix(output): empty-state message for list commands

### DIFF
--- a/cmd/auth/profile.go
+++ b/cmd/auth/profile.go
@@ -94,7 +94,7 @@ func runProfileList(opts *options.RootOptions) error {
 		return fmt.Errorf("no profiles configured (run honeycomb auth login)")
 	}
 
-	return opts.OutputWriterList().Write(entries, profileTable)
+	return opts.OutputWriterList().WriteList(entries, profileTable, "No profiles found.")
 }
 
 func discoverProfiles(cfg *config.Config, active string) []string {

--- a/cmd/board/list.go
+++ b/cmd/board/list.go
@@ -60,5 +60,5 @@ func runBoardList(ctx context.Context, opts *options.RootOptions) error {
 		items[i] = item
 	}
 
-	return opts.OutputWriterList().Write(items, boardListTable)
+	return opts.OutputWriterList().WriteList(items, boardListTable, "No boards found.")
 }

--- a/cmd/board/view_list.go
+++ b/cmd/board/view_list.go
@@ -41,5 +41,5 @@ func runViewList(ctx context.Context, opts *options.RootOptions, boardID string)
 		items[i] = viewResponseToItem(v)
 	}
 
-	return opts.OutputWriterList().Write(items, viewListTable)
+	return opts.OutputWriterList().WriteList(items, viewListTable, "No board views found.")
 }

--- a/cmd/column/calculated_list.go
+++ b/cmd/column/calculated_list.go
@@ -56,5 +56,5 @@ func runCalculatedList(ctx context.Context, opts *options.RootOptions, dataset s
 		items[i] = toCalculatedItem(f)
 	}
 
-	return opts.OutputWriterList().Write(items, calculatedListTable)
+	return opts.OutputWriterList().WriteList(items, calculatedListTable, "No calculated columns found.")
 }

--- a/cmd/column/list.go
+++ b/cmd/column/list.go
@@ -57,7 +57,7 @@ func runColumnList(ctx context.Context, opts *options.RootOptions, dataset, keyN
 		}
 	}
 
-	return opts.OutputWriterList().Write(items, columnListTable)
+	return opts.OutputWriterList().WriteList(items, columnListTable, "No columns found.")
 }
 
 // listColumns fetches columns via the raw ListColumns method because the

--- a/cmd/dataset/list.go
+++ b/cmd/dataset/list.go
@@ -85,5 +85,5 @@ func runDatasetList(ctx context.Context, opts *options.RootOptions) error {
 		items[i] = item
 	}
 
-	return opts.OutputWriterList().Write(items, datasetListTable)
+	return opts.OutputWriterList().WriteList(items, datasetListTable, "No datasets found.")
 }

--- a/cmd/environment/list.go
+++ b/cmd/environment/list.go
@@ -60,7 +60,7 @@ func runEnvironmentList(ctx context.Context, opts *options.RootOptions, team str
 		params.PageAfter = &cursor
 	}
 
-	return opts.OutputWriterList().Write(items, environmentListTable)
+	return opts.OutputWriterList().WriteList(items, environmentListTable, "No environments found.")
 }
 
 // nextPageCursor extracts the page[after] cursor from a links.next URL.

--- a/cmd/key/list.go
+++ b/cmd/key/list.go
@@ -76,5 +76,5 @@ func runKeyList(ctx context.Context, opts *options.RootOptions, team, filterType
 		items[i] = objectToItem(obj)
 	}
 
-	return opts.OutputWriterList().Write(items, keyListTable)
+	return opts.OutputWriterList().WriteList(items, keyListTable, "No keys found.")
 }

--- a/cmd/marker/list.go
+++ b/cmd/marker/list.go
@@ -41,5 +41,5 @@ func runMarkerList(ctx context.Context, opts *options.RootOptions, dataset strin
 		items[i] = markerToItem(m)
 	}
 
-	return opts.OutputWriterList().Write(items, markerListTable)
+	return opts.OutputWriterList().WriteList(items, markerListTable, "No markers found.")
 }

--- a/cmd/marker/setting_list.go
+++ b/cmd/marker/setting_list.go
@@ -41,5 +41,5 @@ func runSettingList(ctx context.Context, opts *options.RootOptions, dataset stri
 		items[i] = toSettingItem(s)
 	}
 
-	return opts.OutputWriterList().Write(items, settingListTable)
+	return opts.OutputWriterList().WriteList(items, settingListTable, "No marker settings found.")
 }

--- a/cmd/query/annotation_list.go
+++ b/cmd/query/annotation_list.go
@@ -62,7 +62,7 @@ func runAnnotationList(ctx context.Context, opts *options.RootOptions, dataset s
 		items[i] = item
 	}
 
-	return opts.OutputWriterList().Write(items, annotationListTable)
+	return opts.OutputWriterList().WriteList(items, annotationListTable, "No query annotations found.")
 }
 
 func ptr[T any](v T) *T {

--- a/cmd/recipient/list.go
+++ b/cmd/recipient/list.go
@@ -47,5 +47,5 @@ func runList(ctx context.Context, opts *options.RootOptions) error {
 		return err
 	}
 
-	return opts.OutputWriterList().Write(details, recipientListTable)
+	return opts.OutputWriterList().WriteList(details, recipientListTable, "No recipients found.")
 }

--- a/cmd/recipient/triggers.go
+++ b/cmd/recipient/triggers.go
@@ -56,7 +56,7 @@ func runTriggers(ctx context.Context, opts *options.RootOptions, recipientID str
 		items[i] = toTriggerItem(t)
 	}
 
-	return opts.OutputWriterList().Write(items, triggerListTable)
+	return opts.OutputWriterList().WriteList(items, triggerListTable, "No triggers found.")
 }
 
 func toTriggerItem(t api.TriggerResponse) triggerItem {

--- a/cmd/slo/burn_alert_list.go
+++ b/cmd/slo/burn_alert_list.go
@@ -56,5 +56,5 @@ func runBurnAlertList(ctx context.Context, opts *options.RootOptions, dataset, s
 		}
 	}
 
-	return opts.OutputWriterList().Write(items, burnAlertListTable)
+	return opts.OutputWriterList().WriteList(items, burnAlertListTable, "No burn alerts found.")
 }

--- a/cmd/slo/list.go
+++ b/cmd/slo/list.go
@@ -61,5 +61,5 @@ func runSLOList(ctx context.Context, opts *options.RootOptions, dataset string) 
 		}
 	}
 
-	return opts.OutputWriterList().Write(items, sloListTable)
+	return opts.OutputWriterList().WriteList(items, sloListTable, "No SLOs found.")
 }

--- a/cmd/trigger/list.go
+++ b/cmd/trigger/list.go
@@ -44,5 +44,5 @@ func runList(ctx context.Context, opts *options.RootOptions, dataset string) err
 		items[i] = toItem(t)
 	}
 
-	return opts.OutputWriterList().Write(items, triggerListTable)
+	return opts.OutputWriterList().WriteList(items, triggerListTable, "No triggers found.")
 }

--- a/cmd/trigger/list_test.go
+++ b/cmd/trigger/list_test.go
@@ -117,6 +117,28 @@ func TestList_Empty(t *testing.T) {
 	}
 }
 
+func TestList_EmptyTable(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	opts.Format = output.FormatTable
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"list", "--dataset", "test-dataset"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	out := ts.OutBuf.String()
+	if out != "No triggers found.\n" {
+		t.Errorf("output = %q, want %q", out, "No triggers found.\n")
+	}
+	if strings.Contains(out, "NAME") {
+		t.Errorf("expected no header table for empty list:\n%s", out)
+	}
+}
+
 func TestList_NoKey(t *testing.T) {
 	ts := iostreams.Test(t)
 	opts := &options.RootOptions{

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -86,6 +86,20 @@ func (w *Writer) Write(data any, td TableDef) error {
 	}
 }
 
+// WriteList renders a slice the same as Write, except that an empty slice in
+// table mode prints emptyMessage on its own line instead of a header-only
+// table. JSON mode is unchanged and always emits the slice (e.g. []).
+func (w *Writer) WriteList(data any, td TableDef, emptyMessage string) error {
+	if w.format == FormatTable {
+		rv := reflect.ValueOf(data)
+		if rv.Kind() == reflect.Slice && rv.Len() == 0 {
+			_, err := fmt.Fprintln(w.out, emptyMessage)
+			return err
+		}
+	}
+	return w.Write(data, td)
+}
+
 // WriteMessage emits data as JSON, or a single human-readable line in table
 // mode. An empty line writes nothing in table mode. It covers the "JSON
 // object, or one status line" shape that previously required callers to pass

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -98,6 +98,55 @@ func TestWrite_Table_Empty(t *testing.T) {
 	}
 }
 
+func TestWriteList_Table_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	w := New(&buf, FormatTable)
+
+	var items []testItem
+	if err := w.WriteList(items, testTable, "No items found."); err != nil {
+		t.Fatal(err)
+	}
+
+	if out := buf.String(); out != "No items found.\n" {
+		t.Errorf("table output = %q, want %q", out, "No items found.\n")
+	}
+	if strings.Contains(buf.String(), "NAME") {
+		t.Errorf("expected no header table for empty list:\n%s", buf.String())
+	}
+}
+
+func TestWriteList_Table_NonEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	w := New(&buf, FormatTable)
+
+	items := []testItem{{Name: "a", Count: 1}}
+	if err := w.WriteList(items, testTable, "No items found."); err != nil {
+		t.Fatal(err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "NAME") || !strings.Contains(out, "a") {
+		t.Errorf("expected header table for non-empty list:\n%s", out)
+	}
+	if strings.Contains(out, "No items found.") {
+		t.Errorf("unexpected empty message for non-empty list:\n%s", out)
+	}
+}
+
+func TestWriteList_JSON_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	w := New(&buf, FormatJSON)
+
+	items := []testItem{}
+	if err := w.WriteList(items, testTable, "No items found."); err != nil {
+		t.Fatal(err)
+	}
+
+	if out := strings.TrimSpace(buf.String()); out != "[]" {
+		t.Errorf("JSON output = %q, want %q", out, "[]")
+	}
+}
+
 func TestWrite_UnsupportedFormat(t *testing.T) {
 	var buf bytes.Buffer
 	w := New(&buf, "xml")


### PR DESCRIPTION
Closes #198

Adds a `WriteList(data, td, emptyMessage)` method to the shared `output.Writer`. In table mode, an empty slice prints `emptyMessage` on its own line instead of rendering a header-only table (the phantom box). JSON mode is unchanged and still emits `[]`.

Previously every list command called `OutputWriterList().Write(items, td)` regardless of length, and `writeTable` rendered headers plus zero rows. On an empty dataset, `trigger list` showed an empty box rather than a clear "no triggers" message.

Because the fix lives in the shared writer, it covers all list commands at once, not just `trigger list`. Each of the ~16 `WriteList` call sites passes an accurate plural noun (e.g. `No triggers found.`, `No boards found.`, `No columns found.`).

Tests cover the empty-slice table path (prints the message, no header), the non-empty path (unchanged), JSON still emitting `[]` for empty, and a command-level `trigger list` empty-table assertion.
