### PR TITLE
docs(skills): apply Gen AI Cost board build lessons

### DIFF
--- a/skills/board/SKILL.md
+++ b/skills/board/SKILL.md
@@ -97,7 +97,7 @@ honeycomb board get <board-id> --format json | \
 
 When adding panels to an existing board, fetch the board JSON first, modify the panels array, and send the full board back with `--replace`. The merge behavior without `--replace` replaces the panels array wholesale if the `panels` key is present.
 
-**Important**: The `dataset` field appears in `board get` output on query panels but is rejected by the update API. Strip it before sending: `jq 'walk(if type == "object" and has("dataset") and has("query_id") then del(.dataset) else . end)'`
+**Note**: Query panels include a `dataset` field in `board get` output that the update API rejects (HTTP 422). The CLI strips it automatically on `create` and `update`, so no manual `jq` filtering is needed.
 
 ## Panel Types
 
@@ -193,6 +193,7 @@ Add up to 5 preset filters for cross-board filtering. These create dropdown filt
 - `alias` is the display label (max 50 chars)
 - Choose columns that meaningfully partition the data across all panels
 - Common choices: `service.name`, `environment`, `k8s.namespace.name`, `http.route`
+- Preset filters list **every** value of the column across the whole dataset, not only values that match the panels' filters. On a focused board this surfaces irrelevant options (e.g., services that emit none of the board's events). Add a preset filter only when all of the column's values are relevant to the board's scope.
 
 ### Tags
 
@@ -331,6 +332,12 @@ honeycomb board get <board-id> --format json | \
   jq '.panels |= [.[2], .[0], .[1]] + .[3:]' | \
   honeycomb board update <board-id> --file - --replace
 ```
+
+## Gotchas
+
+### `board update --replace` Resets the Default Time Range
+
+The board-level "Default time range" overrides each query's `granularity` -- a panel built with `granularity: 86400` (daily bars) may render as 30-minute bars. This setting is not exposed in the board API, and every `board update --replace` resets it to "Last 7 days" with auto granularity. After a `--replace`, restore per-query time ranges and granularity by clicking **Apply defaults** in the board's time picker in the UI. Minimize `--replace` when per-query granularity matters.
 
 ## Reference
 

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -63,11 +63,13 @@ Choose chart types based on the data pattern, not the Honeycomb default (line gr
 | Value | Name | Best for |
 |-------|------|----------|
 | `line` | Line graph | Continuous metrics with high cardinality over time (CPU, memory) |
-| `tsbar` | Time series bar | Time-bucketed counts and sparse data (errors, deploys, events) |
-| `stacked` | Stacked area | Showing composition/proportion over time (errors by type, traffic by service) |
+| `tsbar` | Time series bar | Time-bucketed counts and sparse data (errors, deploys, events). Renders as **stacked bars** when the query has breakdowns. |
+| `stacked` | Stacked **area** | Proportion over time as filled areas, *not* bars (errors by type, traffic by service) |
 | `stat` | Stat card | Single headline number with sparkline (current p99, error rate) |
 | `cbar` | Categorical bar | Comparing values across groups, non-time-series (latency by endpoint) |
 | `cpie` | Categorical pie | Proportional breakdown of a total (traffic share by region) |
+
+**"Stacked bar" is `tsbar`, not `stacked`.** `stacked` renders a filled area chart. For stacked *bars*, use `tsbar` with breakdowns -- Honeycomb stacks the bars automatically.
 
 ### `chart_index`
 
@@ -87,7 +89,7 @@ When a query has multiple calculations, `chart_index` maps to the 0-based index 
 ### Latency
 
 - **Calculations**: Use percentiles, never AVG. AVG is skewed by outliers and doesn't represent typical user experience. Use `P50` as the baseline (median) and `P99` for worst-case.
-- **Chart type**: `line` with `overlaid_charts: true` for P50/P99 overlay. The gap between P50 and P99 is the signal -- a widening gap indicates tail latency problems.
+- **Chart type**: `line`. Set `overlaid_charts: true` to put P50 and P99 on one chart, but Honeycomb does not reliably merge multiple calculations -- they may still render as separate areas (see Anti-Patterns). The gap between P50 and P99 is the signal -- a widening gap indicates tail latency problems.
 - **Units**: Always milliseconds. Note conversion in the panel title if the column uses other units.
 - **Title pattern**: "Latency: P50 and P99 (ms)"
 - **Granularity**: Match to request volume. Low-traffic services need larger buckets (300s+) to avoid noisy graphs.
@@ -104,7 +106,7 @@ When a query has multiple calculations, `chart_index` maps to the 0-based index 
 ### Throughput / request volume
 
 - **Calculations**: `COUNT`
-- **Chart type**: `stacked` bar when broken down by service or route -- clearly shows both total volume and composition. Use `tsbar` only for total count without breakdown.
+- **Chart type**: `tsbar`. With a breakdown by service or route, Honeycomb stacks the bars automatically, showing total volume and composition together. (`stacked` is a filled *area* chart, not bars -- use it only for proportion-over-time.)
 - **Breakdowns**: `service.name`, `http.route`, `rpc.method`
 - **Granularity**: Produce meaningful bars. For a 2-hour window, 60-120s. For 24 hours, 300-600s.
 - **Title pattern**: "Request Volume by Service"
@@ -142,6 +144,9 @@ When data arrives infrequently (webhooks, batch jobs, rare errors):
 - **Status code breakdowns**: Too many series, not actionable. Break down by service or route instead.
 - **Line charts on sparse data**: Interpolation creates false continuity. Use `tsbar`.
 - **Too many breakdowns**: More than 5-7 series on one chart becomes unreadable. Use `limit` in the query or aggregate differently.
+- **`overlaid_charts` for multiple calculations**: Honeycomb does not reliably render multiple calculations (two `SUM`s, or P50 + P99) on one overlaid chart -- they often stay separate areas. Prefer a single calculation with a breakdown.
+- **Bare `COUNT` in tables**: A `COUNT` column beside other calculations is ambiguous. Alias it ("Requests", "Turns") or drop it -- it rarely adds value next to a `SUM` or `AVG`.
+- **Raw IDs as breakdowns**: Trace IDs, conversation IDs, and similar high-cardinality identifiers are unreadable in tables and always reachable by clicking through. Break down by human-readable dimensions (names, emails, routes).
 
 ## SLI-Oriented Query Design
 
@@ -152,7 +157,7 @@ Structure queries around Service Level Indicators. An SLI is a ratio: good event
 | Availability | `AVG(error)` inverted (1 - error rate) | `line` |
 | Latency | `P50`/`P99` on `duration_ms` | `line` overlaid |
 | Error rate | `AVG(error)` on boolean column | `line` |
-| Throughput | `COUNT` | `stacked` by service |
+| Throughput | `COUNT` | `tsbar`, stacked by service |
 | Freshness | `MAX(age_seconds)` or custom | `line` |
 
 For SLO-aware dashboards, use `compare_time_offset_seconds` (e.g., `86400`) to overlay current error rate against the previous day. This shows burn trajectory without requiring SLO-specific API access.


### PR DESCRIPTION
Folds the lessons from the Gen AI Cost Overview board build into the `board` and `query` skills. Closes #140.

## Changes

- Clarifies that `stacked` is a filled *area* chart and that stacked *bars* are `tsbar` with breakdowns (Honeycomb stacks them automatically). Fixes the throughput guidance and the SLI table, which previously called `stacked` a bar chart.
- Documents that `overlaid_charts` does not reliably merge multiple calculations onto one chart, and softens the P50/P99 overlay recommendation accordingly.
- Adds a board gotcha: `board update --replace` resets the board's default time range, which overrides per-query `granularity`.
- Notes that preset filters list every value of a column across the whole dataset, not just values matching the panels' filters.
- Replaces the manual `dataset`-strip `jq` snippet with a note that the CLI strips the field automatically on `create` and `update` (`stripPanelDataset`).

## References

The two "possible CLI improvements" from #140 are already resolved: `stripPanelDataset` (`cmd/board/update.go`) strips the 422-causing `dataset` field on every create/update path, and the board default-time-range setting has no API to expose.
