### PR TITLE
refactor(output): add Col[T] to drop v.(T) assertions

### DIFF
--- a/cmd/auth/logout.go
+++ b/cmd/auth/logout.go
@@ -78,7 +78,7 @@ func runAuthLogout(opts *options.RootOptions, keyType string) error {
 
 	return opts.OutputWriter().Write(deleted, output.TableDef{
 		Columns: []output.Column{
-			{Header: "TYPE", Value: func(v any) string { return v.(logoutResult).Type }},
+			output.Col("TYPE", func(r logoutResult) string { return r.Type }),
 		},
 	})
 }

--- a/cmd/auth/profile.go
+++ b/cmd/auth/profile.go
@@ -23,15 +23,15 @@ type profileEntry struct {
 
 var profileTable = output.TableDef{
 	Columns: []output.Column{
-		{Header: "Name", Value: func(v any) string { return v.(profileEntry).Name }},
-		{Header: "Active", Value: func(v any) string {
-			if v.(profileEntry).Active {
+		output.Col("Name", func(p profileEntry) string { return p.Name }),
+		output.Col("Active", func(p profileEntry) string {
+			if p.Active {
 				return "*"
 			}
 			return ""
-		}},
-		{Header: "Keys", Value: func(v any) string { return strings.Join(v.(profileEntry).Keys, ", ") }},
-		{Header: "Team", Value: func(v any) string { return v.(profileEntry).Team }},
+		}),
+		output.Col("Keys", func(p profileEntry) string { return strings.Join(p.Keys, ", ") }),
+		output.Col("Team", func(p profileEntry) string { return p.Team }),
 	},
 }
 

--- a/cmd/auth/status.go
+++ b/cmd/auth/status.go
@@ -31,11 +31,11 @@ type KeyStatus struct {
 
 var statusTable = output.TableDef{
 	Columns: []output.Column{
-		{Header: "Type", Value: func(v any) string { return v.(KeyStatus).Type }},
-		{Header: "Status", Value: func(v any) string { return v.(KeyStatus).Status }},
-		{Header: "Team", Value: func(v any) string { return v.(KeyStatus).Team }},
-		{Header: "Environment", Value: func(v any) string { return v.(KeyStatus).Environment }},
-		{Header: "Key ID", Value: func(v any) string { return v.(KeyStatus).KeyID }},
+		output.Col("Type", func(k KeyStatus) string { return k.Type }),
+		output.Col("Status", func(k KeyStatus) string { return k.Status }),
+		output.Col("Team", func(k KeyStatus) string { return k.Team }),
+		output.Col("Environment", func(k KeyStatus) string { return k.Environment }),
+		output.Col("Key ID", func(k KeyStatus) string { return k.KeyID }),
 	},
 }
 

--- a/cmd/board/list.go
+++ b/cmd/board/list.go
@@ -14,10 +14,10 @@ import (
 
 var boardListTable = output.TableDef{
 	Columns: []output.Column{
-		{Header: "ID", Value: func(v any) string { return v.(boardListItem).ID }},
-		{Header: "Name", Value: func(v any) string { return v.(boardListItem).Name }},
-		{Header: "Description", Value: func(v any) string { return output.Truncate(v.(boardListItem).Description, 40) }},
-		{Header: "URL", Value: func(v any) string { return v.(boardListItem).URL }},
+		output.Col("ID", func(b boardListItem) string { return b.ID }),
+		output.Col("Name", func(b boardListItem) string { return b.Name }),
+		output.Col("Description", func(b boardListItem) string { return output.Truncate(b.Description, 40) }),
+		output.Col("URL", func(b boardListItem) string { return b.URL }),
 	},
 }
 

--- a/cmd/column/column.go
+++ b/cmd/column/column.go
@@ -31,17 +31,17 @@ type columnDetail struct {
 
 var columnListTable = output.TableDef{
 	Columns: []output.Column{
-		{Header: "ID", Value: func(v any) string { return v.(columnItem).ID }},
-		{Header: "Key Name", Value: func(v any) string { return v.(columnItem).KeyName }},
-		{Header: "Type", Value: func(v any) string { return v.(columnItem).Type }},
-		{Header: "Description", Value: func(v any) string { return v.(columnItem).Description }},
-		{Header: "Hidden", Value: func(v any) string {
-			if v.(columnItem).Hidden {
+		output.Col("ID", func(c columnItem) string { return c.ID }),
+		output.Col("Key Name", func(c columnItem) string { return c.KeyName }),
+		output.Col("Type", func(c columnItem) string { return c.Type }),
+		output.Col("Description", func(c columnItem) string { return c.Description }),
+		output.Col("Hidden", func(c columnItem) string {
+			if c.Hidden {
 				return "yes"
 			}
 			return "no"
-		}},
-		{Header: "Last Written", Value: func(v any) string { return v.(columnItem).LastWritten }},
+		}),
+		output.Col("Last Written", func(c columnItem) string { return c.LastWritten }),
 	},
 }
 

--- a/cmd/dataset/list.go
+++ b/cmd/dataset/list.go
@@ -24,18 +24,18 @@ type datasetItem struct {
 var datasetListTable = func() output.TableDef {
 	table := output.TableFromTags[datasetItem]()
 	table.Columns = append(table.Columns,
-		output.Column{Header: "Columns", Value: func(v any) string {
-			if c := v.(datasetItem).Columns; c != nil {
+		output.Col("Columns", func(d datasetItem) string {
+			if c := d.Columns; c != nil {
 				return fmt.Sprintf("%d", *c)
 			}
 			return "—"
-		}},
-		output.Column{Header: "Last Written", Value: func(v any) string {
-			if lw := v.(datasetItem).LastWritten; lw != nil {
+		}),
+		output.Col("Last Written", func(d datasetItem) string {
+			if lw := d.LastWritten; lw != nil {
 				return *lw
 			}
 			return "—"
-		}},
+		}),
 	)
 	return table
 }()

--- a/cmd/marker/marker.go
+++ b/cmd/marker/marker.go
@@ -25,22 +25,22 @@ type markerItem struct {
 
 var markerListTable = output.TableDef{
 	Columns: []output.Column{
-		{Header: "ID", Value: func(v any) string { return v.(markerItem).ID }},
-		{Header: "Type", Value: func(v any) string { return v.(markerItem).Type }},
-		{Header: "Message", Value: func(v any) string { return v.(markerItem).Message }},
-		{Header: "Start Time", Value: func(v any) string {
-			if st := v.(markerItem).StartTime; st != nil {
+		output.Col("ID", func(m markerItem) string { return m.ID }),
+		output.Col("Type", func(m markerItem) string { return m.Type }),
+		output.Col("Message", func(m markerItem) string { return m.Message }),
+		output.Col("Start Time", func(m markerItem) string {
+			if st := m.StartTime; st != nil {
 				return fmt.Sprintf("%d", *st)
 			}
 			return ""
-		}},
-		{Header: "End Time", Value: func(v any) string {
-			if et := v.(markerItem).EndTime; et != nil {
+		}),
+		output.Col("End Time", func(m markerItem) string {
+			if et := m.EndTime; et != nil {
 				return fmt.Sprintf("%d", *et)
 			}
 			return ""
-		}},
-		{Header: "Color", Value: func(v any) string { return v.(markerItem).Color }},
+		}),
+		output.Col("Color", func(m markerItem) string { return m.Color }),
 	},
 }
 

--- a/cmd/mcp/tools.go
+++ b/cmd/mcp/tools.go
@@ -13,8 +13,8 @@ import (
 
 var toolsTable = output.TableDef{
 	Columns: []output.Column{
-		{Header: "Name", Value: func(v any) string { return v.(mcp.Tool).Name }},
-		{Header: "Description", Value: func(v any) string { return v.(mcp.Tool).Description }},
+		output.Col("Name", func(t mcp.Tool) string { return t.Name }),
+		output.Col("Description", func(t mcp.Tool) string { return t.Description }),
 	},
 }
 

--- a/cmd/recipient/list.go
+++ b/cmd/recipient/list.go
@@ -12,9 +12,9 @@ import (
 )
 
 var recipientListTable = output.TableDef{Columns: []output.Column{
-	{Header: "ID", Value: func(v any) string { return v.(recipientDetail).ID }},
-	{Header: "Type", Value: func(v any) string { return v.(recipientDetail).Type }},
-	{Header: "Target", Value: func(v any) string { return extractTarget(v.(recipientDetail)) }},
+	output.Col("ID", func(r recipientDetail) string { return r.ID }),
+	output.Col("Type", func(r recipientDetail) string { return r.Type }),
+	output.Col("Target", func(r recipientDetail) string { return extractTarget(r) }),
 }}
 
 func NewListCmd(opts *options.RootOptions) *cobra.Command {

--- a/cmd/slo/list.go
+++ b/cmd/slo/list.go
@@ -14,12 +14,12 @@ import (
 
 var sloListTable = output.TableDef{
 	Columns: []output.Column{
-		{Header: "ID", Value: func(v any) string { return v.(sloItem).ID }},
-		{Header: "Name", Value: func(v any) string { return v.(sloItem).Name }},
-		{Header: "Target", Value: func(v any) string { return formatTarget(v.(sloItem).TargetPerMillion) }},
-		{Header: "Time Period", Value: func(v any) string { return formatTimePeriod(v.(sloItem).TimePeriodDays) }},
-		{Header: "SLI Alias", Value: func(v any) string { return v.(sloItem).SLIAlias }},
-		{Header: "Description", Value: func(v any) string { return output.Truncate(v.(sloItem).Description, 40) }},
+		output.Col("ID", func(s sloItem) string { return s.ID }),
+		output.Col("Name", func(s sloItem) string { return s.Name }),
+		output.Col("Target", func(s sloItem) string { return formatTarget(s.TargetPerMillion) }),
+		output.Col("Time Period", func(s sloItem) string { return formatTimePeriod(s.TimePeriodDays) }),
+		output.Col("SLI Alias", func(s sloItem) string { return s.SLIAlias }),
+		output.Col("Description", func(s sloItem) string { return output.Truncate(s.Description, 40) }),
 	},
 }
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -51,6 +51,13 @@ type Column struct {
 	Value  func(any) string
 }
 
+// Col builds a Column from a typed accessor, removing the per-call-site v.(T)
+// assertion. Value is still stored as func(any) string, so Col-built columns
+// mix freely with TableFromTags-derived ones.
+func Col[T any](header string, value func(T) string) Column {
+	return Column{Header: header, Value: func(v any) string { return value(v.(T)) }}
+}
+
 type TableDef struct {
 	Columns []Column
 }


### PR DESCRIPTION
Adds a generic `output.Col[T]` constructor so custom table columns take a typed accessor instead of an unchecked `v.(T)` assertion in every `Value` closure. A wrong field or type now fails to compile rather than panicking at runtime.

```go
func Col[T any](header string, value func(T) string) Column {
	return Column{Header: header, Value: func(v any) string { return value(v.(T)) }}
}
```

Call sites go from `output.Column{Header: "Description", Value: func(v any) string { return output.Truncate(v.(boardListItem).Description, 40) }}` to `output.Col("Description", func(b boardListItem) string { return output.Truncate(b.Description, 40) })`.

## Changes

- Added `output.Col[T]` to `internal/output/output.go`.
- Migrated 39 custom column closures across 10 files (`board/list`, `recipient/list`, `auth/{logout,status,profile}`, `dataset/list`, `column`, `mcp/tools`, `slo/list`, `marker`).
- `Value` is still stored as `func(any) string`, so `Col`-built columns mix freely with `TableFromTags`-derived ones. The JSON path, `TableFromTags`, and `OutputWriter`/`OutputWriterList` are unchanged.

I did not add the `Field` analog (`Fld`): `Field.Value` is a plain `string` computed inline at each detail site, with no `v.(T)` assertion to remove, so a helper there would be noise.

Closes #206
