### PR TITLE
fix(cli): unify -f/--file and stdin handling

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -49,14 +49,14 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&o.method, "method", "X", "", "HTTP method (default: auto-detected)")
-	cmd.Flags().StringArrayVarP(&o.fields, "field", "f", nil, "String field: key=value")
+	cmd.Flags().StringArrayVarP(&o.fields, "field", "f", nil, "String field: key=value (repeatable; not a file)")
 	cmd.Flags().StringArrayVarP(&o.typed, "typed-field", "F", nil, "Typed field: bool/number/null coercion, @file")
 	cmd.Flags().StringArrayVarP(&o.headers, "header", "H", nil, "Request header: key:value")
 	cmd.Flags().StringVarP(&o.jqExpr, "jq", "q", "", "Filter response with jq expression")
 	cmd.Flags().BoolVarP(&o.include, "include", "i", false, "Show response status line and headers")
 	cmd.Flags().BoolVar(&o.paginate, "paginate", false, "Follow Link rel=\"next\" pagination")
 	cmd.Flags().StringVar(&o.keyType, "key-type", "", "Override auth key type: config, ingest, management")
-	cmd.Flags().StringVar(&o.input, "input", "", "Read body from file (- for stdin)")
+	cmd.Flags().StringVar(&o.input, "input", "", "Read the request body from a file (- for stdin)")
 	cmd.Flags().BoolVar(&o.raw, "raw", false, "Output the full JSON:API envelope instead of flattened attributes")
 
 	hideFormatFlag(cmd)

--- a/cmd/column/create.go
+++ b/cmd/column/create.go
@@ -1,6 +1,8 @@
 package column
 
 import (
+	"bytes"
+	"context"
 	"fmt"
 
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
@@ -21,6 +23,7 @@ var columnTypes = []string{
 
 func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	var (
+		file        string
 		keyName     string
 		colType     string
 		description string
@@ -31,6 +34,10 @@ func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 		Use:   "create",
 		Short: "Create a column",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if file != "" {
+				return runColumnCreateFromFile(cmd.Context(), opts, *dataset, file)
+			}
+
 			if keyName == "" {
 				if !opts.IOStreams.CanPrompt() {
 					return fmt.Errorf("--key-name is required in non-interactive mode")
@@ -54,12 +61,42 @@ func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 		},
 	}
 
+	cmd.Flags().StringVarP(&file, "file", "f", "", "Path to JSON file (- for stdin)")
 	cmd.Flags().StringVar(&keyName, "key-name", "", "Column key name (required)")
 	cmd.Flags().StringVar(&colType, "type", "", "Column type: string, float, integer, boolean, histogram")
 	cmd.Flags().StringVar(&description, "description", "", "Column description")
 	cmd.Flags().BoolVar(&hidden, "hidden", false, "Hide column from autocomplete")
 
+	cmd.MarkFlagsMutuallyExclusive("file", "key-name")
+	cmd.MarkFlagsMutuallyExclusive("file", "type")
+	cmd.MarkFlagsMutuallyExclusive("file", "description")
+	cmd.MarkFlagsMutuallyExclusive("file", "hidden")
+
 	return cmd
+}
+
+func runColumnCreateFromFile(ctx context.Context, opts *options.RootOptions, dataset, file string) error {
+	client, err := opts.Client(config.KeyConfig)
+	if err != nil {
+		return err
+	}
+
+	data, err := command.ReadDefinitionFile(opts.IOStreams, file)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.CreateColumnWithBodyWithResponse(ctx, dataset, "application/json", bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("creating column: %w", err)
+	}
+
+	col, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.JSON201)
+	if err != nil {
+		return err
+	}
+
+	return writeColumnDetail(opts, *col)
 }
 
 func runColumnCreate(cmd *cobra.Command, opts *options.RootOptions, dataset, keyName, colType, description string, hidden bool) error {

--- a/cmd/column/create_test.go
+++ b/cmd/column/create_test.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -68,6 +71,99 @@ func TestCreate_InvalidType(t *testing.T) {
 	want := `invalid --type "bogus": must be one of string, float, integer, boolean, histogram`
 	if err.Error() != want {
 		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestCreate_WithFile(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(body, &req)
+		if req["key_name"] != "from_file" {
+			t.Errorf("key_name = %v, want from_file", req["key_name"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":       "file-id",
+			"key_name": "from_file",
+			"type":     "string",
+		})
+	}))
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "column.json")
+	if err := os.WriteFile(file, []byte(`{"key_name":"from_file","type":"string"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"create", "--dataset", "my-dataset", "--file", file})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var detail columnDetail
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &detail); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if detail.ID != "file-id" {
+		t.Errorf("ID = %q, want %q", detail.ID, "file-id")
+	}
+}
+
+func TestCreate_WithStdin(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(body, &req)
+		if req["key_name"] != "from_stdin" {
+			t.Errorf("key_name = %v, want from_stdin", req["key_name"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":       "stdin-id",
+			"key_name": "from_stdin",
+			"type":     "string",
+		})
+	}))
+
+	ts.InBuf.WriteString(`{"key_name":"from_stdin","type":"string"}`)
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"create", "--dataset", "my-dataset", "--file", "-"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var detail columnDetail
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &detail); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if detail.ID != "stdin-id" {
+		t.Errorf("ID = %q, want %q", detail.ID, "stdin-id")
+	}
+}
+
+func TestCreate_FileAndFlagsMutuallyExclusive(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("API should not be called when flags conflict")
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"create", "--dataset", "my-dataset", "--file", "-", "--key-name", "x"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for mutually exclusive flags")
+	}
+	if !strings.Contains(err.Error(), "if any flags in the group") {
+		t.Errorf("error = %q, want mutual exclusion message", err.Error())
 	}
 }
 

--- a/cmd/column/update.go
+++ b/cmd/column/update.go
@@ -2,8 +2,11 @@ package column
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
@@ -12,6 +15,7 @@ import (
 
 func NewUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	var (
+		file        string
 		description string
 		hidden      bool
 	)
@@ -21,44 +25,77 @@ func NewUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 		Short: "Update a column",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("description") && !cmd.Flags().Changed("hidden") {
-				return fmt.Errorf("provide at least one of --description, --hidden")
+			hasFile := cmd.Flags().Changed("file")
+			hasDesc := cmd.Flags().Changed("description")
+			hasHidden := cmd.Flags().Changed("hidden")
+
+			if !hasFile && !hasDesc && !hasHidden {
+				return fmt.Errorf("provide --file or at least one of --description, --hidden")
 			}
-			return runColumnUpdate(cmd, opts, *dataset, args[0], description, hidden)
+
+			return runColumnUpdate(cmd.Context(), opts, *dataset, args[0], columnUpdateFlags{
+				file:        file,
+				hasFile:     hasFile,
+				description: description,
+				hasDesc:     hasDesc,
+				hidden:      hidden,
+				hasHidden:   hasHidden,
+			})
 		},
 	}
 
+	cmd.Flags().StringVarP(&file, "file", "f", "", "Path to JSON file (- for stdin)")
 	cmd.Flags().StringVar(&description, "description", "", "Column description")
 	cmd.Flags().BoolVar(&hidden, "hidden", false, "Hide column from autocomplete")
+
+	cmd.MarkFlagsMutuallyExclusive("file", "description")
+	cmd.MarkFlagsMutuallyExclusive("file", "hidden")
 
 	return cmd
 }
 
-func runColumnUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, columnID, description string, hidden bool) error {
+type columnUpdateFlags struct {
+	file        string
+	hasFile     bool
+	description string
+	hasDesc     bool
+	hidden      bool
+	hasHidden   bool
+}
+
+func runColumnUpdate(ctx context.Context, opts *options.RootOptions, dataset, columnID string, flags columnUpdateFlags) error {
 	client, err := opts.Client(config.KeyConfig)
 	if err != nil {
 		return err
 	}
 
-	ctx := cmd.Context()
+	var col api.Column
 
-	getResp, err := client.GetColumnWithResponse(ctx, dataset, columnID)
-	if err != nil {
-		return fmt.Errorf("getting column: %w", err)
-	}
+	if flags.hasFile {
+		data, err := command.ReadDefinitionFile(opts.IOStreams, flags.file)
+		if err != nil {
+			return err
+		}
+		if err := json.Unmarshal(data, &col); err != nil {
+			return fmt.Errorf("parsing column JSON: %w", err)
+		}
+	} else {
+		getResp, err := client.GetColumnWithResponse(ctx, dataset, columnID)
+		if err != nil {
+			return fmt.Errorf("getting column: %w", err)
+		}
+		current, err := api.Decode(getResp.StatusCode(), getResp.Status(), getResp.Body, getResp.JSON200)
+		if err != nil {
+			return err
+		}
+		col = *current
 
-	current, err := api.Decode(getResp.StatusCode(), getResp.Status(), getResp.Body, getResp.JSON200)
-	if err != nil {
-		return err
-	}
-
-	col := *current
-
-	if cmd.Flags().Changed("description") {
-		col.Description = &description
-	}
-	if cmd.Flags().Changed("hidden") {
-		col.Hidden = &hidden
+		if flags.hasDesc {
+			col.Description = &flags.description
+		}
+		if flags.hasHidden {
+			col.Hidden = &flags.hidden
+		}
 	}
 
 	data, err := api.MarshalStrippingReadOnly(col, "Column")

--- a/cmd/column/update_test.go
+++ b/cmd/column/update_test.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -75,6 +78,109 @@ func TestUpdate_NoFlags(t *testing.T) {
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error when no update flags provided")
+	}
+}
+
+func TestUpdate_WithFile(t *testing.T) {
+	var getCount int
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			getCount++
+		case http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			var req map[string]any
+			_ = json.Unmarshal(body, &req)
+			if req["description"] != "From File" {
+				t.Errorf("description = %v, want From File", req["description"])
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":          "abc123",
+				"key_name":    "duration_ms",
+				"type":        "float",
+				"description": "From File",
+				"hidden":      false,
+			})
+		}
+	}))
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "column.json")
+	input := `{"id":"abc123","key_name":"duration_ms","type":"float","description":"From File"}`
+	if err := os.WriteFile(file, []byte(input), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"update", "--dataset", "my-dataset", "abc123", "--file", file})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if getCount != 0 {
+		t.Errorf("GET count = %d, want 0 (file mode should skip GET)", getCount)
+	}
+
+	var detail columnDetail
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &detail); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if detail.Description != "From File" {
+		t.Errorf("Description = %q, want %q", detail.Description, "From File")
+	}
+}
+
+func TestUpdate_WithStdin(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet {
+			t.Error("file mode should skip GET")
+		}
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(body, &req)
+		if req["description"] != "From Stdin" {
+			t.Errorf("description = %v, want From Stdin", req["description"])
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":          "abc123",
+			"key_name":    "duration_ms",
+			"type":        "float",
+			"description": "From Stdin",
+		})
+	}))
+
+	ts.InBuf.WriteString(`{"id":"abc123","key_name":"duration_ms","type":"float","description":"From Stdin"}`)
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"update", "--dataset", "my-dataset", "abc123", "--file", "-"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var detail columnDetail
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &detail); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if detail.Description != "From Stdin" {
+		t.Errorf("Description = %q, want %q", detail.Description, "From Stdin")
+	}
+}
+
+func TestUpdate_FileAndFlagsMutuallyExclusive(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("API should not be called when flags conflict")
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"update", "--dataset", "my-dataset", "abc123", "--file", "-", "--description", "x"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for mutually exclusive flags")
+	}
+	if !strings.Contains(err.Error(), "if any flags in the group") {
+		t.Errorf("error = %q, want mutual exclusion message", err.Error())
 	}
 }
 

--- a/cmd/marker/create.go
+++ b/cmd/marker/create.go
@@ -2,9 +2,11 @@ package marker
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
@@ -14,6 +16,7 @@ import (
 
 func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	var (
+		file       string
 		markerType string
 		message    string
 		url        string
@@ -26,6 +29,10 @@ func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 		Use:   "create",
 		Short: "Create a marker",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if file != "" {
+				return runMarkerCreateFromFile(cmd.Context(), opts, *dataset, file)
+			}
+
 			if markerType == "" && opts.IOStreams.CanPrompt() {
 				v, err := prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Type: ")
 				if err != nil {
@@ -74,6 +81,7 @@ func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 		},
 	}
 
+	cmd.Flags().StringVarP(&file, "file", "f", "", "Path to JSON file (- for stdin)")
 	cmd.Flags().StringVar(&markerType, "type", "", "Marker type (e.g., deploy)")
 	cmd.Flags().StringVar(&message, "message", "", "Marker message")
 	cmd.Flags().StringVar(&url, "url", "", "URL associated with the marker")
@@ -81,7 +89,25 @@ func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	cmd.Flags().IntVar(&endTime, "end-time", 0, "End time as Unix timestamp")
 	cmd.Flags().StringVar(&color, "color", "", "Marker color")
 
+	for _, name := range []string{"type", "message", "url", "start-time", "end-time", "color"} {
+		cmd.MarkFlagsMutuallyExclusive("file", name)
+	}
+
 	return cmd
+}
+
+func runMarkerCreateFromFile(ctx context.Context, opts *options.RootOptions, dataset, file string) error {
+	data, err := command.ReadDefinitionFile(opts.IOStreams, file)
+	if err != nil {
+		return err
+	}
+
+	var body api.CreateMarkerJSONRequestBody
+	if err := json.Unmarshal(data, &body); err != nil {
+		return fmt.Errorf("parsing marker JSON: %w", err)
+	}
+
+	return runMarkerCreate(ctx, opts, dataset, body)
 }
 
 func runMarkerCreate(ctx context.Context, opts *options.RootOptions, dataset string, body api.CreateMarkerJSONRequestBody) error {

--- a/cmd/marker/create_test.go
+++ b/cmd/marker/create_test.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -90,6 +93,103 @@ func TestCreate_RequiredFlags_NonInteractive(t *testing.T) {
 				t.Errorf("error = %q, want %q", err.Error(), tc.wantErr)
 			}
 		})
+	}
+}
+
+func TestCreate_WithFile(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(body, &req)
+		if req["type"] != "deploy" {
+			t.Errorf("type = %v, want deploy", req["type"])
+		}
+		if req["message"] != "from file" {
+			t.Errorf("message = %v, want from file", req["message"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":         "file123",
+			"type":       "deploy",
+			"message":    "from file",
+			"start_time": 1700000000,
+			"created_at": "2024-01-01T00:00:00Z",
+		})
+	}))
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "marker.json")
+	if err := os.WriteFile(file, []byte(`{"type":"deploy","message":"from file","start_time":1700000000}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"create", "--dataset", "test-dataset", "--file", file})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var item markerItem
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &item); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if item.ID != "file123" {
+		t.Errorf("ID = %q, want %q", item.ID, "file123")
+	}
+}
+
+func TestCreate_WithStdin(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(body, &req)
+		if req["message"] != "from stdin" {
+			t.Errorf("message = %v, want from stdin", req["message"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":         "stdin123",
+			"type":       "deploy",
+			"message":    "from stdin",
+			"start_time": 1700000000,
+			"created_at": "2024-01-01T00:00:00Z",
+		})
+	}))
+
+	ts.InBuf.WriteString(`{"type":"deploy","message":"from stdin","start_time":1700000000}`)
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"create", "--dataset", "test-dataset", "--file", "-"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var item markerItem
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &item); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if item.ID != "stdin123" {
+		t.Errorf("ID = %q, want %q", item.ID, "stdin123")
+	}
+}
+
+func TestCreate_FileAndFlagsMutuallyExclusive(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("API should not be called when flags conflict")
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"create", "--dataset", "test-dataset", "--file", "-", "--type", "deploy"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for mutually exclusive flags")
+	}
+	if !strings.Contains(err.Error(), "if any flags in the group") {
+		t.Errorf("error = %q, want mutual exclusion message", err.Error())
 	}
 }
 

--- a/cmd/marker/setting_create.go
+++ b/cmd/marker/setting_create.go
@@ -2,8 +2,10 @@ package marker
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
@@ -13,6 +15,7 @@ import (
 
 func NewSettingCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	var (
+		file        string
 		settingType string
 		color       string
 	)
@@ -21,6 +24,18 @@ func NewSettingCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Comm
 		Use:   "create",
 		Short: "Create a marker setting",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if file != "" {
+				data, err := command.ReadDefinitionFile(opts.IOStreams, file)
+				if err != nil {
+					return err
+				}
+				var body api.MarkerSetting
+				if err := json.Unmarshal(data, &body); err != nil {
+					return fmt.Errorf("parsing marker setting JSON: %w", err)
+				}
+				return runSettingCreate(cmd.Context(), opts, *dataset, body)
+			}
+
 			if settingType == "" && opts.IOStreams.CanPrompt() {
 				v, err := prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Type: ")
 				if err != nil {
@@ -46,8 +61,12 @@ func NewSettingCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Comm
 		},
 	}
 
+	cmd.Flags().StringVarP(&file, "file", "f", "", "Path to JSON file (- for stdin)")
 	cmd.Flags().StringVar(&settingType, "type", "", "Marker setting type (e.g., deploys)")
 	cmd.Flags().StringVar(&color, "color", "", "Marker setting color (hex, e.g., #F96E11)")
+
+	cmd.MarkFlagsMutuallyExclusive("file", "type")
+	cmd.MarkFlagsMutuallyExclusive("file", "color")
 
 	return cmd
 }

--- a/cmd/marker/setting_test.go
+++ b/cmd/marker/setting_test.go
@@ -3,6 +3,8 @@ package marker
 import (
 	"encoding/json"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -119,6 +121,101 @@ func TestSettingCreate(t *testing.T) {
 	}
 	if item.Type != "deploys" {
 		t.Errorf("Type = %q, want %q", item.Type, "deploys")
+	}
+}
+
+func TestSettingCreate_WithFile(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["type"] != "deploys" {
+			t.Errorf("body type = %q, want %q", body["type"], "deploys")
+		}
+		if body["color"] != "#ABCDEF" {
+			t.Errorf("body color = %q, want %q", body["color"], "#ABCDEF")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":    "ms-file",
+			"type":  "deploys",
+			"color": "#ABCDEF",
+		})
+	}))
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "setting.json")
+	if err := os.WriteFile(file, []byte(`{"type":"deploys","color":"#ABCDEF"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"--dataset", "test", "setting", "create", "--file", file})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var item settingItem
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &item); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if item.ID != "ms-file" {
+		t.Errorf("ID = %q, want %q", item.ID, "ms-file")
+	}
+}
+
+func TestSettingCreate_WithStdin(t *testing.T) {
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["color"] != "#123456" {
+			t.Errorf("body color = %q, want %q", body["color"], "#123456")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":    "ms-stdin",
+			"type":  "deploys",
+			"color": "#123456",
+		})
+	}))
+
+	ts.InBuf.WriteString(`{"type":"deploys","color":"#123456"}`)
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"--dataset", "test", "setting", "create", "--file", "-"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var item settingItem
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &item); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if item.ID != "ms-stdin" {
+		t.Errorf("ID = %q, want %q", item.ID, "ms-stdin")
+	}
+}
+
+func TestSettingCreate_FileAndFlagsMutuallyExclusive(t *testing.T) {
+	opts, _ := setupTest(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("API should not be called when flags conflict")
+	}))
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"--dataset", "test", "setting", "create", "--file", "-", "--type", "deploys"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for mutually exclusive flags")
+	}
+	if !strings.Contains(err.Error(), "if any flags in the group") {
+		t.Errorf("error = %q, want mutual exclusion message", err.Error())
 	}
 }
 

--- a/cmd/mcp/call.go
+++ b/cmd/mcp/call.go
@@ -41,9 +41,9 @@ func newCallCmd(opts *options.RootOptions, token *string, factory clientFactory)
 		},
 	}
 
-	cmd.Flags().StringArrayVarP(&o.fieldFlags, "field", "f", nil, "String field: key=value")
+	cmd.Flags().StringArrayVarP(&o.fieldFlags, "field", "f", nil, "String field: key=value (repeatable; not a file)")
 	cmd.Flags().StringArrayVarP(&o.typedFlags, "typed-field", "F", nil, "Typed field: bool/number/null coercion, @file")
-	cmd.Flags().StringVar(&o.input, "input", "", "Read arguments from file (- for stdin)")
+	cmd.Flags().StringVar(&o.input, "input", "", "Read full arguments JSON from a file (- for stdin)")
 	cmd.Flags().StringVarP(&o.jqExpr, "jq", "q", "", "Filter output with jq expression")
 
 	return cmd

--- a/cmd/trigger/update.go
+++ b/cmd/trigger/update.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
@@ -52,7 +52,7 @@ func NewUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&file, "file", "", "Path to JSON file with full trigger definition")
+	cmd.Flags().StringVarP(&file, "file", "f", "", "Path to JSON file with full trigger definition (- for stdin)")
 	cmd.Flags().StringVar(&name, "name", "", "Trigger name")
 	cmd.Flags().StringVar(&description, "description", "", "Trigger description")
 	cmd.Flags().BoolVar(&disabled, "disabled", false, "Disable the trigger")
@@ -89,9 +89,9 @@ func runUpdate(ctx context.Context, opts *options.RootOptions, dataset, triggerI
 	var body api.TriggerResponse
 
 	if flags.hasFile {
-		data, err := os.ReadFile(flags.file)
+		data, err := command.ReadDefinitionFile(opts.IOStreams, flags.file)
 		if err != nil {
-			return fmt.Errorf("reading file: %w", err)
+			return err
 		}
 		if err := json.Unmarshal(data, &body); err != nil {
 			return fmt.Errorf("parsing trigger JSON: %w", err)

--- a/cmd/trigger/update_test.go
+++ b/cmd/trigger/update_test.go
@@ -114,6 +114,54 @@ func TestUpdate_WithFile(t *testing.T) {
 	}
 }
 
+func TestUpdate_WithStdin(t *testing.T) {
+	var getCount int
+	opts, ts := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			getCount++
+		case http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			var parsed map[string]any
+			_ = json.Unmarshal(body, &parsed)
+			if parsed["name"] != "From Stdin" {
+				t.Errorf("name = %v, want %q", parsed["name"], "From Stdin")
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":         "trigger-1",
+				"name":       "From Stdin",
+				"disabled":   false,
+				"triggered":  false,
+				"alert_type": "on_change",
+				"frequency":  600,
+				"threshold":  map[string]any{"op": ">=", "value": 50},
+				"updated_at": "2025-06-02T12:00:00Z",
+			})
+		}
+	}))
+
+	ts.InBuf.WriteString(`{"name":"From Stdin","frequency":600,"threshold":{"op":">=","value":50}}`)
+
+	cmd := NewCmd(opts)
+	cmd.SetArgs([]string{"update", "--dataset", "test-dataset", "trigger-1", "--file", "-"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if getCount != 0 {
+		t.Errorf("GET count = %d, want 0 (file mode should skip GET)", getCount)
+	}
+
+	var detail triggerDetail
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &detail); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if detail.Name != "From Stdin" {
+		t.Errorf("Name = %q, want %q", detail.Name, "From Stdin")
+	}
+}
+
 func TestUpdate_DisabledFlag(t *testing.T) {
 	opts, _ := setupTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
Closes #172. Routes the create/update commands that lacked it through the shared `command.ReadDefinitionFile` helper so every `-f/--file` flag reads a JSON definition from a path or `-` (stdin), matching the calculated-column, board, and trigger-create commands that already did this. The flag handling was inconsistent across resources: some commands had no file intake, `trigger update` read files with a bare `os.ReadFile` (so `-` did not reach stdin) and only exposed `--file` without the `-f` shorthand.

Changes:

- `column create` / `column update`: add `-f/--file` (stdin-aware), decoding the request body from JSON. `update` skips the GET-then-merge path when `--file` is set.
- `marker create` / `marker setting create`: add `-f/--file` decoding `CreateMarkerJSONRequestBody` / `api.MarkerSetting` from file or stdin.
- `trigger update`: switch `--file` to `-f/--file` reusing the stdin-aware reader, so `-` now reads stdin.

For commands where `--file` carries the whole body, the discrete scalar flags are registered as mutually exclusive with `--file` via `cmd.MarkFlagsMutuallyExclusive`, matching the existing precedent in `column calculated` and `board create`. No command needed the `command.ApplyOverrides` merge path.

`mcp call` and `api` keep their deliberate gh-style split (`-f` is a repeatable `key=value` field, `--input` reads a file). This change only clarifies their help text so the distinction is obvious; the flags are unchanged.

Adds table-driven tests for the new file, stdin, and mutual-exclusion paths on each affected command.
