### PR TITLE
fix(mcp): parse JSON object/array -F values

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -50,7 +50,7 @@ func NewCmd(opts *options.RootOptions) *cobra.Command {
 
 	cmd.Flags().StringVarP(&o.method, "method", "X", "", "HTTP method (default: auto-detected)")
 	cmd.Flags().StringArrayVarP(&o.fields, "field", "f", nil, "String field: key=value (repeatable; not a file)")
-	cmd.Flags().StringArrayVarP(&o.typed, "typed-field", "F", nil, "Typed field: bool/number/null coercion, @file")
+	cmd.Flags().StringArrayVarP(&o.typed, "typed-field", "F", nil, "Typed field: bool/number/null/JSON object/array coercion, @file")
 	cmd.Flags().StringArrayVarP(&o.headers, "header", "H", nil, "Request header: key:value")
 	cmd.Flags().StringVarP(&o.jqExpr, "jq", "q", "", "Filter response with jq expression")
 	cmd.Flags().BoolVarP(&o.include, "include", "i", false, "Show response status line and headers")

--- a/cmd/mcp/call.go
+++ b/cmd/mcp/call.go
@@ -42,7 +42,7 @@ func newCallCmd(opts *options.RootOptions, token *string, factory clientFactory)
 	}
 
 	cmd.Flags().StringArrayVarP(&o.fieldFlags, "field", "f", nil, "String field: key=value (repeatable; not a file)")
-	cmd.Flags().StringArrayVarP(&o.typedFlags, "typed-field", "F", nil, "Typed field: bool/number/null coercion, @file")
+	cmd.Flags().StringArrayVarP(&o.typedFlags, "typed-field", "F", nil, "Typed field: bool/number/null/JSON object/array coercion, @file")
 	cmd.Flags().StringVar(&o.input, "input", "", "Read full arguments JSON from a file (- for stdin)")
 	cmd.Flags().StringVarP(&o.jqExpr, "jq", "q", "", "Filter output with jq expression")
 

--- a/cmd/mcp/call_test.go
+++ b/cmd/mcp/call_test.go
@@ -44,6 +44,51 @@ func TestCall(t *testing.T) {
 	}
 }
 
+func TestCall_TypedJSONObjectArgument(t *testing.T) {
+	srv, opts, _ := setupMCPTest(t)
+
+	var got map[string]any
+	srv.AddTool(
+		mcp.NewTool("run_query",
+			mcp.WithString("dataset"),
+			mcp.WithObject("query_json"),
+		),
+		func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			got = req.GetArguments()
+			return mcp.NewToolResultText("ok"), nil
+		},
+	)
+
+	cmd := newCallCmd(opts, nil, testFactory(srv))
+	cmd.SetArgs([]string{"run_query",
+		"-f", "dataset=api",
+		"-F", `query_json={"calculations":[{"op":"SUM","column":"gen_ai.usage.cost"}],"time_range":604800,"granularity":86400}`,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if ds, ok := got["dataset"].(string); !ok || ds != "api" {
+		t.Errorf("dataset = %#v, want string %q", got["dataset"], "api")
+	}
+
+	query, ok := got["query_json"].(map[string]any)
+	if !ok {
+		t.Fatalf("query_json = %#v, want map[string]any (a parsed object, not a string)", got["query_json"])
+	}
+	if tr, ok := query["time_range"].(float64); !ok || tr != 604800 {
+		t.Errorf("query_json.time_range = %#v, want 604800", query["time_range"])
+	}
+	calcs, ok := query["calculations"].([]any)
+	if !ok || len(calcs) != 1 {
+		t.Fatalf("query_json.calculations = %#v, want one calculation", query["calculations"])
+	}
+	calc, ok := calcs[0].(map[string]any)
+	if !ok || calc["op"] != "SUM" || calc["column"] != "gen_ai.usage.cost" {
+		t.Errorf("query_json.calculations[0] = %#v, want SUM(gen_ai.usage.cost)", calcs[0])
+	}
+}
+
 func TestCall_ToolError(t *testing.T) {
 	srv, opts, _ := setupMCPTest(t)
 	srv.AddTool(

--- a/internal/fields/fields.go
+++ b/internal/fields/fields.go
@@ -1,6 +1,7 @@
 package fields
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -86,6 +87,10 @@ func CoerceValue(s string, stdin io.Reader) (any, error) {
 		return readFileValue(s[1:], stdin)
 	}
 
+	if v, ok := parseJSON(s); ok {
+		return v, nil
+	}
+
 	if i, err := strconv.ParseInt(s, 10, 64); err == nil {
 		return i, nil
 	}
@@ -94,6 +99,27 @@ func CoerceValue(s string, stdin io.Reader) (any, error) {
 	}
 
 	return s, nil
+}
+
+// parseJSON parses a JSON object or array value so structured arguments (such
+// as the MCP run_query tool's query_json) reach the server as nested data
+// rather than a string the server cannot interpret. Only values that begin
+// with '{' or '[' are treated as JSON; bare scalars fall through to the
+// numeric and string handling so plain values keep their existing types.
+func parseJSON(s string) (any, bool) {
+	trimmed := strings.TrimSpace(s)
+	if len(trimmed) == 0 {
+		return nil, false
+	}
+	if trimmed[0] != '{' && trimmed[0] != '[' {
+		return nil, false
+	}
+
+	var v any
+	if err := json.Unmarshal([]byte(trimmed), &v); err != nil {
+		return nil, false
+	}
+	return v, true
 }
 
 func readFileValue(path string, stdin io.Reader) (string, error) {

--- a/internal/fields/fields_test.go
+++ b/internal/fields/fields_test.go
@@ -81,6 +81,31 @@ func TestParse(t *testing.T) {
 			raw:  []string{"a[b][c]=deep"},
 			want: `{"a":{"b":{"c":"deep"}}}`,
 		},
+		{
+			name:  "typed JSON object parses to nested map",
+			typed: []string{`query_json={"calculations":[{"op":"SUM","column":"gen_ai.usage.cost"}],"time_range":604800,"granularity":86400}`},
+			want:  `{"query_json":{"calculations":[{"column":"gen_ai.usage.cost","op":"SUM"}],"granularity":86400,"time_range":604800}}`,
+		},
+		{
+			name:  "typed JSON array parses to slice",
+			typed: []string{`tags=["a","b"]`},
+			want:  `{"tags":["a","b"]}`,
+		},
+		{
+			name: "raw JSON object stays a string",
+			raw:  []string{`query_json={"op":"COUNT"}`},
+			want: `{"query_json":"{\"op\":\"COUNT\"}"}`,
+		},
+		{
+			name:  "typed plain string stays a string",
+			typed: []string{"dataset=api"},
+			want:  `{"dataset":"api"}`,
+		},
+		{
+			name:  "typed invalid JSON object falls back to string",
+			typed: []string{"value={not json}"},
+			want:  `{"value":"{not json}"}`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
`honeycomb mcp call run_query -F query_json='{...}'` now forwards the query spec as a parsed JSON object instead of a bare string, so the MCP server runs the requested query rather than falling back to its default `COUNT` query.

## Issue

`mcp call` builds its tool arguments with `fields.Parse` (`cmd/mcp/call.go`). A `-f key=value` field is stored as a Go `string` and JSON-marshaled verbatim into the tool call. The `run_query` tool's input schema declares `query_json` as an **object**, so a JSON *string* fails the server's schema check and it silently runs the default `{"calculations":[{"op":"COUNT"}],"granularity":60,"time_range":7200}`. There was previously no flag that could send a nested object at all. Closes #138.

## Changes

- `internal/fields/fields.go`: the typed coercion path (`-F`/`--typed-field`) now parses a value that begins with `{` or `[` and is valid JSON into the nested `map`/`slice`, alongside the existing bool/number/null/`@file` handling. `-f` stays string-only per its documented contract.
- Because `fields` is shared, `honeycomb api -F` gains the same nested-JSON-body capability. Flag help in `cmd/mcp/call.go` and `cmd/api/api.go` updated.

## Decision: `-F`, not `-f`

I kept `-f` as "always a string" and put JSON parsing in `-F`, mirroring `gh api`'s `--raw-field`/`--field` split. The tradeoff: the issue's repro used lowercase `-f`, so the working command becomes `-F query_json='{...}'`. Making `-f` itself parse objects would close the repro verbatim but break the string contract other commands rely on. If you'd rather the exact `-f` form work, say so and I'll move the parsing into the raw path.

A deeper fix would coerce each argument to the MCP tool's declared input-schema type automatically (no `-f`/`-F` distinction needed), but that's a larger change; this is the minimal correct one.

## Testing

Unit tests cover `-F` object/array → nested value, `-f` staying a string, and invalid JSON falling back to string. An in-process MCP server test (`cmd/mcp/call_test.go`) declares an object-typed `query_json` and asserts the server receives a parsed `map`, not a string.

**Draft:** I can't verify end-to-end against the live Honeycomb MCP server here (no OAuth creds). Needs a `mcp call run_query -F query_json='{...}'` smoke test against a real account to confirm the schema-type assumption.
