### PR TITLE
refactor(auth): declare auth requirement per command

### DIFF
--- a/cmd/auth/status.go
+++ b/cmd/auth/status.go
@@ -72,7 +72,8 @@ func runAuthStatus(ctx context.Context, opts *options.RootOptions, offline bool)
 	}
 
 	var keys []storedKey
-	for _, kt := range config.KeyTypes() {
+	for _, kind := range options.AuthKinds() {
+		kt := kind.KeyType()
 		val, err := config.GetKey(profile, kt)
 		if errors.Is(err, keyring.ErrNotFound) {
 			continue

--- a/cmd/auth/status_test.go
+++ b/cmd/auth/status_test.go
@@ -270,3 +270,42 @@ func TestAuthStatus_MultipleKeys(t *testing.T) {
 		t.Errorf("statuses[1].type = %q, want %q", statuses[1].Type, "management")
 	}
 }
+
+// TestAuthStatus_EnumeratesAuthKinds verifies status enumerates every auth kind
+// in options.AuthKinds() order (config, ingest, management) rather than a
+// hardcoded slice, so storing one key of each type reports all three offline.
+func TestAuthStatus_EnumeratesAuthKinds(t *testing.T) {
+	ts := iostreams.Test(t)
+	opts := &options.RootOptions{
+		IOStreams: ts.IOStreams,
+		Config:    &config.Config{},
+		Format:    output.FormatJSON,
+	}
+
+	for _, kind := range options.AuthKinds() {
+		kt := kind.KeyType()
+		if err := config.SetKey("default", kt, string(kt)+"-key"); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = config.DeleteKey("default", kt) })
+	}
+
+	if err := runAuthStatus(t.Context(), opts, true); err != nil {
+		t.Fatal(err)
+	}
+
+	var statuses []KeyStatus
+	if err := json.Unmarshal(ts.OutBuf.Bytes(), &statuses); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+
+	kinds := options.AuthKinds()
+	if len(statuses) != len(kinds) {
+		t.Fatalf("got %d statuses, want %d", len(statuses), len(kinds))
+	}
+	for i, kind := range kinds {
+		if statuses[i].Type != string(kind.KeyType()) {
+			t.Errorf("statuses[%d].type = %q, want %q", i, statuses[i].Type, kind.KeyType())
+		}
+	}
+}

--- a/cmd/board/create.go
+++ b/cmd/board/create.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
@@ -51,7 +50,7 @@ characters) for each entry:
 }
 
 func runBoardCreate(cmd *cobra.Command, opts *options.RootOptions, file, name, desc string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/board/delete.go
+++ b/cmd/board/delete.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +33,7 @@ func NewDeleteCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runBoardDelete(ctx context.Context, opts *options.RootOptions, boardID string, yes bool) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/board/get.go
+++ b/cmd/board/get.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -24,7 +23,7 @@ func NewGetCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runBoardGet(ctx context.Context, opts *options.RootOptions, boardID string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/board/list.go
+++ b/cmd/board/list.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
 	"github.com/bendrucker/honeycomb-cli/internal/output"
 	"github.com/spf13/cobra"
@@ -37,7 +36,7 @@ func NewListCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runBoardList(ctx context.Context, opts *options.RootOptions) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/board/update.go
+++ b/cmd/board/update.go
@@ -9,7 +9,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -54,7 +53,7 @@ preset_filters array requires both "column" (the column name) and "alias"
 }
 
 func runBoardUpdate(cmd *cobra.Command, opts *options.RootOptions, boardID, file string, replace bool, name, desc string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/board/view_create.go
+++ b/cmd/board/view_create.go
@@ -9,7 +9,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
@@ -50,7 +49,7 @@ func NewViewCreateCmd(opts *options.RootOptions, board *string) *cobra.Command {
 }
 
 func runViewCreate(cmd *cobra.Command, opts *options.RootOptions, boardID, file, name string, filterArgs []string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/board/view_delete.go
+++ b/cmd/board/view_delete.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +33,7 @@ func NewViewDeleteCmd(opts *options.RootOptions, board *string) *cobra.Command {
 }
 
 func runViewDelete(ctx context.Context, opts *options.RootOptions, boardID, viewID string, yes bool) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/board/view_get.go
+++ b/cmd/board/view_get.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -24,7 +23,7 @@ func NewViewGetCmd(opts *options.RootOptions, board *string) *cobra.Command {
 }
 
 func runViewGet(ctx context.Context, opts *options.RootOptions, boardID, viewID string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/board/view_list.go
+++ b/cmd/board/view_list.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -23,7 +22,7 @@ func NewViewListCmd(opts *options.RootOptions, board *string) *cobra.Command {
 }
 
 func runViewList(ctx context.Context, opts *options.RootOptions, boardID string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/board/view_update.go
+++ b/cmd/board/view_update.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
 	"github.com/spf13/cobra"
 )
@@ -46,7 +45,7 @@ func NewViewUpdateCmd(opts *options.RootOptions, board *string) *cobra.Command {
 }
 
 func runViewUpdate(cmd *cobra.Command, opts *options.RootOptions, boardID, viewID, file, name string, filterArgs []string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/column/calculated_create.go
+++ b/cmd/column/calculated_create.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
@@ -76,7 +75,7 @@ func NewCalculatedCreateCmd(opts *options.RootOptions, dataset *string) *cobra.C
 }
 
 func runCalculatedCreateFromFile(ctx context.Context, opts *options.RootOptions, dataset, file string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}
@@ -100,7 +99,7 @@ func runCalculatedCreateFromFile(ctx context.Context, opts *options.RootOptions,
 }
 
 func runCalculatedCreate(ctx context.Context, opts *options.RootOptions, dataset string, body api.CreateCalculatedFieldJSONRequestBody) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/column/calculated_delete.go
+++ b/cmd/column/calculated_delete.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +28,7 @@ func NewCalculatedDeleteCmd(opts *options.RootOptions, dataset *string) *cobra.C
 }
 
 func runCalculatedDelete(ctx context.Context, opts *options.RootOptions, dataset, id string, yes bool) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/column/calculated_get.go
+++ b/cmd/column/calculated_get.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +21,7 @@ func NewCalculatedGetCmd(opts *options.RootOptions, dataset *string) *cobra.Comm
 }
 
 func runCalculatedGet(ctx context.Context, opts *options.RootOptions, dataset, id string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/column/calculated_list.go
+++ b/cmd/column/calculated_list.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -23,7 +22,7 @@ func NewCalculatedListCmd(opts *options.RootOptions, dataset *string) *cobra.Com
 }
 
 func runCalculatedList(ctx context.Context, opts *options.RootOptions, dataset string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/column/calculated_update.go
+++ b/cmd/column/calculated_update.go
@@ -9,7 +9,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -72,7 +71,7 @@ type calculatedUpdateFlags struct {
 }
 
 func runCalculatedUpdate(ctx context.Context, opts *options.RootOptions, dataset, id string, flags calculatedUpdateFlags) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/column/create.go
+++ b/cmd/column/create.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
@@ -76,7 +75,7 @@ func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runColumnCreateFromFile(ctx context.Context, opts *options.RootOptions, dataset, file string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}
@@ -100,7 +99,7 @@ func runColumnCreateFromFile(ctx context.Context, opts *options.RootOptions, dat
 }
 
 func runColumnCreate(cmd *cobra.Command, opts *options.RootOptions, dataset, keyName, colType, description string, hidden bool) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/column/delete.go
+++ b/cmd/column/delete.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +28,7 @@ func NewDeleteCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runColumnDelete(ctx context.Context, opts *options.RootOptions, dataset, columnID string, yes bool) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/column/get.go
+++ b/cmd/column/get.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +28,7 @@ func NewGetCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runColumnGet(ctx context.Context, opts *options.RootOptions, dataset, column string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/column/list.go
+++ b/cmd/column/list.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
 	"github.com/spf13/cobra"
 )
@@ -30,7 +29,7 @@ func NewListCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runColumnList(ctx context.Context, opts *options.RootOptions, dataset, keyName string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/column/update.go
+++ b/cmd/column/update.go
@@ -9,7 +9,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -64,7 +63,7 @@ type columnUpdateFlags struct {
 }
 
 func runColumnUpdate(ctx context.Context, opts *options.RootOptions, dataset, columnID string, flags columnUpdateFlags) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/dataset/create.go
+++ b/cmd/dataset/create.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
 	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
@@ -73,7 +72,7 @@ func runDatasetCreate(ctx context.Context, opts *options.RootOptions, name, desc
 		}
 	}
 
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/dataset/definition_get.go
+++ b/cmd/dataset/definition_get.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -27,7 +26,7 @@ func NewDefinitionGetCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runDefinitionGet(ctx context.Context, opts *options.RootOptions, slug string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/dataset/definition_update.go
+++ b/cmd/dataset/definition_update.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -37,7 +36,7 @@ func NewDefinitionUpdateCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runDefinitionUpdate(ctx context.Context, opts *options.RootOptions, slug, file string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/dataset/delete.go
+++ b/cmd/dataset/delete.go
@@ -10,7 +10,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -37,7 +36,7 @@ func NewDeleteCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runDatasetDelete(ctx context.Context, opts *options.RootOptions, slug string, yes bool) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/dataset/get.go
+++ b/cmd/dataset/get.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
 	"github.com/bendrucker/honeycomb-cli/internal/output"
 	"github.com/spf13/cobra"
@@ -59,7 +58,7 @@ func NewGetCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runDatasetGet(ctx context.Context, opts *options.RootOptions, slug string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/dataset/list.go
+++ b/cmd/dataset/list.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
 	"github.com/bendrucker/honeycomb-cli/internal/output"
 	"github.com/spf13/cobra"
@@ -56,7 +55,7 @@ func NewListCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runDatasetList(ctx context.Context, opts *options.RootOptions) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/dataset/update.go
+++ b/cmd/dataset/update.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -53,7 +52,7 @@ func NewUpdateCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runDatasetUpdate(ctx context.Context, opts *options.RootOptions, slug string, description *string, expandJsonDepth *int, deleteProtected *bool) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/environment/create.go
+++ b/cmd/environment/create.go
@@ -6,7 +6,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
@@ -23,14 +22,15 @@ func NewCreateCmd(opts *options.RootOptions, team *string) *cobra.Command {
 		Use:   "create",
 		Short: "Create an environment",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if err := opts.RequireTeam(team); err != nil {
-				return err
-			}
 			if err := command.ValidateEnum("color", color, environmentColors); err != nil {
 				return err
 			}
+			client, err := opts.ClientFor(team, options.AuthManagement)
+			if err != nil {
+				return err
+			}
 			clearProtection := cmd.Flags().Changed("delete-protected") && !deleteProtected
-			return runEnvironmentCreate(cmd, opts, *team, name, desc, color, clearProtection)
+			return runEnvironmentCreate(cmd, opts, client, *team, name, desc, color, clearProtection)
 		},
 	}
 
@@ -42,11 +42,8 @@ func NewCreateCmd(opts *options.RootOptions, team *string) *cobra.Command {
 	return cmd
 }
 
-func runEnvironmentCreate(cmd *cobra.Command, opts *options.RootOptions, team, name, desc, color string, clearProtection bool) error {
-	client, err := opts.Client(config.KeyManagement)
-	if err != nil {
-		return err
-	}
+func runEnvironmentCreate(cmd *cobra.Command, opts *options.RootOptions, client *api.ClientWithResponses, team, name, desc, color string, clearProtection bool) error {
+	var err error
 
 	if name == "" {
 		if !opts.IOStreams.CanPrompt() {

--- a/cmd/environment/delete.go
+++ b/cmd/environment/delete.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -19,10 +18,11 @@ func NewDeleteCmd(opts *options.RootOptions, team *string) *cobra.Command {
 		Short: "Delete an environment",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := opts.RequireTeam(team); err != nil {
+			client, err := opts.ClientFor(team, options.AuthManagement)
+			if err != nil {
 				return err
 			}
-			return runEnvironmentDelete(cmd.Context(), opts, *team, args[0], yes)
+			return runEnvironmentDelete(cmd.Context(), opts, client, *team, args[0], yes)
 		},
 	}
 
@@ -31,12 +31,7 @@ func NewDeleteCmd(opts *options.RootOptions, team *string) *cobra.Command {
 	return cmd
 }
 
-func runEnvironmentDelete(ctx context.Context, opts *options.RootOptions, team, envID string, yes bool) error {
-	client, err := opts.Client(config.KeyManagement)
-	if err != nil {
-		return err
-	}
-
+func runEnvironmentDelete(ctx context.Context, opts *options.RootOptions, client *api.ClientWithResponses, team, envID string, yes bool) error {
 	proceed, err := command.ConfirmDelete(opts.IOStreams, yes, "environment", envID, func() (string, error) {
 		getResp, err := client.GetEnvironmentWithResponse(ctx, team, envID)
 		if err != nil {

--- a/cmd/environment/environment.go
+++ b/cmd/environment/environment.go
@@ -37,7 +37,7 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 		Aliases: []string{"environments", "env"},
 	}
 
-	cmd.PersistentFlags().StringVar(&team, "team", "", "Team slug")
+	cmd.PersistentFlags().StringVar(&team, "team", "", "Team slug (defaults to the active profile's team when one is set)")
 
 	cmd.AddCommand(NewListCmd(opts, &team))
 	cmd.AddCommand(NewGetCmd(opts, &team))

--- a/cmd/environment/get.go
+++ b/cmd/environment/get.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -16,20 +15,16 @@ func NewGetCmd(opts *options.RootOptions, team *string) *cobra.Command {
 		Short: "Get an environment",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := opts.RequireTeam(team); err != nil {
+			client, err := opts.ClientFor(team, options.AuthManagement)
+			if err != nil {
 				return err
 			}
-			return runEnvironmentGet(cmd.Context(), opts, *team, args[0])
+			return runEnvironmentGet(cmd.Context(), opts, client, *team, args[0])
 		},
 	}
 }
 
-func runEnvironmentGet(ctx context.Context, opts *options.RootOptions, team, envID string) error {
-	client, err := opts.Client(config.KeyManagement)
-	if err != nil {
-		return err
-	}
-
+func runEnvironmentGet(ctx context.Context, opts *options.RootOptions, client *api.ClientWithResponses, team, envID string) error {
 	resp, err := client.GetEnvironmentWithResponse(ctx, team, envID)
 	if err != nil {
 		return fmt.Errorf("getting environment: %w", err)

--- a/cmd/environment/list.go
+++ b/cmd/environment/list.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -19,20 +18,16 @@ func NewListCmd(opts *options.RootOptions, team *string) *cobra.Command {
 		Use:   "list",
 		Short: "List environments",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if err := opts.RequireTeam(team); err != nil {
+			client, err := opts.ClientFor(team, options.AuthManagement)
+			if err != nil {
 				return err
 			}
-			return runEnvironmentList(cmd.Context(), opts, *team)
+			return runEnvironmentList(cmd.Context(), opts, client, *team)
 		},
 	}
 }
 
-func runEnvironmentList(ctx context.Context, opts *options.RootOptions, team string) error {
-	client, err := opts.Client(config.KeyManagement)
-	if err != nil {
-		return err
-	}
-
+func runEnvironmentList(ctx context.Context, opts *options.RootOptions, client *api.ClientWithResponses, team string) error {
 	var items []environmentItem
 	params := &api.ListEnvironmentsParams{}
 	for {

--- a/cmd/environment/update.go
+++ b/cmd/environment/update.go
@@ -6,7 +6,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -22,13 +21,14 @@ func NewUpdateCmd(opts *options.RootOptions, team *string) *cobra.Command {
 		Short: "Update an environment",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := opts.RequireTeam(team); err != nil {
-				return err
-			}
 			if err := command.ValidateEnum("color", color, environmentColors); err != nil {
 				return err
 			}
-			return runEnvironmentUpdate(cmd, opts, *team, args[0], desc, color, deleteProtected)
+			client, err := opts.ClientFor(team, options.AuthManagement)
+			if err != nil {
+				return err
+			}
+			return runEnvironmentUpdate(cmd, opts, client, *team, args[0], desc, color, deleteProtected)
 		},
 	}
 
@@ -39,14 +39,9 @@ func NewUpdateCmd(opts *options.RootOptions, team *string) *cobra.Command {
 	return cmd
 }
 
-func runEnvironmentUpdate(cmd *cobra.Command, opts *options.RootOptions, team, envID, desc, color string, deleteProtected bool) error {
+func runEnvironmentUpdate(cmd *cobra.Command, opts *options.RootOptions, client *api.ClientWithResponses, team, envID, desc, color string, deleteProtected bool) error {
 	if !cmd.Flags().Changed("description") && !cmd.Flags().Changed("color") && !cmd.Flags().Changed("delete-protected") {
 		return fmt.Errorf("--description, --color, or --delete-protected is required")
-	}
-
-	client, err := opts.Client(config.KeyManagement)
-	if err != nil {
-		return err
 	}
 
 	body := api.UpdateEnvironmentRequest{}

--- a/cmd/key/create.go
+++ b/cmd/key/create.go
@@ -10,7 +10,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
 	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
@@ -51,10 +50,11 @@ func NewCreateCmd(opts *options.RootOptions, team *string) *cobra.Command {
   honeycomb key create --name "config" --key-type configuration \
     --environment env-abc --permission boards --permission triggers`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if err := opts.RequireTeam(team); err != nil {
+			client, err := opts.ClientFor(team, options.AuthManagement)
+			if err != nil {
 				return err
 			}
-			return runKeyCreate(cmd, opts, *team, file, name, keyType, environment, permissions, allPermissions)
+			return runKeyCreate(cmd, opts, client, *team, file, name, keyType, environment, permissions, allPermissions)
 		},
 	}
 
@@ -75,19 +75,14 @@ func NewCreateCmd(opts *options.RootOptions, team *string) *cobra.Command {
 	return cmd
 }
 
-func runKeyCreate(cmd *cobra.Command, opts *options.RootOptions, team, file, name, keyType, environment string, permissions []string, allPermissions bool) error {
+func runKeyCreate(cmd *cobra.Command, opts *options.RootOptions, client *api.ClientWithResponses, team, file, name, keyType, environment string, permissions []string, allPermissions bool) error {
 	if file != "" {
-		return runKeyCreateFromFile(cmd.Context(), opts, team, file)
+		return runKeyCreateFromFile(cmd.Context(), opts, client, team, file)
 	}
-	return runKeyCreateFromFlags(cmd, opts, team, name, keyType, environment, permissions, allPermissions)
+	return runKeyCreateFromFlags(cmd, opts, client, team, name, keyType, environment, permissions, allPermissions)
 }
 
-func runKeyCreateFromFile(ctx context.Context, opts *options.RootOptions, team, file string) error {
-	client, err := opts.Client(config.KeyManagement)
-	if err != nil {
-		return err
-	}
-
+func runKeyCreateFromFile(ctx context.Context, opts *options.RootOptions, client *api.ClientWithResponses, team, file string) error {
 	data, err := command.ReadDefinitionFile(opts.IOStreams, file)
 	if err != nil {
 		return err
@@ -101,7 +96,7 @@ func runKeyCreateFromFile(ctx context.Context, opts *options.RootOptions, team, 
 	return handleCreateResponse(opts, resp)
 }
 
-func runKeyCreateFromFlags(cmd *cobra.Command, opts *options.RootOptions, team, name, keyType, environment string, permissions []string, allPermissions bool) error {
+func runKeyCreateFromFlags(cmd *cobra.Command, opts *options.RootOptions, client *api.ClientWithResponses, team, name, keyType, environment string, permissions []string, allPermissions bool) error {
 	var err error
 
 	if name == "" {
@@ -150,11 +145,6 @@ func runKeyCreateFromFlags(cmd *cobra.Command, opts *options.RootOptions, team, 
 		if environment == "" {
 			return fmt.Errorf("environment ID is required")
 		}
-	}
-
-	client, err := opts.Client(config.KeyManagement)
-	if err != nil {
-		return err
 	}
 
 	body := api.ApiKeyCreateRequest{}

--- a/cmd/key/delete.go
+++ b/cmd/key/delete.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -24,10 +23,11 @@ func NewDeleteCmd(opts *options.RootOptions, team *string) *cobra.Command {
   honeycomb key delete abc123 --yes`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := opts.RequireTeam(team); err != nil {
+			client, err := opts.ClientFor(team, options.AuthManagement)
+			if err != nil {
 				return err
 			}
-			return runKeyDelete(cmd.Context(), opts, *team, args[0], yes)
+			return runKeyDelete(cmd.Context(), opts, client, *team, args[0], yes)
 		},
 	}
 
@@ -36,12 +36,7 @@ func NewDeleteCmd(opts *options.RootOptions, team *string) *cobra.Command {
 	return cmd
 }
 
-func runKeyDelete(ctx context.Context, opts *options.RootOptions, team, id string, yes bool) error {
-	client, err := opts.Client(config.KeyManagement)
-	if err != nil {
-		return err
-	}
-
+func runKeyDelete(ctx context.Context, opts *options.RootOptions, client *api.ClientWithResponses, team, id string, yes bool) error {
 	proceed, err := command.ConfirmDelete(opts.IOStreams, yes, "API key", id, nil)
 	if err != nil {
 		return err

--- a/cmd/key/get.go
+++ b/cmd/key/get.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -18,20 +17,16 @@ func NewGetCmd(opts *options.RootOptions, team *string) *cobra.Command {
   honeycomb key get abc123`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := opts.RequireTeam(team); err != nil {
+			client, err := opts.ClientFor(team, options.AuthManagement)
+			if err != nil {
 				return err
 			}
-			return runKeyGet(cmd.Context(), opts, *team, args[0])
+			return runKeyGet(cmd.Context(), opts, client, *team, args[0])
 		},
 	}
 }
 
-func runKeyGet(ctx context.Context, opts *options.RootOptions, team, id string) error {
-	client, err := opts.Client(config.KeyManagement)
-	if err != nil {
-		return err
-	}
-
+func runKeyGet(ctx context.Context, opts *options.RootOptions, client *api.ClientWithResponses, team, id string) error {
 	resp, err := client.GetApiKeyWithResponse(ctx, api.TeamSlug(team), api.ID(id))
 	if err != nil {
 		return fmt.Errorf("getting API key: %w", err)

--- a/cmd/key/key.go
+++ b/cmd/key/key.go
@@ -25,7 +25,7 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
   honeycomb key get abc123`,
 	}
 
-	cmd.PersistentFlags().StringVar(&team, "team", "", "Team slug")
+	cmd.PersistentFlags().StringVar(&team, "team", "", "Team slug (defaults to the active profile's team when one is set)")
 
 	cmd.AddCommand(NewListCmd(opts, &team))
 	cmd.AddCommand(NewGetCmd(opts, &team))

--- a/cmd/key/list.go
+++ b/cmd/key/list.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -31,14 +30,15 @@ func NewListCmd(opts *options.RootOptions, team *string) *cobra.Command {
   # List only ingest keys
   honeycomb key list --key-type ingest`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if err := opts.RequireTeam(team); err != nil {
-				return err
-			}
 			filterType := keyType
 			if filterType == "" {
 				filterType = legacyType
 			}
-			return runKeyList(cmd.Context(), opts, *team, filterType)
+			client, err := opts.ClientFor(team, options.AuthManagement)
+			if err != nil {
+				return err
+			}
+			return runKeyList(cmd.Context(), opts, client, *team, filterType)
 		},
 	}
 
@@ -50,13 +50,8 @@ func NewListCmd(opts *options.RootOptions, team *string) *cobra.Command {
 	return cmd
 }
 
-func runKeyList(ctx context.Context, opts *options.RootOptions, team, filterType string) error {
+func runKeyList(ctx context.Context, opts *options.RootOptions, client *api.ClientWithResponses, team, filterType string) error {
 	if err := command.ValidateEnum("key-type", filterType, keyTypes); err != nil {
-		return err
-	}
-
-	client, err := opts.Client(config.KeyManagement)
-	if err != nil {
 		return err
 	}
 

--- a/cmd/key/update.go
+++ b/cmd/key/update.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -30,13 +29,14 @@ func NewUpdateCmd(opts *options.RootOptions, team *string) *cobra.Command {
   honeycomb key update abc123 --disabled`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := opts.RequireTeam(team); err != nil {
+			client, err := opts.ClientFor(team, options.AuthManagement)
+			if err != nil {
 				return err
 			}
 			if file != "" {
-				return runKeyUpdateFromFile(cmd.Context(), opts, *team, args[0], file)
+				return runKeyUpdateFromFile(cmd.Context(), opts, client, *team, args[0], file)
 			}
-			return runKeyUpdateFromFlags(cmd, opts, *team, args[0], name)
+			return runKeyUpdateFromFlags(cmd, opts, client, *team, args[0], name)
 		},
 	}
 
@@ -53,12 +53,7 @@ func NewUpdateCmd(opts *options.RootOptions, team *string) *cobra.Command {
 	return cmd
 }
 
-func runKeyUpdateFromFile(ctx context.Context, opts *options.RootOptions, team, id, file string) error {
-	client, err := opts.Client(config.KeyManagement)
-	if err != nil {
-		return err
-	}
-
+func runKeyUpdateFromFile(ctx context.Context, opts *options.RootOptions, client *api.ClientWithResponses, team, id, file string) error {
 	data, err := command.ReadDefinitionFile(opts.IOStreams, file)
 	if err != nil {
 		return err
@@ -77,14 +72,9 @@ func runKeyUpdateFromFile(ctx context.Context, opts *options.RootOptions, team, 
 	return writeKeyDetail(opts, objectToDetail(updated.Data))
 }
 
-func runKeyUpdateFromFlags(cmd *cobra.Command, opts *options.RootOptions, team, id, name string) error {
+func runKeyUpdateFromFlags(cmd *cobra.Command, opts *options.RootOptions, client *api.ClientWithResponses, team, id, name string) error {
 	if !cmd.Flags().Changed("name") && !cmd.Flags().Changed("disabled") && !cmd.Flags().Changed("enabled") {
 		return fmt.Errorf("--file, --name, --disabled, or --enabled is required")
-	}
-
-	client, err := opts.Client(config.KeyManagement)
-	if err != nil {
-		return err
 	}
 
 	ctx := cmd.Context()

--- a/cmd/marker/create.go
+++ b/cmd/marker/create.go
@@ -9,7 +9,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
@@ -111,7 +110,7 @@ func runMarkerCreateFromFile(ctx context.Context, opts *options.RootOptions, dat
 }
 
 func runMarkerCreate(ctx context.Context, opts *options.RootOptions, dataset string, body api.CreateMarkerJSONRequestBody) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/marker/delete.go
+++ b/cmd/marker/delete.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +28,7 @@ func NewDeleteCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runMarkerDelete(ctx context.Context, opts *options.RootOptions, dataset, markerID string, yes bool) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/marker/get.go
+++ b/cmd/marker/get.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +21,7 @@ func NewGetCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runMarkerGet(ctx context.Context, opts *options.RootOptions, dataset, markerID string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/marker/list.go
+++ b/cmd/marker/list.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +20,7 @@ func NewListCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runMarkerList(ctx context.Context, opts *options.RootOptions, dataset string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/marker/setting_create.go
+++ b/cmd/marker/setting_create.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
@@ -72,7 +71,7 @@ func NewSettingCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Comm
 }
 
 func runSettingCreate(ctx context.Context, opts *options.RootOptions, dataset string, body api.CreateMarkerSettingJSONRequestBody) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/marker/setting_delete.go
+++ b/cmd/marker/setting_delete.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +28,7 @@ func NewSettingDeleteCmd(opts *options.RootOptions, dataset *string) *cobra.Comm
 }
 
 func runSettingDelete(ctx context.Context, opts *options.RootOptions, dataset, settingID string, yes bool) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/marker/setting_list.go
+++ b/cmd/marker/setting_list.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +20,7 @@ func NewSettingListCmd(opts *options.RootOptions, dataset *string) *cobra.Comman
 }
 
 func runSettingList(ctx context.Context, opts *options.RootOptions, dataset string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/marker/setting_update.go
+++ b/cmd/marker/setting_update.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +33,7 @@ func NewSettingUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.Comm
 func runSettingUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, settingID, settingType, color string) error {
 	ctx := cmd.Context()
 
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/marker/update.go
+++ b/cmd/marker/update.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -42,7 +41,7 @@ func NewUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 func runMarkerUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, markerID, markerType, message, url string, startTime, endTime int, color string) error {
 	ctx := cmd.Context()
 
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/mcp/mcp.go
+++ b/cmd/mcp/mcp.go
@@ -22,8 +22,10 @@ import (
 const tokenEnvVar = "HONEYCOMB_MCP_TOKEN"
 
 // connectOptions carries everything the client factory needs to authenticate
-// and open an MCP session. It deliberately excludes the Honeycomb config API
-// key: that credential is not accepted by the OAuth-protected MCP server.
+// and open an MCP session. This is the OAuth path that options.AuthMCPOAuth
+// names: it deliberately excludes the Honeycomb config API key, which the
+// OAuth-protected MCP server does not accept, and reaches the server through the
+// OAuth transport below rather than opts.Client / opts.ClientFor.
 type connectOptions struct {
 	root   *options.RootOptions
 	mcpURL string

--- a/cmd/options/authkind.go
+++ b/cmd/options/authkind.go
@@ -1,0 +1,95 @@
+package options
+
+import (
+	"fmt"
+
+	"github.com/bendrucker/honeycomb-cli/internal/api"
+	"github.com/bendrucker/honeycomb-cli/internal/config"
+)
+
+// AuthKind names the credential a command authenticates with. It is the single
+// command-level declaration of "this command authenticates this way", replacing
+// the config.KeyType literals that were spread across every call site and the
+// RequireTeam guards duplicated in each management command.
+type AuthKind int
+
+const (
+	// AuthConfig uses a Configuration API key (X-Honeycomb-Team) for the v1
+	// Configuration API: boards, columns, SLOs, triggers, queries, etc.
+	AuthConfig AuthKind = iota
+	// AuthIngest uses an Ingest API key (X-Honeycomb-Team) for sending events.
+	AuthIngest
+	// AuthManagement uses a Management v2 key (id:secret bearer) for the
+	// Management API: environments and keys. Management commands operate on a
+	// team, so this kind requires a team slug.
+	AuthManagement
+	// AuthMCPOAuth names the OAuth path the mcp commands use to reach the
+	// OAuth-protected Honeycomb MCP server through the mcp package's OAuth
+	// transport, not ClientFor. It has no keyring API key and cannot build a REST
+	// client, so ClientFor rejects it and AuthKinds excludes it from the
+	// login/status machinery. It exists to make the auth taxonomy complete; no
+	// command passes it to ClientFor.
+	AuthMCPOAuth
+)
+
+// authKindKeyType maps an AuthKind to the config.KeyType whose credential and
+// transport it uses. AuthMCPOAuth has no entry: the MCP server is an OAuth
+// protected resource reached through the mcp package's OAuth transport, not a
+// keyring API key, so it cannot build a REST client here.
+func authKindKeyType(kind AuthKind) (config.KeyType, bool) {
+	switch kind {
+	case AuthConfig:
+		return config.KeyConfig, true
+	case AuthIngest:
+		return config.KeyIngest, true
+	case AuthManagement:
+		return config.KeyManagement, true
+	default:
+		return "", false
+	}
+}
+
+// requiresTeam reports whether a kind operates on a single team and therefore
+// needs a team slug resolved before a request can be issued.
+func (k AuthKind) requiresTeam() bool {
+	return k == AuthManagement
+}
+
+// AuthKinds returns every AuthKind that authenticates with a stored API key, in
+// the order auth status reports them. AuthMCPOAuth is excluded: its credential
+// is an OAuth token set, not a verifiable API key, and stays out of the
+// login/status machinery.
+func AuthKinds() []AuthKind {
+	return []AuthKind{AuthConfig, AuthIngest, AuthManagement}
+}
+
+// KeyType returns the config.KeyType backing a key-based AuthKind. It is only
+// valid for kinds with a keyring-stored credential (everything except
+// AuthMCPOAuth) and is used by auth status to enumerate the credentials it
+// verifies.
+func (k AuthKind) KeyType() config.KeyType {
+	kt, _ := authKindKeyType(k)
+	return kt
+}
+
+// ClientFor builds an API client for the declared auth kind. For
+// team-scoped kinds (AuthManagement) it first resolves the team slug into
+// *team, folding the per-command RequireTeam guard into one place, then bakes
+// the matching credential's request editor into the client.
+//
+// Pass the command's --team flag pointer for team-scoped kinds; pass nil for
+// kinds that do not operate on a team.
+func (o *RootOptions) ClientFor(team *string, kind AuthKind) (*api.ClientWithResponses, error) {
+	kt, ok := authKindKeyType(kind)
+	if !ok {
+		return nil, fmt.Errorf("auth kind does not use an API key")
+	}
+
+	if kind.requiresTeam() {
+		if err := o.RequireTeam(team); err != nil {
+			return nil, err
+		}
+	}
+
+	return o.Client(kt)
+}

--- a/cmd/options/authkind_test.go
+++ b/cmd/options/authkind_test.go
@@ -1,0 +1,184 @@
+package options
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bendrucker/honeycomb-cli/internal/config"
+	"github.com/bendrucker/honeycomb-cli/internal/iostreams"
+	"github.com/zalando/go-keyring"
+)
+
+func init() {
+	keyring.MockInit()
+}
+
+func newTestOptions(t *testing.T, apiURL string, cfg *config.Config) *RootOptions {
+	t.Helper()
+	ts := iostreams.Test(t)
+	return &RootOptions{
+		IOStreams: ts.IOStreams,
+		Config:    cfg,
+		APIUrl:    apiURL,
+	}
+}
+
+func TestClientForAuthHeader(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		kind       AuthKind
+		keyType    config.KeyType
+		key        string
+		team       string
+		wantHeader string
+		wantValue  string
+	}{
+		{
+			name:       "config sets honeycomb team header",
+			kind:       AuthConfig,
+			keyType:    config.KeyConfig,
+			key:        "cfg-secret",
+			wantHeader: "X-Honeycomb-Team",
+			wantValue:  "cfg-secret",
+		},
+		{
+			name:       "ingest sets honeycomb team header",
+			kind:       AuthIngest,
+			keyType:    config.KeyIngest,
+			key:        "ingest-secret",
+			wantHeader: "X-Honeycomb-Team",
+			wantValue:  "ingest-secret",
+		},
+		{
+			name:       "management sets bearer header",
+			kind:       AuthManagement,
+			keyType:    config.KeyManagement,
+			key:        "id:secret",
+			team:       "my-team",
+			wantHeader: "Authorization",
+			wantValue:  "Bearer id:secret",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = r.Header.Get(tc.wantHeader)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			t.Cleanup(srv.Close)
+
+			if err := config.SetKey("default", tc.keyType, tc.key); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = config.DeleteKey("default", tc.keyType) })
+
+			opts := newTestOptions(t, srv.URL, &config.Config{})
+			team := tc.team
+			client, err := opts.ClientFor(&team, tc.kind)
+			if err != nil {
+				t.Fatalf("ClientFor: %v", err)
+			}
+
+			if _, err := client.GetAuthWithResponse(t.Context()); err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			if got != tc.wantValue {
+				t.Errorf("header %s = %q, want %q", tc.wantHeader, got, tc.wantValue)
+			}
+		})
+	}
+}
+
+func TestClientForMCPOAuthRejected(t *testing.T) {
+	opts := newTestOptions(t, "http://example.invalid", &config.Config{})
+	if _, err := opts.ClientFor(nil, AuthMCPOAuth); err == nil {
+		t.Fatal("expected error building a REST client for AuthMCPOAuth")
+	}
+}
+
+func TestClientForManagementRequiresKey(t *testing.T) {
+	opts := newTestOptions(t, "http://example.invalid", &config.Config{
+		Profiles: map[string]*config.Profile{"default": {Team: "known-team"}},
+	})
+	team := ""
+	// Team is inferred, but no management key is stored, so client construction
+	// still fails on the missing credential rather than the missing team.
+	_, err := opts.ClientFor(&team, AuthManagement)
+	if err == nil {
+		t.Fatal("expected error for missing management key")
+	}
+	if team != "known-team" {
+		t.Errorf("team = %q, want inferred %q", team, "known-team")
+	}
+}
+
+func TestRequireTeamInference(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		cfg      *config.Config
+		flag     string
+		wantTeam string
+		wantErr  bool
+	}{
+		{
+			name:     "explicit flag wins",
+			cfg:      &config.Config{Profiles: map[string]*config.Profile{"default": {Team: "profile-team"}}},
+			flag:     "explicit-team",
+			wantTeam: "explicit-team",
+		},
+		{
+			name:     "single known team is inferred",
+			cfg:      &config.Config{Profiles: map[string]*config.Profile{"default": {Team: "profile-team"}}},
+			flag:     "",
+			wantTeam: "profile-team",
+		},
+		{
+			name:    "no known team errors",
+			cfg:     &config.Config{Profiles: map[string]*config.Profile{"default": {}}},
+			flag:    "",
+			wantErr: true,
+		},
+		{
+			name:    "no profile errors",
+			cfg:     &config.Config{},
+			flag:    "",
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := newTestOptions(t, "http://example.invalid", tc.cfg)
+			team := tc.flag
+			err := opts.RequireTeam(&team)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("RequireTeam: %v", err)
+			}
+			if team != tc.wantTeam {
+				t.Errorf("team = %q, want %q", team, tc.wantTeam)
+			}
+		})
+	}
+}
+
+func TestAuthKindsEnumeration(t *testing.T) {
+	kinds := AuthKinds()
+	want := []config.KeyType{config.KeyConfig, config.KeyIngest, config.KeyManagement}
+	if len(kinds) != len(want) {
+		t.Fatalf("got %d kinds, want %d", len(kinds), len(want))
+	}
+	for i, k := range kinds {
+		if k == AuthMCPOAuth {
+			t.Errorf("AuthKinds must not include AuthMCPOAuth")
+		}
+		if k.KeyType() != want[i] {
+			t.Errorf("kinds[%d].KeyType() = %q, want %q", i, k.KeyType(), want[i])
+		}
+	}
+}

--- a/cmd/options/options.go
+++ b/cmd/options/options.go
@@ -45,18 +45,38 @@ func (o *RootOptions) ResolveConfigPath() string {
 	return config.DefaultPath()
 }
 
+// RequireTeam resolves the team slug a management command operates on, writing
+// the result back into *flag. Precedence:
+//
+//  1. An explicit --team flag is used as-is.
+//  2. Otherwise the active profile's stored team is inferred, but only when
+//     exactly one team is known. A management key can span multiple teams, so
+//     inference is deliberately limited to the single-team case the profile
+//     records; with zero (or, in the future, more than one) known teams the
+//     required-flag error stands.
 func (o *RootOptions) RequireTeam(flag *string) error {
 	if *flag != "" {
 		return nil
 	}
-	if o.Config != nil {
-		profile := o.ActiveProfile()
-		if p, ok := o.Config.Profiles[profile]; ok && p.Team != "" {
-			*flag = p.Team
-			return nil
-		}
+	if team, ok := o.inferTeam(); ok {
+		*flag = team
+		return nil
 	}
-	return fmt.Errorf("--team is required (or set via honeycomb auth login --team)")
+	return fmt.Errorf("--team is required (or set a single team via honeycomb auth login --team)")
+}
+
+// inferTeam returns the team slug to use when --team is unset, reporting false
+// when no single team is known. The profile stores at most one team, so a
+// recorded team is unambiguous; a missing team leaves the choice to the caller.
+func (o *RootOptions) inferTeam() (string, bool) {
+	if o.Config == nil {
+		return "", false
+	}
+	profile := o.ActiveProfile()
+	if p, ok := o.Config.Profiles[profile]; ok && p.Team != "" {
+		return p.Team, true
+	}
+	return "", false
 }
 
 func (o *RootOptions) ResolveFormat() string {

--- a/cmd/query/annotation_create.go
+++ b/cmd/query/annotation_create.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
@@ -58,7 +57,7 @@ flag is mutually exclusive with the flag-mode inputs.`,
 }
 
 func runAnnotationCreate(cmd *cobra.Command, opts *options.RootOptions, dataset, file, name, desc, queryID string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/query/annotation_delete.go
+++ b/cmd/query/annotation_delete.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +33,7 @@ func NewDeleteCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runAnnotationDelete(ctx context.Context, opts *options.RootOptions, dataset, annotationID string, yes bool) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/query/annotation_list.go
+++ b/cmd/query/annotation_list.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -33,7 +32,7 @@ func NewListCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runAnnotationList(ctx context.Context, opts *options.RootOptions, dataset string, includeBoardAnnotations bool) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/query/annotation_update.go
+++ b/cmd/query/annotation_update.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -46,7 +45,7 @@ func NewUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runAnnotationUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, annotationID, file, name, desc string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/query/annotation_view.go
+++ b/cmd/query/annotation_view.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -31,7 +30,7 @@ func NewViewCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runAnnotationView(ctx context.Context, opts *options.RootOptions, dataset, annotationID string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/query/run.go
+++ b/cmd/query/run.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/output"
 	"github.com/bendrucker/honeycomb-cli/internal/poll"
 	"github.com/bendrucker/honeycomb-cli/internal/prompt"
@@ -46,7 +45,7 @@ func NewRunCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runQueryRun(ctx context.Context, opts *options.RootOptions, dataset, file, annotation string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/recipient/create.go
+++ b/cmd/recipient/create.go
@@ -11,7 +11,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
@@ -243,7 +242,7 @@ func createFromFile(ctx context.Context, opts *options.RootOptions, file string)
 }
 
 func sendCreate(ctx context.Context, opts *options.RootOptions, data []byte) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/recipient/delete.go
+++ b/cmd/recipient/delete.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +28,7 @@ func NewDeleteCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runDelete(ctx context.Context, opts *options.RootOptions, recipientID string, yes bool) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/recipient/get.go
+++ b/cmd/recipient/get.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +21,7 @@ func NewGetCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runGet(ctx context.Context, opts *options.RootOptions, recipientID string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/recipient/list.go
+++ b/cmd/recipient/list.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -28,7 +27,7 @@ func NewListCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runList(ctx context.Context, opts *options.RootOptions) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/recipient/triggers.go
+++ b/cmd/recipient/triggers.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
 	"github.com/bendrucker/honeycomb-cli/internal/output"
 	"github.com/spf13/cobra"
@@ -36,7 +35,7 @@ func NewTriggersCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runTriggers(ctx context.Context, opts *options.RootOptions, recipientID string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/recipient/update.go
+++ b/cmd/recipient/update.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -48,7 +47,7 @@ func NewUpdateCmd(opts *options.RootOptions) *cobra.Command {
 }
 
 func runUpdate(cmd *cobra.Command, opts *options.RootOptions, recipientID, file, recipientType, target, channel, integrationKey, name, url string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/slo/burn_alert_create.go
+++ b/cmd/slo/burn_alert_create.go
@@ -9,7 +9,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -57,7 +56,7 @@ func NewBurnAlertCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Co
 }
 
 func runBurnAlertCreateFromFile(ctx context.Context, opts *options.RootOptions, dataset, file string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}
@@ -136,7 +135,7 @@ func runBurnAlertCreateFromFlags(cmd *cobra.Command, opts *options.RootOptions, 
 		return fmt.Errorf("encoding burn alert: %w", err)
 	}
 
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/slo/burn_alert_delete.go
+++ b/cmd/slo/burn_alert_delete.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +28,7 @@ func NewBurnAlertDeleteCmd(opts *options.RootOptions, dataset *string) *cobra.Co
 }
 
 func runBurnAlertDelete(ctx context.Context, opts *options.RootOptions, dataset, burnAlertID string, yes bool) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/slo/burn_alert_get.go
+++ b/cmd/slo/burn_alert_get.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -24,7 +23,7 @@ func NewBurnAlertGetCmd(opts *options.RootOptions, dataset *string) *cobra.Comma
 }
 
 func runBurnAlertGet(ctx context.Context, opts *options.RootOptions, dataset, burnAlertID string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/slo/burn_alert_list.go
+++ b/cmd/slo/burn_alert_list.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +28,7 @@ func NewBurnAlertListCmd(opts *options.RootOptions, dataset *string) *cobra.Comm
 }
 
 func runBurnAlertList(ctx context.Context, opts *options.RootOptions, dataset, sloID string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/slo/burn_alert_update.go
+++ b/cmd/slo/burn_alert_update.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -48,7 +47,7 @@ func NewBurnAlertUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.Co
 var burnAlertUpdateFlags = []string{"exhaustion-minutes", "budget-rate-window-minutes", "budget-rate-threshold", "recipient", "description"}
 
 func runBurnAlertUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, burnAlertID, file string, exhaustionMinutes, budgetRateWindow, budgetRateThreshold int, recipients []string, description string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/slo/create.go
+++ b/cmd/slo/create.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -47,7 +46,7 @@ func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runSLOCreate(cmd *cobra.Command, opts *options.RootOptions, dataset, file, name, sliAlias string, target, timePeriod int, desc string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/slo/delete.go
+++ b/cmd/slo/delete.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +28,7 @@ func NewDeleteCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runSLODelete(ctx context.Context, opts *options.RootOptions, dataset, sloID string, yes bool) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/slo/get.go
+++ b/cmd/slo/get.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +28,7 @@ func NewGetCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runSLOGet(ctx context.Context, opts *options.RootOptions, dataset, sloID string, detailed bool) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/slo/history.go
+++ b/cmd/slo/history.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -58,7 +57,7 @@ func mergeSLOIDs(args, flagIDs []string) []string {
 }
 
 func runHistory(ctx context.Context, opts *options.RootOptions, sloIDs []string, startTime, endTime int) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/slo/list.go
+++ b/cmd/slo/list.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
 	"github.com/bendrucker/honeycomb-cli/internal/output"
 	"github.com/spf13/cobra"
@@ -34,7 +33,7 @@ func NewListCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runSLOList(ctx context.Context, opts *options.RootOptions, dataset string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/slo/update.go
+++ b/cmd/slo/update.go
@@ -9,7 +9,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -46,7 +45,7 @@ func NewUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runSLOUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, sloID, file, name, desc string, target, timePeriod int) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/trigger/create.go
+++ b/cmd/trigger/create.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -72,7 +71,7 @@ type createFlags struct {
 }
 
 func runCreate(cmd *cobra.Command, opts *options.RootOptions, dataset string, flags createFlags) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/trigger/delete.go
+++ b/cmd/trigger/delete.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +33,7 @@ func NewDeleteCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runDelete(ctx context.Context, opts *options.RootOptions, dataset, triggerID string, yes bool) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/trigger/get.go
+++ b/cmd/trigger/get.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -24,7 +23,7 @@ func NewGetCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runGet(ctx context.Context, opts *options.RootOptions, dataset, triggerID string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/trigger/list.go
+++ b/cmd/trigger/list.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/bendrucker/honeycomb-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -29,7 +28,7 @@ func NewListCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 }
 
 func runList(ctx context.Context, opts *options.RootOptions, dataset string) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/trigger/update.go
+++ b/cmd/trigger/update.go
@@ -9,7 +9,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -86,7 +85,7 @@ type updateFlags struct {
 }
 
 func runUpdate(ctx context.Context, opts *options.RootOptions, dataset, triggerID string, flags updateFlags) error {
-	client, err := opts.Client(config.KeyConfig)
+	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Introduces an `AuthKind` abstraction so each command declares which credential it needs, instead of every call site passing a `config.KeyType` literal and each management command re-implementing the team requirement. This gives team inference and the credential transport a single home.

## Issue

Auth type, team requirement, and wire format were spread across ~70 call sites and every management command's `RunE`, with `auth status` keeping its own hardcoded key-type slice. There was no place to express "this command authenticates differently." Closes #179.

## Changes

- **`cmd/options/authkind.go`**: `AuthKind` (`AuthConfig`, `AuthIngest`, `AuthManagement`, `AuthMCPOAuth`). `(*RootOptions).ClientFor(team, kind)` is the single resolver — it maps the key-based kinds to their `config.KeyType` and reuses the existing `opts.Client(kt)` editor seam. `AuthMCPOAuth` has no REST client and errors if asked for one.
- Every command now calls `opts.ClientFor(nil, options.AuthConfig)` / `opts.ClientFor(team, options.AuthManagement)`; no `config.KeyType` literals remain at call sites.
- **Team inference**: when `--team` is unset, `RequireTeam` infers it from the active profile when a single team is known; zero/unknown teams keep the required-flag error. `ClientFor` runs the guard for `AuthManagement`, so the duplicated check was removed from all `cmd/environment/*` and `cmd/key/*` `RunE` bodies. The `--team` flag help documents the precedence.
- **`auth status`** enumerates `options.AuthKinds()` instead of `config.KeyTypes()`; the `errInvalidKey` sentinel and print-then-fail behavior are preserved.
- **mcp**: already authenticates via OAuth (the earlier OAuth work fixed the config-key bug); `options.AuthMCPOAuth` is now associated with the OAuth transport so the enum value isn't dead.

## Testing

- `cmd/options/authkind_test.go`: per-kind client resolution asserts the right auth header reaches an httptest server (config/ingest → `X-Honeycomb-Team`, management → `Authorization: Bearer`); `AuthMCPOAuth` rejected for REST; `RequireTeam` table (explicit wins, single team infers, zero team errors); `AuthKinds` enumeration.
- `cmd/auth/status_test.go`: asserts status reports every `AuthKinds()` entry in order.

## Notes

The issue's "more than one team" branch is currently unreachable — a profile stores at most one team, so inference is inherently single-team. I documented this and structured `inferTeam` so a future multi-team source can opt out without changing call sites.
