### PR TITLE
fix(mcp): harden OAuth callback and token handling

### DIFF
--- a/cmd/auth/logout.go
+++ b/cmd/auth/logout.go
@@ -57,13 +57,18 @@ func runAuthLogout(opts *options.RootOptions, keyType string) error {
 		deleted = append(deleted, logoutResult{Type: string(kt)})
 	}
 
-	// A full logout (no --key-type) also clears any stored MCP OAuth token set.
+	// A full logout (no --key-type) also clears any stored MCP OAuth token set
+	// and the persisted DCR client ID.
 	if keyType == "" {
 		err := config.DeleteMCPToken(profile)
 		if err == nil {
 			deleted = append(deleted, logoutResult{Type: "mcp"})
 		} else if !errors.Is(err, keyring.ErrNotFound) {
 			return fmt.Errorf("deleting MCP token: %w", err)
+		}
+
+		if err := config.DeleteMCPClientID(profile); err != nil && !errors.Is(err, keyring.ErrNotFound) {
+			return fmt.Errorf("deleting MCP client ID: %w", err)
 		}
 	}
 

--- a/cmd/auth/logout_test.go
+++ b/cmd/auth/logout_test.go
@@ -79,6 +79,88 @@ func TestAuthLogout_AllKeys(t *testing.T) {
 	}
 }
 
+func TestAuthLogout_ClearsMCPToken(t *testing.T) {
+	ts := iostreams.Test(t)
+	opts := &options.RootOptions{
+		IOStreams: ts.IOStreams,
+		Config:    &config.Config{},
+		Format:    "json",
+	}
+
+	if err := config.SetKey("default", config.KeyConfig, "cfg-key"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = config.DeleteKey("default", config.KeyConfig) })
+	if err := config.SetMCPToken("default", map[string]string{"access_token": "tok"}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = config.DeleteMCPToken("default") })
+
+	if err := runAuthLogout(opts, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	var results []logoutResult
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &results); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+
+	var sawMCP bool
+	for _, r := range results {
+		if r.Type == "mcp" {
+			sawMCP = true
+		}
+	}
+	if !sawMCP {
+		t.Errorf("expected a mcp result, got %+v", results)
+	}
+
+	var tok map[string]string
+	if err := config.GetMCPToken("default", &tok); err == nil {
+		t.Error("expected MCP token to be deleted")
+	}
+}
+
+func TestAuthLogout_KeyTypeLeavesMCPToken(t *testing.T) {
+	ts := iostreams.Test(t)
+	opts := &options.RootOptions{
+		IOStreams: ts.IOStreams,
+		Config:    &config.Config{},
+		Format:    "json",
+	}
+
+	if err := config.SetKey("default", config.KeyConfig, "cfg-key"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = config.DeleteKey("default", config.KeyConfig) })
+	if err := config.SetMCPToken("default", map[string]string{"access_token": "tok"}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = config.DeleteMCPToken("default") })
+
+	// A targeted logout only removes the named key type. The MCP token is left
+	// intact so logging out a single API key does not silently drop the
+	// separately scoped MCP credential.
+	if err := runAuthLogout(opts, "config"); err != nil {
+		t.Fatal(err)
+	}
+
+	var results []logoutResult
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &results); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	for _, r := range results {
+		if r.Type == "mcp" {
+			t.Errorf("targeted logout reported mcp result: %+v", results)
+		}
+	}
+
+	var tok map[string]string
+	if err := config.GetMCPToken("default", &tok); err != nil {
+		t.Errorf("expected MCP token to remain, got error: %v", err)
+	}
+}
+
 func TestAuthLogout_NoKeys(t *testing.T) {
 	ts := iostreams.Test(t)
 	opts := &options.RootOptions{

--- a/cmd/mcp/mcp.go
+++ b/cmd/mcp/mcp.go
@@ -105,7 +105,7 @@ func connectWithOAuth(ctx context.Context, conn connectOptions) (*mcpclient.Clie
 		return nil, errNonInteractiveAuth
 	}
 
-	if authErr := authorizeInteractive(ctx, conn.root.IOStreams, err, listener); authErr != nil {
+	if authErr := authorizeInteractive(ctx, conn.root.IOStreams, conn.root.ActiveProfile(), err, listener); authErr != nil {
 		_ = c.Close()
 		return nil, authErr
 	}
@@ -198,17 +198,30 @@ func remediateAuthError(err error) error {
 		return err
 	}
 
-	msg := err.Error()
-	if mcpclient.IsOAuthAuthorizationRequiredError(err) ||
-		strings.Contains(msg, "401") || strings.Contains(msg, "403") ||
-		strings.Contains(strings.ToLower(msg), "unauthorized") ||
-		strings.Contains(strings.ToLower(msg), "forbidden") {
+	if isAuthRejection(err) {
 		return fmt.Errorf("%w (the MCP server rejected the request as unauthenticated; "+
 			"the CLI authenticates to MCP via OAuth, not your API key: re-run interactively to "+
 			"authorize in a browser, set %s for CI, or run 'honeycomb auth logout' to clear stale "+
 			"tokens; see 'honeycomb mcp --help')", err, tokenEnvVar)
 	}
 	return err
+}
+
+// isAuthRejection reports whether err represents the MCP server rejecting the
+// request for authentication or authorization reasons. The typed library
+// errors are the primary signal; the string fallback is tightened to specific
+// phrases so an unrelated error whose text merely contains "401"/"403" digits
+// (e.g. a byte count) does not misfire.
+func isAuthRejection(err error) bool {
+	if mcpclient.IsOAuthAuthorizationRequiredError(err) ||
+		mcpclient.IsAuthorizationRequiredError(err) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unauthorized") ||
+		strings.Contains(msg, "forbidden") ||
+		strings.Contains(msg, "status 401") ||
+		strings.Contains(msg, "status 403")
 }
 
 func NewCmd(opts *options.RootOptions) *cobra.Command {

--- a/cmd/mcp/oauth.go
+++ b/cmd/mcp/oauth.go
@@ -45,6 +45,12 @@ func (s *keyringTokenStore) GetToken(ctx context.Context) (*transport.Token, err
 	if errors.Is(err, keyring.ErrNotFound) {
 		return nil, transport.ErrNoToken
 	}
+	// A stored-but-unparseable entry is unusable. Treat it as no token so the
+	// library re-runs the authorization flow rather than hard-failing both
+	// refresh and re-auth.
+	if errors.Is(err, config.ErrMCPTokenCorrupt) {
+		return nil, transport.ErrNoToken
+	}
 	if err != nil {
 		return nil, fmt.Errorf("reading MCP token: %w", err)
 	}
@@ -64,8 +70,14 @@ func (s *keyringTokenStore) SaveToken(ctx context.Context, token *transport.Toke
 // oauthConfig builds the library OAuth configuration for a profile, wiring the
 // keyring-backed token store, the requested scopes, a loopback redirect URI per
 // RFC 8252, and PKCE (S256). The config key is never referenced here.
+//
+// A previously persisted DCR client ID is seeded so the refresh-token grant can
+// send a stable client_id across CLI invocations. A missing or unreadable entry
+// leaves the client ID empty, which triggers a fresh registration.
 func oauthConfig(profile, redirectURI string) transport.OAuthConfig {
+	clientID, _ := config.GetMCPClientID(profile)
 	return transport.OAuthConfig{
+		ClientID:    clientID,
 		ClientURI:   "https://github.com/bendrucker/honeycomb-cli",
 		RedirectURI: redirectURI,
 		Scopes:      oauthScopes,
@@ -89,7 +101,7 @@ func newOAuthClient(mcpURL, profile, redirectURI string) (*mcpclient.Client, err
 // required. It starts a loopback callback server, opens the browser to the
 // authorization URL, validates the returned state, and exchanges the code for
 // tokens, which the handler persists through the keyring token store.
-func authorizeInteractive(ctx context.Context, ios *iostreams.IOStreams, authErr error, listener net.Listener) error {
+func authorizeInteractive(ctx context.Context, ios *iostreams.IOStreams, profile string, authErr error, listener net.Listener) error {
 	handler := mcpclient.GetOAuthHandler(authErr)
 	if handler == nil {
 		return fmt.Errorf("MCP server requires authorization but no OAuth handler was provided")
@@ -109,6 +121,13 @@ func authorizeInteractive(ctx context.Context, ios *iostreams.IOStreams, authErr
 	if handler.GetClientID() == "" {
 		if err := handler.RegisterClient(ctx, clientName); err != nil {
 			return fmt.Errorf("registering OAuth client: %w", err)
+		}
+		// Persist the registered client ID so a later invocation's refresh grant
+		// sends a stable client_id instead of forcing a fresh browser flow. A
+		// failure here is non-fatal: the in-memory handler still works for this
+		// session.
+		if id := handler.GetClientID(); id != "" {
+			_ = config.SetMCPClientID(profile, id)
 		}
 	}
 
@@ -171,23 +190,54 @@ type callbackParams struct {
 	err     error
 }
 
+const callbackPath = "/callback"
+
+const successPage = `<!doctype html><html><body>` +
+	`<h1>Authorization complete</h1>` +
+	`<p>You can close this window and return to the terminal.</p>` +
+	`</body></html>`
+
+const failurePage = `<!doctype html><html><body>` +
+	`<h1>Authorization failed</h1>` +
+	`<p>Return to the terminal.</p>` +
+	`</body></html>`
+
+// callbackHandler serves the loopback OAuth redirect. It handles only GET
+// requests to the redirect path that carry an authorization result (a code or
+// an error). Browser probes such as /favicon.ico, or bare hits to the redirect
+// path with neither parameter, get a 404/204 and are never delivered to the
+// channel, so exactly one meaningful result reaches the waiting flow without
+// leaking a blocked-send goroutine. The Go flow remains authoritative for state
+// validation; the rendered page only reflects whether the callback looks valid.
 func callbackHandler(ch chan<- callbackParams) http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(callbackPath, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
 		q := r.URL.Query()
-		params := callbackParams{
-			code:    q.Get("code"),
-			state:   q.Get("state"),
-			errCode: q.Get("error"),
+		code := q.Get("code")
+		errCode := q.Get("error")
+		state := q.Get("state")
+
+		// A request carrying neither a code nor an error is not an
+		// authorization response (e.g. a browser probe). Do not consume the
+		// channel slot for it.
+		if code == "" && errCode == "" {
+			w.WriteHeader(http.StatusNoContent)
+			return
 		}
 
 		w.Header().Set("Content-Type", "text/html")
-		_, _ = w.Write([]byte(`<!doctype html><html><body>` +
-			`<h1>Authorization complete</h1>` +
-			`<p>You can close this window and return to the terminal.</p>` +
-			`</body></html>`))
+		if errCode == "" && code != "" {
+			_, _ = w.Write([]byte(successPage))
+		} else {
+			_, _ = w.Write([]byte(failurePage))
+		}
 
-		ch <- params
+		ch <- callbackParams{code: code, state: state, errCode: errCode}
 	})
 	return mux
 }
@@ -201,7 +251,7 @@ func newLoopbackListener() (net.Listener, string, error) {
 		return nil, "", fmt.Errorf("starting loopback callback server: %w", err)
 	}
 	addr := l.Addr().(*net.TCPAddr)
-	redirectURI := fmt.Sprintf("http://127.0.0.1:%d/callback", addr.Port)
+	redirectURI := fmt.Sprintf("http://127.0.0.1:%d%s", addr.Port, callbackPath)
 	return l, redirectURI, nil
 }
 

--- a/cmd/mcp/oauth_test.go
+++ b/cmd/mcp/oauth_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -95,10 +96,12 @@ func TestRemediateAuthError(t *testing.T) {
 		wantSameErr bool
 	}{
 		{name: "nil", err: nil, wantRemedy: false},
-		{name: "401", err: errors.New("request failed with status 401"), wantRemedy: true},
-		{name: "403", err: errors.New("got 403 from server"), wantRemedy: true},
+		{name: "status 401", err: errors.New("request failed with status 401"), wantRemedy: true},
+		{name: "status 403", err: errors.New("request failed with status 403"), wantRemedy: true},
 		{name: "unauthorized text", err: errors.New("Unauthorized"), wantRemedy: true},
 		{name: "forbidden text", err: errors.New("Forbidden"), wantRemedy: true},
+		{name: "benign 401 digits", err: errors.New("read 401 bytes from response"), wantRemedy: false, wantSameErr: true},
+		{name: "benign 403 digits", err: errors.New("payload was 403 bytes"), wantRemedy: false, wantSameErr: true},
 		{name: "unrelated", err: errors.New("connection refused"), wantRemedy: false, wantSameErr: true},
 		{name: "non-interactive passthrough", err: errNonInteractiveAuth, wantRemedy: false, wantSameErr: true},
 	} {
@@ -144,25 +147,91 @@ func TestNewLoopbackListener(t *testing.T) {
 }
 
 func TestCallbackHandler(t *testing.T) {
-	ch := make(chan callbackParams, 1)
-	srv := httptestServer(t, callbackHandler(ch))
+	for _, tc := range []struct {
+		name       string
+		path       string
+		wantStatus int
+		wantSend   bool
+		wantParams callbackParams
+		wantBody   string
+	}{
+		{
+			name:       "valid code renders success and delivers",
+			path:       "/callback?code=abc&state=xyz",
+			wantStatus: http.StatusOK,
+			wantSend:   true,
+			wantParams: callbackParams{code: "abc", state: "xyz"},
+			wantBody:   "Authorization complete",
+		},
+		{
+			name:       "error param renders failure and delivers",
+			path:       "/callback?error=access_denied&state=xyz",
+			wantStatus: http.StatusOK,
+			wantSend:   true,
+			wantParams: callbackParams{errCode: "access_denied", state: "xyz"},
+			wantBody:   "Authorization failed",
+		},
+		{
+			name:       "favicon probe is ignored",
+			path:       "/favicon.ico",
+			wantStatus: http.StatusNotFound,
+			wantSend:   false,
+		},
+		{
+			name:       "bare callback without params is ignored",
+			path:       "/callback",
+			wantStatus: http.StatusNoContent,
+			wantSend:   false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ch := make(chan callbackParams, 1)
+			srv := httptestServer(t, callbackHandler(ch))
 
-	resp, err := http.Get(srv + "/callback?code=abc&state=xyz")
-	if err != nil {
-		t.Fatalf("GET callback: %v", err)
+			resp, err := http.Get(srv + tc.path)
+			if err != nil {
+				t.Fatalf("GET %s: %v", tc.path, err)
+			}
+			body, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+
+			if resp.StatusCode != tc.wantStatus {
+				t.Errorf("status = %d, want %d", resp.StatusCode, tc.wantStatus)
+			}
+			if tc.wantBody != "" && !strings.Contains(string(body), tc.wantBody) {
+				t.Errorf("body = %q, want it to contain %q", string(body), tc.wantBody)
+			}
+
+			select {
+			case params := <-ch:
+				if !tc.wantSend {
+					t.Fatalf("unexpected channel delivery: %+v", params)
+				}
+				if params != tc.wantParams {
+					t.Errorf("params = %+v, want %+v", params, tc.wantParams)
+				}
+			case <-time.After(200 * time.Millisecond):
+				if tc.wantSend {
+					t.Fatal("callback params not received")
+				}
+			}
+		})
 	}
-	_ = resp.Body.Close()
+}
 
-	select {
-	case params := <-ch:
-		if params.code != "abc" {
-			t.Errorf("code = %q, want abc", params.code)
-		}
-		if params.state != "xyz" {
-			t.Errorf("state = %q, want xyz", params.state)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("callback params not received")
+func TestKeyringTokenStore_CorruptJSON(t *testing.T) {
+	const profile = "corrupt-token-test"
+	t.Cleanup(func() { _ = config.DeleteMCPToken(profile) })
+
+	// Store an entry whose JSON is valid but cannot decode into a Token: a
+	// non-RFC3339 string for the time-typed expires_at field.
+	if err := config.SetMCPToken(profile, map[string]any{"expires_at": "not-a-time"}); err != nil {
+		t.Fatalf("SetMCPToken: %v", err)
+	}
+
+	store := newKeyringTokenStore(profile)
+	if _, err := store.GetToken(context.Background()); !errors.Is(err, transport.ErrNoToken) {
+		t.Fatalf("GetToken on corrupt entry = %v, want ErrNoToken", err)
 	}
 }
 

--- a/internal/config/keyring.go
+++ b/internal/config/keyring.go
@@ -2,12 +2,18 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/zalando/go-keyring"
 )
+
+// ErrMCPTokenCorrupt indicates a stored MCP token entry exists but could not be
+// decoded. Callers treat this like a missing token: the entry is unusable, so
+// re-authorizing is the only recovery.
+var ErrMCPTokenCorrupt = errors.New("stored MCP token is corrupt")
 
 const (
 	keyringService = "honeycomb-cli"
@@ -77,7 +83,8 @@ func SetMCPToken(profile string, v any) error {
 }
 
 // GetMCPToken decodes the stored OAuth token set for a profile into v. It
-// returns keyring.ErrNotFound when no token has been stored.
+// returns keyring.ErrNotFound when no token has been stored and
+// ErrMCPTokenCorrupt when the stored entry cannot be decoded.
 func GetMCPToken(profile string, v any) error {
 	var raw string
 	err := withTimeout(func() error {
@@ -89,7 +96,7 @@ func GetMCPToken(profile string, v any) error {
 		return err
 	}
 	if err := json.Unmarshal([]byte(raw), v); err != nil {
-		return fmt.Errorf("decoding MCP token: %w", err)
+		return fmt.Errorf("%w: %w", ErrMCPTokenCorrupt, err)
 	}
 	return nil
 }
@@ -98,6 +105,42 @@ func GetMCPToken(profile string, v any) error {
 func DeleteMCPToken(profile string) error {
 	return withTimeout(func() error {
 		return keyring.Delete(keyringService, mcpTokenKey(profile))
+	})
+}
+
+// mcpClientIDSuffix is the keyring sub-key under which the Dynamic Client
+// Registration client ID is stored. Persisting it lets the refresh-token grant
+// send a stable client_id across CLI invocations instead of re-registering and
+// forcing a fresh browser flow on every token expiry.
+const mcpClientIDSuffix = "mcp-client"
+
+func mcpClientIDKey(profile string) string {
+	return fmt.Sprintf("%s:%s", profile, mcpClientIDSuffix)
+}
+
+// SetMCPClientID stores the DCR-registered OAuth client ID for a profile.
+func SetMCPClientID(profile, clientID string) error {
+	return withTimeout(func() error {
+		return keyring.Set(keyringService, mcpClientIDKey(profile), clientID)
+	})
+}
+
+// GetMCPClientID returns the stored OAuth client ID for a profile, or
+// keyring.ErrNotFound when none has been registered.
+func GetMCPClientID(profile string) (string, error) {
+	var val string
+	err := withTimeout(func() error {
+		var e error
+		val, e = keyring.Get(keyringService, mcpClientIDKey(profile))
+		return e
+	})
+	return val, err
+}
+
+// DeleteMCPClientID removes the stored OAuth client ID for a profile.
+func DeleteMCPClientID(profile string) error {
+	return withTimeout(func() error {
+		return keyring.Delete(keyringService, mcpClientIDKey(profile))
 	})
 }
 


### PR DESCRIPTION
Post-merge review hardening for the experimental `honeycomb mcp` OAuth flow. Follows up #178 / #226. This does not close an issue.

## Callback handler

The loopback callback handler matched every path on `/` and pushed into a size-1 channel unconditionally. A browser probe (`/favicon.ico`) sent an empty `{code:"",state:""}` that could win the `select`, triggering a false "state mismatch (CSRF)" abort and leaking the real handler goroutine on a blocked send. The handler now registers only on `/callback`, accepts only `GET`, and returns `204`/`404` for requests carrying neither `code` nor `error` without touching the channel. Exactly one meaningful result reaches the waiting flow.

The handler also wrote the `Authorization complete` page unconditionally, so `?error=access_denied` or an empty/mismatched `state` still rendered success. It now inspects `error`/`code` first and renders a neutral `Authorization failed` page otherwise. State validation stays authoritative in the Go flow; the page only reflects whether the callback looks like a valid authorization response.

## Token store

A stored-but-unparseable MCP token entry returned a hard `decoding MCP token` error from `GetMCPToken`, blocking both refresh and re-auth. `GetMCPToken` now wraps decode failures in a new `config.ErrMCPTokenCorrupt` sentinel, and the keyring `TokenStore.GetToken` maps that to the library's `transport.ErrNoToken`. A malformed entry is unusable, so the flow re-authorizes instead of dead-ending.

## Auth-error remediation

`remediateAuthError` substring-matched a bare `401`/`403` anywhere in the message, misfiring on unrelated errors whose text merely contained those digits (e.g. a byte count). The typed `IsOAuthAuthorizationRequiredError` / `IsAuthorizationRequiredError` checks are now the primary signal, and the string fallback is tightened to specific phrases (`unauthorized`, `forbidden`, `status 401`, `status 403`). Genuine-401 remediation is unchanged.

## Logout coverage

Added tests in `logout_test.go`: a full `auth logout` with a stored MCP token removes it and reports a `mcp` result, and a targeted `--key-type config` logout leaves the MCP token intact (documents the intended scoping). Forcing a non-`NotFound` `DeleteMCPToken` error is not cleanly simulable (`go-keyring`'s `MockInitWithError` fails every operation globally, so it cannot isolate the MCP delete from the key-deletion loop), so that path is left uncovered rather than refactoring the command to inject a deleter.

## DCR client-id persistence

Investigated the finding that the Dynamic Client Registration `client_id` was held only in the in-memory `OAuthHandler` and never persisted, so a later CLI invocation built a fresh handler with an empty `client_id`. The library's refresh grant sends `data.Set("client_id", h.config.ClientID)`, so an empty value would force a new browser flow on every token expiry.

Fixed with a small persistence hook rather than documenting it: `oauthConfig` seeds `OAuthConfig.ClientID` from a new `{profile}:mcp-client` keyring entry, and `authorizeInteractive` persists `handler.GetClientID()` after a successful `RegisterClient`. A full `auth logout` clears the entry alongside the token. Persistence failures are non-fatal: the in-memory handler still works for the current session.

## Verification

- `go build -o /dev/null ./cmd/honeycomb`
- `go test ./...`
- `go vet ./...`
- `golangci-lint run ./...`
