### PR TITLE
fix(cli): exit non-zero on errors and bad subcommands

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/spf13/cobra"
 )
@@ -16,5 +17,5 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 	cmd.AddCommand(NewStatusCmd(opts))
 	cmd.AddCommand(NewProfileCmd(opts))
 
-	return cmd
+	return command.Group(cmd)
 }

--- a/cmd/auth/profile.go
+++ b/cmd/auth/profile.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/output"
@@ -42,7 +43,7 @@ func NewProfileCmd(opts *options.RootOptions) *cobra.Command {
 
 	cmd.AddCommand(newProfileListCmd(opts))
 
-	return cmd
+	return command.Group(cmd)
 }
 
 func newProfileListCmd(opts *options.RootOptions) *cobra.Command {

--- a/cmd/auth/status.go
+++ b/cmd/auth/status.go
@@ -14,6 +14,11 @@ import (
 	"github.com/zalando/go-keyring"
 )
 
+// errInvalidKey reports that at least one stored key failed verification. The
+// per-key statuses are still written before this is returned, so the exit code
+// is non-zero while JSON/table output remains intact for inspection.
+var errInvalidKey = errors.New("one or more stored keys are invalid")
+
 type KeyStatus struct {
 	Type        string `json:"type"`
 	Status      string `json:"status"`
@@ -97,7 +102,17 @@ func runAuthStatus(ctx context.Context, opts *options.RootOptions, offline bool)
 		}
 	}
 
-	return opts.OutputWriter().Write(statuses, statusTable)
+	if err := opts.OutputWriter().Write(statuses, statusTable); err != nil {
+		return err
+	}
+
+	for _, ks := range statuses {
+		if ks.Status == "invalid" || ks.Status == "error" {
+			return errInvalidKey
+		}
+	}
+
+	return nil
 }
 
 func verifyKey(ctx context.Context, client *api.ClientWithResponses, kt config.KeyType, value string) (KeyStatus, error) {

--- a/cmd/auth/status_test.go
+++ b/cmd/auth/status_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -81,6 +82,7 @@ func TestAuthStatus_Verify(t *testing.T) {
 		key     string
 		handler http.Handler
 		want    KeyStatus
+		wantErr bool
 	}{
 		{
 			name:    "config key valid",
@@ -125,6 +127,7 @@ func TestAuthStatus_Verify(t *testing.T) {
 				Type:   "ingest",
 				Status: "invalid",
 			},
+			wantErr: true,
 		},
 		{
 			name:    "management key valid",
@@ -178,7 +181,12 @@ func TestAuthStatus_Verify(t *testing.T) {
 			}
 			t.Cleanup(func() { _ = config.DeleteKey("default", tt.keyType) })
 
-			if err := runAuthStatus(t.Context(), opts, false); err != nil {
+			err := runAuthStatus(t.Context(), opts, false)
+			if tt.wantErr {
+				if !errors.Is(err, errInvalidKey) {
+					t.Fatalf("got error %v, want errInvalidKey", err)
+				}
+			} else if err != nil {
 				t.Fatal(err)
 			}
 

--- a/cmd/board/board.go
+++ b/cmd/board/board.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
@@ -26,7 +27,7 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 	cmd.AddCommand(NewDeleteCmd(opts))
 	cmd.AddCommand(NewViewCmd(opts))
 
-	return cmd
+	return command.Group(cmd)
 }
 
 type boardListItem struct {

--- a/cmd/board/view.go
+++ b/cmd/board/view.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
@@ -98,5 +99,5 @@ func NewViewCmd(opts *options.RootOptions) *cobra.Command {
 	cmd.AddCommand(NewViewUpdateCmd(opts, &board))
 	cmd.AddCommand(NewViewDeleteCmd(opts, &board))
 
-	return cmd
+	return command.Group(cmd)
 }

--- a/cmd/column/calculated.go
+++ b/cmd/column/calculated.go
@@ -1,6 +1,7 @@
 package column
 
 import (
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
@@ -64,5 +65,5 @@ func NewCalculatedCmd(opts *options.RootOptions, dataset *string) *cobra.Command
 	cmd.AddCommand(NewCalculatedUpdateCmd(opts, dataset))
 	cmd.AddCommand(NewCalculatedDeleteCmd(opts, dataset))
 
-	return cmd
+	return command.Group(cmd)
 }

--- a/cmd/column/column.go
+++ b/cmd/column/column.go
@@ -1,6 +1,7 @@
 package column
 
 import (
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
@@ -81,5 +82,5 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 	cmd.AddCommand(NewDeleteCmd(opts, &dataset))
 	cmd.AddCommand(NewCalculatedCmd(opts, &dataset))
 
-	return cmd
+	return command.Group(cmd)
 }

--- a/cmd/command/group.go
+++ b/cmd/command/group.go
@@ -1,0 +1,27 @@
+package command
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Group configures a grouping command (one that only dispatches to
+// subcommands) so that invoking it without a subcommand prints help and exits
+// non-zero. Without this, cobra falls through to help with exit 0, making a
+// bare or typo'd parent command read as success in CI guards.
+//
+// Cobra already rejects an unknown subcommand with a non-zero "unknown command"
+// error. Group adds the missing case: a bare parent invocation, which sets
+// cobra.NoArgs (so any positional arg is rejected) and a RunE that prints help
+// and returns an error.
+func Group(cmd *cobra.Command) *cobra.Command {
+	cmd.Args = cobra.NoArgs
+	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
+		if err := cmd.Help(); err != nil {
+			return err
+		}
+		return fmt.Errorf("%q requires a subcommand", cmd.CommandPath())
+	}
+	return cmd
+}

--- a/cmd/command/group_test.go
+++ b/cmd/command/group_test.go
@@ -1,0 +1,73 @@
+package command
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newTestGroup(ran *bool) *cobra.Command {
+	parent := Group(&cobra.Command{Use: "parent", Short: "Parent group"})
+	parent.AddCommand(&cobra.Command{
+		Use: "child",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			*ran = true
+			return nil
+		},
+	})
+	return parent
+}
+
+func TestGroup(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		args      []string
+		wantErr   bool
+		wantChild bool
+		wantHelp  bool
+	}{
+		{
+			name:     "bare parent prints help and errors",
+			args:     []string{},
+			wantErr:  true,
+			wantHelp: true,
+		},
+		{
+			name:    "unknown subcommand errors",
+			args:    []string{"bogus"},
+			wantErr: true,
+		},
+		{
+			name:      "valid subcommand runs",
+			args:      []string{"child"},
+			wantErr:   false,
+			wantChild: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var ran bool
+			parent := newTestGroup(&ran)
+
+			var out bytes.Buffer
+			parent.SetOut(&out)
+			parent.SetErr(&out)
+			parent.SetArgs(tc.args)
+
+			err := parent.Execute()
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ran != tc.wantChild {
+				t.Errorf("child ran = %v, want %v", ran, tc.wantChild)
+			}
+			if tc.wantHelp && !strings.Contains(out.String(), "Parent group") {
+				t.Errorf("expected help output, got %q", out.String())
+			}
+		})
+	}
+}

--- a/cmd/command/group_test.go
+++ b/cmd/command/group_test.go
@@ -22,11 +22,12 @@ func newTestGroup(ran *bool) *cobra.Command {
 
 func TestGroup(t *testing.T) {
 	for _, tc := range []struct {
-		name      string
-		args      []string
-		wantErr   bool
-		wantChild bool
-		wantHelp  bool
+		name       string
+		args       []string
+		wantErr    bool
+		wantErrSub string
+		wantChild  bool
+		wantHelp   bool
 	}{
 		{
 			name:     "bare parent prints help and errors",
@@ -35,9 +36,10 @@ func TestGroup(t *testing.T) {
 			wantHelp: true,
 		},
 		{
-			name:    "unknown subcommand errors",
-			args:    []string{"bogus"},
-			wantErr: true,
+			name:       "unknown subcommand errors",
+			args:       []string{"bogus"},
+			wantErr:    true,
+			wantErrSub: "unknown command",
 		},
 		{
 			name:      "valid subcommand runs",
@@ -61,6 +63,9 @@ func TestGroup(t *testing.T) {
 			}
 			if !tc.wantErr && err != nil {
 				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantErrSub != "" && (err == nil || !strings.Contains(err.Error(), tc.wantErrSub)) {
+				t.Errorf("error = %v, want substring %q", err, tc.wantErrSub)
 			}
 			if ran != tc.wantChild {
 				t.Errorf("child ran = %v, want %v", ran, tc.wantChild)

--- a/cmd/dataset/dataset.go
+++ b/cmd/dataset/dataset.go
@@ -1,6 +1,7 @@
 package dataset
 
 import (
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/spf13/cobra"
 )
@@ -19,5 +20,5 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 	cmd.AddCommand(NewDeleteCmd(opts))
 	cmd.AddCommand(NewDefinitionCmd(opts))
 
-	return cmd
+	return command.Group(cmd)
 }

--- a/cmd/dataset/definition.go
+++ b/cmd/dataset/definition.go
@@ -1,6 +1,7 @@
 package dataset
 
 import (
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/spf13/cobra"
 )
@@ -15,5 +16,5 @@ func NewDefinitionCmd(opts *options.RootOptions) *cobra.Command {
 	cmd.AddCommand(NewDefinitionGetCmd(opts))
 	cmd.AddCommand(NewDefinitionUpdateCmd(opts))
 
-	return cmd
+	return command.Group(cmd)
 }

--- a/cmd/environment/environment.go
+++ b/cmd/environment/environment.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/output"
@@ -44,7 +45,7 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 	cmd.AddCommand(NewUpdateCmd(opts, &team))
 	cmd.AddCommand(NewDeleteCmd(opts, &team))
 
-	return cmd
+	return command.Group(cmd)
 }
 
 type environmentItem struct {

--- a/cmd/key/key.go
+++ b/cmd/key/key.go
@@ -3,6 +3,7 @@ package key
 import (
 	"strings"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
@@ -27,7 +28,7 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 	cmd.AddCommand(NewUpdateCmd(opts, &team))
 	cmd.AddCommand(NewDeleteCmd(opts, &team))
 
-	return cmd
+	return command.Group(cmd)
 }
 
 type keyItem struct {

--- a/cmd/marker/marker.go
+++ b/cmd/marker/marker.go
@@ -3,6 +3,7 @@ package marker
 import (
 	"fmt"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
@@ -96,5 +97,5 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 	cmd.AddCommand(NewDeleteCmd(opts, &dataset))
 	cmd.AddCommand(NewSettingCmd(opts, &dataset))
 
-	return cmd
+	return command.Group(cmd)
 }

--- a/cmd/marker/setting.go
+++ b/cmd/marker/setting.go
@@ -1,6 +1,7 @@
 package marker
 
 import (
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
@@ -47,5 +48,5 @@ func NewSettingCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	cmd.AddCommand(NewSettingUpdateCmd(opts, dataset))
 	cmd.AddCommand(NewSettingDeleteCmd(opts, dataset))
 
-	return cmd
+	return command.Group(cmd)
 }

--- a/cmd/mcp/mcp.go
+++ b/cmd/mcp/mcp.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/spf13/cobra"
 )
@@ -226,5 +227,5 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 	cmd.AddCommand(newToolsCmd(opts, &token, nil))
 	cmd.AddCommand(newCallCmd(opts, &token, nil))
 
-	return cmd
+	return command.Group(cmd)
 }

--- a/cmd/query/annotation.go
+++ b/cmd/query/annotation.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
@@ -66,5 +67,5 @@ func NewAnnotationCmd(opts *options.RootOptions, dataset *string) *cobra.Command
 	cmd.AddCommand(NewUpdateCmd(opts, dataset))
 	cmd.AddCommand(NewDeleteCmd(opts, dataset))
 
-	return cmd
+	return command.Group(cmd)
 }

--- a/cmd/query/query.go
+++ b/cmd/query/query.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/spf13/cobra"
 )
@@ -20,5 +21,5 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 	cmd.AddCommand(NewRunCmd(opts, &dataset))
 	cmd.AddCommand(NewAnnotationCmd(opts, &dataset))
 
-	return cmd
+	return command.Group(cmd)
 }

--- a/cmd/recipient/recipient.go
+++ b/cmd/recipient/recipient.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/output"
 	"github.com/spf13/cobra"
@@ -23,7 +24,7 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 	cmd.AddCommand(NewDeleteCmd(opts))
 	cmd.AddCommand(NewTriggersCmd(opts))
 
-	return cmd
+	return command.Group(cmd)
 }
 
 type recipientDetail struct {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/auth"
 	"github.com/bendrucker/honeycomb-cli/cmd/board"
 	"github.com/bendrucker/honeycomb-cli/cmd/column"
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/dataset"
 	"github.com/bendrucker/honeycomb-cli/cmd/environment"
 	"github.com/bendrucker/honeycomb-cli/cmd/key"
@@ -74,5 +75,5 @@ func NewRootCmd(ios *iostreams.IOStreams) *cobra.Command {
 	cmd.AddCommand(slo.NewCmd(opts))
 	cmd.AddCommand(trigger.NewCmd(opts))
 
-	return cmd
+	return command.Group(cmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/auth"
 	"github.com/bendrucker/honeycomb-cli/cmd/board"
 	"github.com/bendrucker/honeycomb-cli/cmd/column"
-	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/dataset"
 	"github.com/bendrucker/honeycomb-cli/cmd/environment"
 	"github.com/bendrucker/honeycomb-cli/cmd/key"
@@ -75,5 +74,5 @@ func NewRootCmd(ios *iostreams.IOStreams) *cobra.Command {
 	cmd.AddCommand(slo.NewCmd(opts))
 	cmd.AddCommand(trigger.NewCmd(opts))
 
-	return command.Group(cmd)
+	return cmd
 }

--- a/cmd/slo/burn_alert.go
+++ b/cmd/slo/burn_alert.go
@@ -1,6 +1,7 @@
 package slo
 
 import (
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/output"
 	"github.com/spf13/cobra"
@@ -40,5 +41,5 @@ func NewBurnAlertCmd(opts *options.RootOptions, dataset *string) *cobra.Command 
 	cmd.AddCommand(NewBurnAlertUpdateCmd(opts, dataset))
 	cmd.AddCommand(NewBurnAlertDeleteCmd(opts, dataset))
 
-	return cmd
+	return command.Group(cmd)
 }

--- a/cmd/slo/slo.go
+++ b/cmd/slo/slo.go
@@ -1,6 +1,7 @@
 package slo
 
 import (
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/spf13/cobra"
 )
@@ -25,5 +26,5 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 	cmd.AddCommand(NewBurnAlertCmd(opts, &dataset))
 	cmd.AddCommand(NewHistoryCmd(opts, &dataset))
 
-	return cmd
+	return command.Group(cmd)
 }

--- a/cmd/trigger/trigger.go
+++ b/cmd/trigger/trigger.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
@@ -29,7 +30,7 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 	cmd.AddCommand(NewUpdateCmd(opts, &dataset))
 	cmd.AddCommand(NewDeleteCmd(opts, &dataset))
 
-	return cmd
+	return command.Group(cmd)
 }
 
 type triggerItem struct {


### PR DESCRIPTION
Closes #173. Two commands returned exit 0 on error or invalid state, so CI guards could not detect failure.

## `auth status` Exits Non-Zero on Invalid Keys

`runAuthStatus` wrote per-key statuses and then unconditionally returned `nil`, so a stored key reported as `invalid` or `error` still exited 0. It now writes the statuses first, then returns a sentinel `errInvalidKey` when any status is `invalid` or `error`. Output (JSON or table) is still printed for inspection; only the exit code changes.

## Grouping Commands Exit Non-Zero Without a Subcommand

Intermediate grouping commands (those that only `AddCommand` children, with no `RunE`) fell through to cobra's help with exit 0, so a bare or typo'd parent read as success. A new `command.Group(cmd)` helper sets `cobra.NoArgs` and a `RunE` that prints help and returns an error when invoked with no subcommand. Cobra already rejects an unknown subcommand with a non-zero `unknown command` error; the helper closes the remaining bare-parent gap.

The helper is applied to every intermediate grouping command: `auth`, `auth profile`, `board`, `board view`, `column`, `column calculated`, `dataset`, `dataset definition`, `environment`, `key`, `marker`, `marker setting`, `mcp`, `query`, `query annotation`, `recipient`, `slo`, `slo burn-alert`, and `trigger`. The root command is left unwrapped so bare `honeycomb` prints help and exits 0, matching `gh`.

## Coverage

Table-driven tests in `cmd/command/group_test.go` exercise the helper across a bare parent (prints help, errors), an unknown subcommand (errors with an `unknown command` message, guarding the path against a future cobra reordering), and a valid subcommand (runs, no error). The `auth status` tests assert the sentinel error fires on an invalid key while the status output is still written.
