### PR TITLE
feat(cmd): add usage examples to top commands

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -10,6 +10,14 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
 		Short: "Manage authentication",
+		Example: `  # Authenticate with Honeycomb
+  honeycomb auth login
+
+  # Check the current authentication status
+  honeycomb auth status
+
+  # Remove stored authentication keys
+  honeycomb auth logout`,
 	}
 
 	cmd.AddCommand(NewLoginCmd(opts))

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -36,6 +36,15 @@ func NewLoginCmd(opts *options.RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Authenticate with Honeycomb",
+		Example: `  # Authenticate interactively
+  honeycomb auth login
+
+  # Store a configuration key non-interactively
+  honeycomb auth login --key-type config --key-secret "$HONEYCOMB_KEY"
+
+  # Store a management key with a team slug
+  honeycomb auth login --key-type management \
+    --key-id KEY_ID --key-secret KEY_SECRET --team my-team`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if cmd.Flags().Changed("no-verify") {
 				verify = false

--- a/cmd/auth/logout.go
+++ b/cmd/auth/logout.go
@@ -21,6 +21,11 @@ func NewLogoutCmd(opts *options.RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logout",
 		Short: "Remove stored authentication keys",
+		Example: `  # Remove all stored keys for the active profile
+  honeycomb auth logout
+
+  # Remove only the management key
+  honeycomb auth logout --key-type management`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runAuthLogout(opts, keyType)
 		},

--- a/cmd/auth/profile.go
+++ b/cmd/auth/profile.go
@@ -39,6 +39,8 @@ func NewProfileCmd(opts *options.RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "profile",
 		Short: "Manage authentication profiles",
+		Example: `  # List configured profiles
+  honeycomb auth profile list`,
 	}
 
 	cmd.AddCommand(newProfileListCmd(opts))
@@ -50,6 +52,8 @@ func newProfileListCmd(opts *options.RootOptions) *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
 		Short: "List configured profiles",
+		Example: `  # List configured profiles
+  honeycomb auth profile list`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runProfileList(opts)
 		},

--- a/cmd/auth/status.go
+++ b/cmd/auth/status.go
@@ -45,6 +45,14 @@ func NewStatusCmd(opts *options.RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Show authentication status",
+		Example: `  # Show status, verifying keys against the API
+  honeycomb auth status
+
+  # Show status without contacting the API
+  honeycomb auth status --offline
+
+  # Output status as JSON
+  honeycomb auth status --format json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runAuthStatus(cmd.Context(), opts, offline)
 		},

--- a/cmd/board/board.go
+++ b/cmd/board/board.go
@@ -18,6 +18,14 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 		Use:     "board",
 		Short:   "Manage boards",
 		Aliases: []string{"boards"},
+		Example: `  # List boards
+  honeycomb board list
+
+  # Get a board by ID
+  honeycomb board get abc123
+
+  # Create a board from a file
+  honeycomb board create --file board.json`,
 	}
 
 	cmd.AddCommand(NewListCmd(opts))

--- a/cmd/board/create.go
+++ b/cmd/board/create.go
@@ -23,6 +23,11 @@ func NewCreateCmd(opts *options.RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a board",
+		Example: `  # Create a board with a name
+  honeycomb board create --name "Latency"
+
+  # Create a board from a JSON file
+  honeycomb board create --file board.json`,
 		Long: `Create a board.
 
 Use --file to provide a full board definition as JSON. The preset_filters array

--- a/cmd/board/delete.go
+++ b/cmd/board/delete.go
@@ -17,7 +17,12 @@ func NewDeleteCmd(opts *options.RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete <board-id>",
 		Short: "Delete a board",
-		Args:  cobra.ExactArgs(1),
+		Example: `  # Delete a board, prompting for confirmation
+  honeycomb board delete abc123
+
+  # Delete without confirmation
+  honeycomb board delete abc123 --yes`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runBoardDelete(cmd.Context(), opts, args[0], yes)
 		},

--- a/cmd/board/get.go
+++ b/cmd/board/get.go
@@ -14,7 +14,9 @@ func NewGetCmd(opts *options.RootOptions) *cobra.Command {
 	return &cobra.Command{
 		Use:   "get <board-id>",
 		Short: "Get a board",
-		Args:  cobra.ExactArgs(1),
+		Example: `  # Get a board by ID
+  honeycomb board get abc123`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runBoardGet(cmd.Context(), opts, args[0])
 		},

--- a/cmd/board/list.go
+++ b/cmd/board/list.go
@@ -25,6 +25,11 @@ func NewListCmd(opts *options.RootOptions) *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
 		Short: "List boards",
+		Example: `  # List boards
+  honeycomb board list
+
+  # List boards as JSON
+  honeycomb board list --format json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runBoardList(cmd.Context(), opts)
 		},

--- a/cmd/board/update.go
+++ b/cmd/board/update.go
@@ -24,6 +24,11 @@ func NewUpdateCmd(opts *options.RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update <board-id>",
 		Short: "Update a board",
+		Example: `  # Rename a board
+  honeycomb board update abc123 --name "Latency"
+
+  # Replace a board entirely from a file
+  honeycomb board update abc123 --file board.json --replace`,
 		Long: `Update a board.
 
 Use --file to provide a full or partial board definition as JSON. The

--- a/cmd/board/view.go
+++ b/cmd/board/view.go
@@ -88,6 +88,11 @@ func NewViewCmd(opts *options.RootOptions) *cobra.Command {
 		Use:     "view",
 		Short:   "Manage board views",
 		Aliases: []string{"views"},
+		Example: `  # List views on a board
+  honeycomb board view list --board abc123
+
+  # Get a view by ID
+  honeycomb board view get view123 --board abc123`,
 	}
 
 	cmd.PersistentFlags().StringVar(&board, "board", "", "Board ID (required)")

--- a/cmd/board/view_create.go
+++ b/cmd/board/view_create.go
@@ -24,6 +24,12 @@ func NewViewCreateCmd(opts *options.RootOptions, board *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a board view",
+		Example: `  # Create a view with a filter
+  honeycomb board view create --board abc123 --name "Errors" \
+    --filter "status_code:>=:500"
+
+  # Create a view from a JSON file
+  honeycomb board view create --board abc123 --file view.json`,
 		Long: "Create a board view.\n\n" +
 			"Each --filter is column:operation:value. The value is omitted for " +
 			"operations that take no operand (e.g. exists). Valid operations:\n\n  " +

--- a/cmd/board/view_delete.go
+++ b/cmd/board/view_delete.go
@@ -17,7 +17,12 @@ func NewViewDeleteCmd(opts *options.RootOptions, board *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete <view-id>",
 		Short: "Delete a board view",
-		Args:  cobra.ExactArgs(1),
+		Example: `  # Delete a view, prompting for confirmation
+  honeycomb board view delete view123 --board abc123
+
+  # Delete without confirmation
+  honeycomb board view delete view123 --board abc123 --yes`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runViewDelete(cmd.Context(), opts, *board, args[0], yes)
 		},

--- a/cmd/board/view_get.go
+++ b/cmd/board/view_get.go
@@ -14,7 +14,9 @@ func NewViewGetCmd(opts *options.RootOptions, board *string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "get <view-id>",
 		Short: "Get a board view",
-		Args:  cobra.ExactArgs(1),
+		Example: `  # Get a board view by ID
+  honeycomb board view get view123 --board abc123`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runViewGet(cmd.Context(), opts, *board, args[0])
 		},

--- a/cmd/board/view_list.go
+++ b/cmd/board/view_list.go
@@ -14,6 +14,8 @@ func NewViewListCmd(opts *options.RootOptions, board *string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
 		Short: "List board views",
+		Example: `  # List views on a board
+  honeycomb board view list --board abc123`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runViewList(cmd.Context(), opts, *board)
 		},

--- a/cmd/board/view_update.go
+++ b/cmd/board/view_update.go
@@ -23,7 +23,13 @@ func NewViewUpdateCmd(opts *options.RootOptions, board *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update <view-id>",
 		Short: "Update a board view",
-		Args:  cobra.ExactArgs(1),
+		Example: `  # Rename a view
+  honeycomb board view update view123 --board abc123 --name "Errors"
+
+  # Replace a view's filters
+  honeycomb board view update view123 --board abc123 \
+    --filter "status_code:>=:500"`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runViewUpdate(cmd, opts, *board, args[0], file, name, filterArgs)
 		},

--- a/cmd/dataset/create.go
+++ b/cmd/dataset/create.go
@@ -23,6 +23,12 @@ func NewCreateCmd(opts *options.RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a dataset",
+		Example: `  # Create a dataset
+  honeycomb dataset create --name "My Dataset"
+
+  # Create a dataset with a description and JSON unpacking
+  honeycomb dataset create --name "My Dataset" \
+    --description "Production traffic" --expand-json-depth 2`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			var ejd *int
 			if cmd.Flags().Changed("expand-json-depth") {

--- a/cmd/dataset/dataset.go
+++ b/cmd/dataset/dataset.go
@@ -11,6 +11,14 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 		Use:     "dataset",
 		Short:   "Manage datasets",
 		Aliases: []string{"datasets"},
+		Example: `  # List datasets
+  honeycomb dataset list
+
+  # Get a dataset by slug
+  honeycomb dataset get my-dataset
+
+  # Create a dataset
+  honeycomb dataset create --name "My Dataset"`,
 	}
 
 	cmd.AddCommand(NewListCmd(opts))

--- a/cmd/dataset/definition.go
+++ b/cmd/dataset/definition.go
@@ -11,6 +11,11 @@ func NewDefinitionCmd(opts *options.RootOptions) *cobra.Command {
 		Use:     "definition",
 		Short:   "Manage dataset definitions",
 		Aliases: []string{"definitions"},
+		Example: `  # Get dataset definitions
+  honeycomb dataset definition get my-dataset
+
+  # Update dataset definitions from a file
+  honeycomb dataset definition update my-dataset --file definitions.json`,
 	}
 
 	cmd.AddCommand(NewDefinitionGetCmd(opts))

--- a/cmd/dataset/definition_get.go
+++ b/cmd/dataset/definition_get.go
@@ -17,7 +17,9 @@ func NewDefinitionGetCmd(opts *options.RootOptions) *cobra.Command {
 	return &cobra.Command{
 		Use:   "get <dataset-slug>",
 		Short: "Get dataset definitions",
-		Args:  cobra.ExactArgs(1),
+		Example: `  # Get the definitions for a dataset
+  honeycomb dataset definition get my-dataset`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDefinitionGet(cmd.Context(), opts, args[0])
 		},

--- a/cmd/dataset/definition_update.go
+++ b/cmd/dataset/definition_update.go
@@ -18,7 +18,13 @@ func NewDefinitionUpdateCmd(opts *options.RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update <dataset-slug>",
 		Short: "Update dataset definitions",
-		Args:  cobra.ExactArgs(1),
+		Example: `  # Update definitions from a file
+  honeycomb dataset definition update my-dataset --file definitions.json
+
+  # Pipe definitions from stdin
+  cat definitions.json | \
+    honeycomb dataset definition update my-dataset --file -`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDefinitionUpdate(cmd.Context(), opts, args[0], file)
 		},

--- a/cmd/dataset/delete.go
+++ b/cmd/dataset/delete.go
@@ -20,7 +20,12 @@ func NewDeleteCmd(opts *options.RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete <slug>",
 		Short: "Delete a dataset",
-		Args:  cobra.ExactArgs(1),
+		Example: `  # Delete a dataset, prompting for confirmation
+  honeycomb dataset delete my-dataset
+
+  # Delete without confirmation
+  honeycomb dataset delete my-dataset --yes`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDatasetDelete(cmd.Context(), opts, args[0], yes)
 		},

--- a/cmd/dataset/get.go
+++ b/cmd/dataset/get.go
@@ -49,7 +49,9 @@ func NewGetCmd(opts *options.RootOptions) *cobra.Command {
 	return &cobra.Command{
 		Use:   "get <slug>",
 		Short: "Get a dataset",
-		Args:  cobra.ExactArgs(1),
+		Example: `  # Get a dataset by slug
+  honeycomb dataset get my-dataset`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDatasetGet(cmd.Context(), opts, args[0])
 		},

--- a/cmd/dataset/list.go
+++ b/cmd/dataset/list.go
@@ -44,6 +44,11 @@ func NewListCmd(opts *options.RootOptions) *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
 		Short: "List datasets",
+		Example: `  # List datasets
+  honeycomb dataset list
+
+  # List datasets as JSON
+  honeycomb dataset list --format json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runDatasetList(cmd.Context(), opts)
 		},

--- a/cmd/dataset/update.go
+++ b/cmd/dataset/update.go
@@ -22,7 +22,12 @@ func NewUpdateCmd(opts *options.RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update <slug>",
 		Short: "Update a dataset",
-		Args:  cobra.ExactArgs(1),
+		Example: `  # Update a dataset's description
+  honeycomb dataset update my-dataset --description "Updated"
+
+  # Disable delete protection
+  honeycomb dataset update my-dataset --delete-protected=false`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var dp *bool
 			if cmd.Flags().Changed("delete-protected") {

--- a/cmd/example_test.go
+++ b/cmd/example_test.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bendrucker/honeycomb-cli/internal/iostreams"
+	"github.com/spf13/cobra"
+)
+
+// coveredResources are the top-level resource commands whose leaf subcommands
+// must carry usage examples. Resources outside this set may add examples later
+// but are not asserted here.
+var coveredResources = map[string]bool{
+	"auth":    true,
+	"query":   true,
+	"dataset": true,
+	"board":   true,
+	"trigger": true,
+	"key":     true,
+}
+
+// TestLeafCommandsHaveExamples walks the command tree and asserts that every
+// leaf command (one with RunE set and no subcommands) under a covered resource
+// has a non-empty Example.
+func TestLeafCommandsHaveExamples(t *testing.T) {
+	root := NewRootCmd(iostreams.Test(t).IOStreams)
+
+	for _, resource := range root.Commands() {
+		if !coveredResources[resource.Name()] {
+			continue
+		}
+
+		walkLeaves(resource, func(leaf *cobra.Command) {
+			t.Run(commandPath(leaf), func(t *testing.T) {
+				if strings.TrimSpace(leaf.Example) == "" {
+					t.Errorf("leaf command %q has no Example", commandPath(leaf))
+				}
+			})
+		})
+	}
+}
+
+func walkLeaves(cmd *cobra.Command, fn func(*cobra.Command)) {
+	subcommands := cmd.Commands()
+	if cmd.RunE != nil && len(subcommands) == 0 {
+		fn(cmd)
+		return
+	}
+	for _, sub := range subcommands {
+		walkLeaves(sub, fn)
+	}
+}
+
+func commandPath(cmd *cobra.Command) string {
+	var parts []string
+	for c := cmd; c != nil; c = c.Parent() {
+		parts = append([]string{c.Name()}, parts...)
+	}
+	return strings.Join(parts, " ")
+}

--- a/cmd/key/create.go
+++ b/cmd/key/create.go
@@ -43,6 +43,13 @@ func NewCreateCmd(opts *options.RootOptions, team *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create an API key",
+		Example: `  # Create an ingest key in an environment
+  honeycomb key create --name "ingest" --key-type ingest \
+    --environment env-abc --all-permissions
+
+  # Create a configuration key with specific permissions
+  honeycomb key create --name "config" --key-type configuration \
+    --environment env-abc --permission boards --permission triggers`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.RequireTeam(team); err != nil {
 				return err

--- a/cmd/key/delete.go
+++ b/cmd/key/delete.go
@@ -17,7 +17,12 @@ func NewDeleteCmd(opts *options.RootOptions, team *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete <id>",
 		Short: "Delete an API key",
-		Args:  cobra.ExactArgs(1),
+		Example: `  # Delete an API key, prompting for confirmation
+  honeycomb key delete abc123
+
+  # Delete without confirmation
+  honeycomb key delete abc123 --yes`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.RequireTeam(team); err != nil {
 				return err

--- a/cmd/key/get.go
+++ b/cmd/key/get.go
@@ -14,7 +14,9 @@ func NewGetCmd(opts *options.RootOptions, team *string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "get <id>",
 		Short: "Get an API key",
-		Args:  cobra.ExactArgs(1),
+		Example: `  # Get an API key by ID
+  honeycomb key get abc123`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.RequireTeam(team); err != nil {
 				return err

--- a/cmd/key/key.go
+++ b/cmd/key/key.go
@@ -18,6 +18,11 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 		Use:     "key",
 		Short:   "Manage API keys",
 		Aliases: []string{"keys"},
+		Example: `  # List API keys
+  honeycomb key list
+
+  # Get an API key by ID
+  honeycomb key get abc123`,
 	}
 
 	cmd.PersistentFlags().StringVar(&team, "team", "", "Team slug")

--- a/cmd/key/list.go
+++ b/cmd/key/list.go
@@ -25,6 +25,11 @@ func NewListCmd(opts *options.RootOptions, team *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List API keys",
+		Example: `  # List API keys
+  honeycomb key list
+
+  # List only ingest keys
+  honeycomb key list --key-type ingest`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.RequireTeam(team); err != nil {
 				return err

--- a/cmd/key/update.go
+++ b/cmd/key/update.go
@@ -23,7 +23,12 @@ func NewUpdateCmd(opts *options.RootOptions, team *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update <id>",
 		Short: "Update an API key",
-		Args:  cobra.ExactArgs(1),
+		Example: `  # Rename an API key
+  honeycomb key update abc123 --name "renamed"
+
+  # Disable an API key
+  honeycomb key update abc123 --disabled`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.RequireTeam(team); err != nil {
 				return err

--- a/cmd/query/annotation.go
+++ b/cmd/query/annotation.go
@@ -59,6 +59,11 @@ func NewAnnotationCmd(opts *options.RootOptions, dataset *string) *cobra.Command
 		Use:     "annotation",
 		Short:   "Manage query annotations (saved queries)",
 		Aliases: []string{"annotations"},
+		Example: `  # List saved query annotations
+  honeycomb query annotation list --dataset my-dataset
+
+  # View a single annotation
+  honeycomb query annotation view q-abc --dataset my-dataset`,
 	}
 
 	cmd.AddCommand(NewListCmd(opts, dataset))

--- a/cmd/query/annotation_delete.go
+++ b/cmd/query/annotation_delete.go
@@ -17,7 +17,12 @@ func NewDeleteCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete <annotation-id>",
 		Short: "Delete a query annotation",
-		Args:  cobra.ExactArgs(1),
+		Example: `  # Delete an annotation, prompting for confirmation
+  honeycomb query annotation delete q-abc --dataset my-dataset
+
+  # Delete without confirmation
+  honeycomb query annotation delete q-abc --dataset my-dataset --yes`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runAnnotationDelete(cmd.Context(), opts, *dataset, args[0], yes)
 		},

--- a/cmd/query/annotation_list.go
+++ b/cmd/query/annotation_list.go
@@ -16,6 +16,12 @@ func NewListCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List query annotations",
+		Example: `  # List annotations for a dataset
+  honeycomb query annotation list --dataset my-dataset
+
+  # Include annotations created from boards
+  honeycomb query annotation list --dataset my-dataset \
+    --include-board-annotations`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runAnnotationList(cmd.Context(), opts, *dataset, includeBoardAnnotations)
 		},

--- a/cmd/query/annotation_update.go
+++ b/cmd/query/annotation_update.go
@@ -22,7 +22,14 @@ func NewUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update <annotation-id>",
 		Short: "Update a query annotation",
-		Args:  cobra.ExactArgs(1),
+		Example: `  # Update an annotation's name
+  honeycomb query annotation update q-abc --dataset my-dataset \
+    --name "p99 latency"
+
+  # Update from a JSON file
+  honeycomb query annotation update q-abc --dataset my-dataset \
+    --file annotation.json`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runAnnotationUpdate(cmd, opts, *dataset, args[0], file, name, desc)
 		},

--- a/cmd/query/annotation_view.go
+++ b/cmd/query/annotation_view.go
@@ -21,7 +21,9 @@ func NewViewCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "view <annotation-id>",
 		Short: "View a query annotation",
-		Args:  cobra.ExactArgs(1),
+		Example: `  # View a query annotation by ID
+  honeycomb query annotation view q-abc --dataset my-dataset`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runAnnotationView(cmd.Context(), opts, *dataset, args[0])
 		},

--- a/cmd/query/query.go
+++ b/cmd/query/query.go
@@ -13,6 +13,11 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 		Use:     "query",
 		Short:   "Manage queries and saved queries",
 		Aliases: []string{"queries"},
+		Example: `  # Run a query from a spec file
+  honeycomb query run --dataset my-dataset --file query.json
+
+  # List saved query annotations
+  honeycomb query annotation list --dataset my-dataset`,
 	}
 
 	cmd.PersistentFlags().StringVar(&dataset, "dataset", "", "Dataset slug (required)")

--- a/cmd/query/run.go
+++ b/cmd/query/run.go
@@ -24,6 +24,15 @@ func NewRunCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Run a query",
+		Example: `  # Run a query from a spec file
+  honeycomb query run --dataset my-dataset --file query.json
+
+  # Pipe a query spec from stdin
+  echo '{"calculations":[{"op":"COUNT"}]}' | \
+    honeycomb query run --dataset my-dataset --file -
+
+  # Re-run a saved query annotation
+  honeycomb query run --dataset my-dataset --annotation q-abc`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runQueryRun(cmd.Context(), opts, *dataset, file, annotation)
 		},

--- a/cmd/trigger/create.go
+++ b/cmd/trigger/create.go
@@ -23,6 +23,12 @@ func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a trigger",
+		Example: `  # Create a trigger from a file
+  honeycomb trigger create --dataset my-dataset --file trigger.json
+
+  # Create from a file, overriding the name
+  honeycomb trigger create --dataset my-dataset --file trigger.json \
+    --name "High latency"`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if !cmd.Flags().Changed("file") {
 				return fmt.Errorf("--file is required")

--- a/cmd/trigger/delete.go
+++ b/cmd/trigger/delete.go
@@ -17,7 +17,12 @@ func NewDeleteCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete <trigger-id>",
 		Short: "Delete a trigger",
-		Args:  cobra.ExactArgs(1),
+		Example: `  # Delete a trigger, prompting for confirmation
+  honeycomb trigger delete abc123 --dataset my-dataset
+
+  # Delete without confirmation
+  honeycomb trigger delete abc123 --dataset my-dataset --yes`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDelete(cmd.Context(), opts, *dataset, args[0], yes)
 		},

--- a/cmd/trigger/get.go
+++ b/cmd/trigger/get.go
@@ -14,7 +14,9 @@ func NewGetCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "get <trigger-id>",
 		Short: "Get a trigger",
-		Args:  cobra.ExactArgs(1),
+		Example: `  # Get a trigger by ID
+  honeycomb trigger get abc123 --dataset my-dataset`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runGet(cmd.Context(), opts, *dataset, args[0])
 		},

--- a/cmd/trigger/list.go
+++ b/cmd/trigger/list.go
@@ -17,6 +17,11 @@ func NewListCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
 		Short: "List triggers",
+		Example: `  # List triggers for a dataset
+  honeycomb trigger list --dataset my-dataset
+
+  # List triggers as JSON
+  honeycomb trigger list --dataset my-dataset --format json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runList(cmd.Context(), opts, *dataset)
 		},

--- a/cmd/trigger/trigger.go
+++ b/cmd/trigger/trigger.go
@@ -19,6 +19,11 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 		Use:     "trigger",
 		Short:   "Manage triggers",
 		Aliases: []string{"triggers"},
+		Example: `  # List triggers for a dataset
+  honeycomb trigger list --dataset my-dataset
+
+  # Get a trigger by ID
+  honeycomb trigger get abc123 --dataset my-dataset`,
 	}
 
 	cmd.PersistentFlags().StringVar(&dataset, "dataset", "", "Dataset slug (required)")

--- a/cmd/trigger/update.go
+++ b/cmd/trigger/update.go
@@ -25,7 +25,12 @@ func NewUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update <trigger-id>",
 		Short: "Update a trigger",
-		Args:  cobra.ExactArgs(1),
+		Example: `  # Disable a trigger
+  honeycomb trigger update abc123 --dataset my-dataset --disabled
+
+  # Update a trigger from a file
+  honeycomb trigger update abc123 --dataset my-dataset --file trigger.json`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			hasFile := cmd.Flags().Changed("file")
 			hasName := cmd.Flags().Changed("name")


### PR DESCRIPTION
Adds cobra `Example` blocks to the most-used resources so `--help` shows runnable invocations, the way `gh` does. Examples are the fastest way to make the CLI legible before sharing it with coworkers.

## Changes

- `Example` on the group command and every leaf for `auth`, `query`, `dataset`, `board`, `trigger`, and `key` (including the `auth profile`, `query annotation`, `dataset definition`, and `board view` subgroups).
- Each leaf shows both an interactive (or simple) and a flag-driven invocation where both modes exist, since every command supports both. Flags are verified against each command's definitions, including persistent flags (`--dataset`, `--board`, `--team`, global `--format`).
- Plain back-tick string literals with 2-space indents, matching the one pre-existing example in `annotation create`. No new dependency.

## Testing

`cmd/example_test.go` builds the command tree via `NewRootCmd`, walks every leaf under the covered resources, and asserts a non-empty `Example` with a subtest per command path. The allowlist scopes the guard to the resources this PR covers, so resources added later don't fail until they're given examples. The test caught `auth profile list`, which now has one.

Closes #160
