### PR TITLE
feat(key): resolve --environment by name

### DIFF
--- a/cmd/key/create.go
+++ b/cmd/key/create.go
@@ -61,7 +61,7 @@ func NewCreateCmd(opts *options.RootOptions, team *string) *cobra.Command {
 	cmd.Flags().StringVarP(&file, "file", "f", "", "Path to JSON:API request body (- for stdin)")
 	cmd.Flags().StringVar(&name, "name", "", "Key name")
 	cmd.Flags().StringVar(&keyType, "key-type", "", "Key type (ingest or configuration)")
-	cmd.Flags().StringVar(&environment, "environment", "", "Environment ID")
+	cmd.Flags().StringVar(&environment, "environment", "", "Environment ID or name")
 	cmd.Flags().StringSliceVar(&permissions, "permission", nil, "Permission to grant (repeatable)")
 	cmd.Flags().BoolVar(&allPermissions, "all-permissions", false, "Grant all permissions")
 
@@ -138,13 +138,18 @@ func runKeyCreateFromFlags(cmd *cobra.Command, opts *options.RootOptions, client
 		if !opts.IOStreams.CanPrompt() {
 			return fmt.Errorf("--environment is required in non-interactive mode")
 		}
-		environment, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Environment ID: ")
+		environment, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Environment ID or name: ")
 		if err != nil {
 			return err
 		}
 		if environment == "" {
 			return fmt.Errorf("environment ID is required")
 		}
+	}
+
+	environmentID, err := resolveEnvironment(cmd.Context(), client, team, environment)
+	if err != nil {
+		return err
 	}
 
 	body := api.ApiKeyCreateRequest{}
@@ -154,7 +159,7 @@ func runKeyCreateFromFlags(cmd *cobra.Command, opts *options.RootOptions, client
 			Id   string                              `json:"id"`
 			Type api.EnvironmentRelationshipDataType `json:"type"`
 		}{
-			Id:   environment,
+			Id:   environmentID,
 			Type: api.EnvironmentRelationshipDataTypeEnvironments,
 		},
 	}

--- a/cmd/key/environment.go
+++ b/cmd/key/environment.go
@@ -1,0 +1,76 @@
+package key
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/bendrucker/honeycomb-cli/internal/api"
+)
+
+// environmentIDPrefix is the prefix Honeycomb uses for environment IDs.
+const environmentIDPrefix = "hcaen_"
+
+// resolveEnvironment turns a user-supplied --environment value into an
+// environment ID. A value carrying the environment ID prefix is returned
+// unchanged. Otherwise the value is treated as an environment name and looked
+// up against the Management API for the team.
+func resolveEnvironment(ctx context.Context, client *api.ClientWithResponses, team, value string) (string, error) {
+	if strings.HasPrefix(value, environmentIDPrefix) {
+		return value, nil
+	}
+
+	params := &api.ListEnvironmentsParams{}
+	for {
+		resp, err := client.ListEnvironmentsWithResponse(ctx, api.TeamSlug(team), params)
+		if err != nil {
+			return "", fmt.Errorf("listing environments: %w", err)
+		}
+
+		list, err := api.Decode(resp.StatusCode(), resp.Status(), resp.Body, resp.ApplicationvndApiJSON200)
+		if err != nil {
+			return "", err
+		}
+
+		for _, e := range list.Data {
+			if e.Attributes.Name == value {
+				return e.Id, nil
+			}
+		}
+
+		cursor, err := nextEnvironmentPageCursor(list.Links)
+		if err != nil {
+			return "", err
+		}
+		if cursor == "" {
+			break
+		}
+		params.PageAfter = &cursor
+	}
+
+	return "", fmt.Errorf("no environment found with name %q", value)
+}
+
+// nextEnvironmentPageCursor extracts the page[after] cursor from a links.next
+// URL. It returns an empty string when there is no further page.
+func nextEnvironmentPageCursor(links *api.PaginationLinks) (string, error) {
+	if links == nil || !links.Next.IsSpecified() || links.Next.IsNull() {
+		return "", nil
+	}
+
+	next, err := links.Next.Get()
+	if err != nil {
+		return "", fmt.Errorf("reading next page link: %w", err)
+	}
+	if next == "" {
+		return "", nil
+	}
+
+	parsed, err := url.Parse(next)
+	if err != nil {
+		return "", fmt.Errorf("parsing next page link: %w", err)
+	}
+
+	return parsed.Query().Get("page[after]"), nil
+}

--- a/cmd/key/environment_test.go
+++ b/cmd/key/environment_test.go
@@ -1,0 +1,125 @@
+package key
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bendrucker/honeycomb-cli/internal/api"
+)
+
+func TestResolveEnvironment(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		value     string
+		pages     [][]envStub
+		wantID    string
+		wantCalls int
+		wantErr   string
+	}{
+		{
+			name:      "id passes through without api call",
+			value:     "hcaen_01abc",
+			wantID:    "hcaen_01abc",
+			wantCalls: 0,
+		},
+		{
+			name:      "name resolves to id",
+			value:     "production",
+			pages:     [][]envStub{{{ID: "hcaen_01prod", Name: "production"}, {ID: "hcaen_01stg", Name: "staging"}}},
+			wantID:    "hcaen_01prod",
+			wantCalls: 1,
+		},
+		{
+			name:  "name resolves on second page",
+			value: "production",
+			pages: [][]envStub{
+				{{ID: "hcaen_01stg", Name: "staging"}},
+				{{ID: "hcaen_01prod", Name: "production"}},
+			},
+			wantID:    "hcaen_01prod",
+			wantCalls: 2,
+		},
+		{
+			name:      "name with no match errors",
+			value:     "missing",
+			pages:     [][]envStub{{{ID: "hcaen_01stg", Name: "staging"}}},
+			wantErr:   `no environment found with name "missing"`,
+			wantCalls: 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls int
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls++
+				page := 0
+				if after := r.URL.Query().Get("page[after]"); after != "" {
+					page = pageIndex(after)
+				}
+				w.Header().Set("Content-Type", "application/vnd.api+json")
+				_, _ = w.Write(envListBody(tc.pages, page))
+			}))
+			t.Cleanup(srv.Close)
+
+			client, err := api.NewClientWithResponses(srv.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			gotID, err := resolveEnvironment(context.Background(), client, "my-team", tc.value)
+
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error = %v, want to contain %q", err, tc.wantErr)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if gotID != tc.wantID {
+				t.Errorf("id = %q, want %q", gotID, tc.wantID)
+			}
+			if calls != tc.wantCalls {
+				t.Errorf("api calls = %d, want %d", calls, tc.wantCalls)
+			}
+		})
+	}
+}
+
+type envStub struct {
+	ID   string
+	Name string
+}
+
+func pageIndex(cursor string) int {
+	switch cursor {
+	case "p1":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func envListBody(pages [][]envStub, page int) []byte {
+	var data []map[string]any
+	if page < len(pages) {
+		for _, e := range pages[page] {
+			data = append(data, map[string]any{
+				"id":         e.ID,
+				"type":       "environments",
+				"attributes": map[string]any{"name": e.Name},
+			})
+		}
+	}
+
+	body := map[string]any{"data": data}
+	if page+1 < len(pages) {
+		body["links"] = map[string]any{"next": "https://api.honeycomb.io/2/teams/my-team/environments?page[after]=p1"}
+	}
+
+	out, _ := json.Marshal(body)
+	return out
+}

--- a/cmd/key/key_test.go
+++ b/cmd/key/key_test.go
@@ -412,8 +412,8 @@ func TestCreate_Flags(t *testing.T) {
 				if body.Data.Type != api.ApiKeyCreateRequestDataTypeApiKeys {
 					t.Errorf("data.type = %q, want %q", body.Data.Type, api.ApiKeyCreateRequestDataTypeApiKeys)
 				}
-				if body.Data.Relationships.Environment.Data.Id != "env1" {
-					t.Errorf("environment ID = %q, want %q", body.Data.Relationships.Environment.Data.Id, "env1")
+				if body.Data.Relationships.Environment.Data.Id != "hcaen_01env1" {
+					t.Errorf("environment ID = %q, want %q", body.Data.Relationships.Environment.Data.Id, "hcaen_01env1")
 				}
 
 				var attrs struct {
@@ -446,7 +446,7 @@ func TestCreate_Flags(t *testing.T) {
 			}))
 
 			cmd := NewCmd(opts)
-			cmd.SetArgs([]string{"--team", "my-team", "create", "--name", "My Key", "--key-type", tc.keyType, "--environment", "env1"})
+			cmd.SetArgs([]string{"--team", "my-team", "create", "--name", "My Key", "--key-type", tc.keyType, "--environment", "hcaen_01env1"})
 			if err := cmd.Execute(); err != nil {
 				t.Fatal(err)
 			}
@@ -546,7 +546,7 @@ func TestCreate_WithPermissions(t *testing.T) {
 				}`))
 			}))
 
-			args := []string{"--team", "my-team", "create", "--name", "My Key", "--key-type", "configuration", "--environment", "env1"}
+			args := []string{"--team", "my-team", "create", "--name", "My Key", "--key-type", "configuration", "--environment", "hcaen_01env1"}
 			args = append(args, tc.args...)
 			cmd := NewCmd(opts)
 			cmd.SetArgs(args)


### PR DESCRIPTION
`honeycomb key create --environment <name>` now accepts an environment name, not just an ID. A value with the `hcaen_` prefix is used as a raw ID (no API call); any other value is looked up by name against the Management API and resolved to its ID.

## Changes

- New `cmd/key/environment.go`: `resolveEnvironment(ctx, client, team, value)` returns a `hcaen_`\-prefixed value unchanged, otherwise lists the team's environments and matches by name. No match returns `no environment found with name "<value>"`. The `hcaen_` prefix is a named constant.
- `runKeyCreateFromFlags` resolves the value after input validation and uses the resolved ID in the request body. The `--file` path is untouched. Flag help and the interactive prompt now read "Environment ID or name".
- Lookup paginates across all environment pages, so a name on a later page resolves.

## Decisions

- **No caching.** The issue lists it as optional; one `key create` does at most one (paginated) list pass, which doesn't justify a persistence/invalidation surface.
- **No ambiguity check.** Environment names are unique per team, so the resolver takes the first exact match.
- I duplicated the ~20-line page-cursor helper from `cmd/environment/list.go` rather than export it across packages for one caller.

## Testing

`cmd/key/environment_test.go` (table-driven, `httptest`): `hcaen_` ID passes through with zero API calls, a name resolves to its ID, a name on the second page resolves (pagination), and an unknown name errors. Existing flag-path create tests now use a `hcaen_` ID to exercise passthrough.

Closes #142.

---

Stacked on #179 (`refactor(auth): declare auth requirement per command`), which it builds on for the `ClientFor(team, AuthManagement)` seam. Review and merge #233 first.