### PR TITLE
feat(mcp): coerce call arguments to declared schema type

### DIFF
--- a/cmd/mcp/call.go
+++ b/cmd/mcp/call.go
@@ -41,7 +41,7 @@ func newCallCmd(opts *options.RootOptions, token *string, factory clientFactory)
 		},
 	}
 
-	cmd.Flags().StringArrayVarP(&o.fieldFlags, "field", "f", nil, "String field: key=value (repeatable; not a file)")
+	cmd.Flags().StringArrayVarP(&o.fieldFlags, "field", "f", nil, "Field: key=value, coerced to the tool's declared schema type (repeatable)")
 	cmd.Flags().StringArrayVarP(&o.typedFlags, "typed-field", "F", nil, "Typed field: bool/number/null/JSON object/array coercion, @file")
 	cmd.Flags().StringVar(&o.input, "input", "", "Read full arguments JSON from a file (- for stdin)")
 	cmd.Flags().StringVarP(&o.jqExpr, "jq", "q", "", "Filter output with jq expression")
@@ -66,6 +66,20 @@ func runCall(cmd *cobra.Command, o *callOptions, toolName string) error {
 		return err
 	}
 	defer func() { _ = c.Close() }()
+
+	// Field arguments arrive as strings; resolve the tool's schema and coerce
+	// them to the declared types. Resolving the tool first also rejects an
+	// unknown name with a clear error before the call is built. --input is
+	// user-authored full JSON, sent as-is with no schema round trip.
+	if o.input == "" {
+		tool, err := findTool(ctx, c, toolName)
+		if err != nil {
+			return err
+		}
+		if err := coerceArgs(args, tool.InputSchema); err != nil {
+			return err
+		}
+	}
 
 	request := mcp.CallToolRequest{}
 	request.Params.Name = toolName

--- a/cmd/mcp/call_test.go
+++ b/cmd/mcp/call_test.go
@@ -3,6 +3,8 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -86,6 +88,88 @@ func TestCall_TypedJSONObjectArgument(t *testing.T) {
 	calc, ok := calcs[0].(map[string]any)
 	if !ok || calc["op"] != "SUM" || calc["column"] != "gen_ai.usage.cost" {
 		t.Errorf("query_json.calculations[0] = %#v, want SUM(gen_ai.usage.cost)", calcs[0])
+	}
+}
+
+func TestCall_SchemaCoercesRawField(t *testing.T) {
+	srv, opts, _ := setupMCPTest(t)
+
+	var got map[string]any
+	srv.AddTool(
+		mcp.NewTool("run_query",
+			mcp.WithString("dataset"),
+			mcp.WithObject("query_json"),
+		),
+		func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			got = req.GetArguments()
+			return mcp.NewToolResultText("ok"), nil
+		},
+	)
+
+	cmd := newCallCmd(opts, nil, testFactory(srv))
+	cmd.SetArgs([]string{"run_query",
+		"-f", "dataset=api",
+		"-f", `query_json={"calculations":[{"op":"SUM","column":"gen_ai.usage.cost"}],"time_range":604800}`,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	query, ok := got["query_json"].(map[string]any)
+	if !ok {
+		t.Fatalf("query_json = %#v, want a parsed object (-f coerced via schema, not left a string)", got["query_json"])
+	}
+	if tr, ok := query["time_range"].(float64); !ok || tr != 604800 {
+		t.Errorf("query_json.time_range = %#v, want 604800", query["time_range"])
+	}
+	if ds, ok := got["dataset"].(string); !ok || ds != "api" {
+		t.Errorf("dataset = %#v, want string %q", got["dataset"], "api")
+	}
+}
+
+func TestCall_UnknownTool(t *testing.T) {
+	srv, opts, _ := setupMCPTest(t)
+	srv.AddTool(mcp.NewTool("known"), func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText("ok"), nil
+	})
+
+	cmd := newCallCmd(opts, nil, testFactory(srv))
+	cmd.SetArgs([]string{"missing", "-f", "key=val"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for unknown tool")
+	}
+	if !strings.Contains(err.Error(), `unknown tool "missing"`) {
+		t.Errorf("error = %q, want unknown tool message", err.Error())
+	}
+}
+
+func TestCall_InputNotCoerced(t *testing.T) {
+	srv, opts, _ := setupMCPTest(t)
+
+	var got map[string]any
+	srv.AddTool(
+		mcp.NewTool("run_query", mcp.WithObject("query_json")),
+		func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			got = req.GetArguments()
+			return mcp.NewToolResultText("ok"), nil
+		},
+	)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "args.json")
+	if err := os.WriteFile(path, []byte(`{"query_json":"raw-string"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newCallCmd(opts, nil, testFactory(srv))
+	cmd.SetArgs([]string{"run_query", "--input", path})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if got["query_json"] != "raw-string" {
+		t.Errorf("query_json = %#v, want the string sent as-is (--input is not schema-coerced)", got["query_json"])
 	}
 }
 

--- a/cmd/mcp/schema.go
+++ b/cmd/mcp/schema.go
@@ -1,0 +1,134 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// findTool fetches the server's tool list and returns the tool with the given
+// name. ListTools follows pagination internally. Resolving the tool up front
+// validates the name (and surfaces its input schema) before the call is built,
+// so an unknown tool fails with a clear error instead of a server-side rejection.
+func findTool(ctx context.Context, c *mcpclient.Client, name string) (mcp.Tool, error) {
+	result, err := c.ListTools(ctx, mcp.ListToolsRequest{})
+	if err != nil {
+		return mcp.Tool{}, fmt.Errorf("listing tools: %w", err)
+	}
+	for _, t := range result.Tools {
+		if t.Name == name {
+			return t, nil
+		}
+	}
+	return mcp.Tool{}, fmt.Errorf("unknown tool %q", name)
+}
+
+// coerceArgs converts string-valued arguments to the type declared for them in
+// the tool's input schema, so a value like -f query_json='{...}' reaches the
+// server as the object the tool expects rather than a string it cannot
+// interpret. Only top-level string values are coerced: non-string values (the
+// already-typed results of -F, and nested maps/arrays built by key[sub]=
+// syntax) are skipped, and a property the schema does not type stays a string.
+func coerceArgs(args map[string]any, schema mcp.ToolInputSchema) error {
+	for key, val := range args {
+		s, ok := val.(string)
+		if !ok {
+			continue
+		}
+
+		prop, ok := schema.Properties[key].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		coerced, err := coerceValue(s, schemaType(prop))
+		if err != nil {
+			return fmt.Errorf("argument %q: %w", key, err)
+		}
+		args[key] = coerced
+	}
+	return nil
+}
+
+// schemaType returns the JSON Schema type for a property. A plain string type
+// is returned as-is; a type expressed as a list (e.g. ["string", "null"] for a
+// nullable property) yields the first non-null entry. Anything else (a type
+// declared through oneOf/anyOf, or absent entirely) returns the empty string,
+// which coerceValue treats as leaving the value as a string.
+func schemaType(prop map[string]any) string {
+	switch t := prop["type"].(type) {
+	case string:
+		return t
+	case []any:
+		for _, item := range t {
+			if s, ok := item.(string); ok && s != "null" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// coerceValue converts a string argument to the Go value matching a declared
+// JSON Schema type. An unknown type, the empty type, or "string" leaves the
+// value as a string. A value that cannot be parsed as the declared type is an
+// error: the user asked for a type the value does not satisfy.
+func coerceValue(s, declaredType string) (any, error) {
+	switch declaredType {
+	case "object", "array":
+		var v any
+		if err := json.Unmarshal([]byte(s), &v); err != nil {
+			return nil, fmt.Errorf("invalid JSON for %s: %w", declaredType, err)
+		}
+		// json.Unmarshal accepts any valid JSON, including scalars, so verify
+		// the parsed value is the declared kind rather than silently sending a
+		// number/string/null where the tool expects an object or array.
+		if !matchesJSONKind(v, declaredType) {
+			return nil, fmt.Errorf("expected a JSON %s", declaredType)
+		}
+		return v, nil
+	case "number":
+		n, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid number: %w", err)
+		}
+		if math.IsNaN(n) || math.IsInf(n, 0) {
+			return nil, fmt.Errorf("invalid number: %q is not a finite JSON number", s)
+		}
+		return n, nil
+	case "integer":
+		i, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid integer: %w", err)
+		}
+		return i, nil
+	case "boolean":
+		b, err := strconv.ParseBool(s)
+		if err != nil {
+			return nil, fmt.Errorf("invalid boolean: %w", err)
+		}
+		return b, nil
+	default:
+		return s, nil
+	}
+}
+
+// matchesJSONKind reports whether a value decoded by json.Unmarshal is the
+// declared JSON Schema container kind: a map for "object", a slice for "array".
+func matchesJSONKind(v any, declaredType string) bool {
+	switch declaredType {
+	case "object":
+		_, ok := v.(map[string]any)
+		return ok
+	case "array":
+		_, ok := v.([]any)
+		return ok
+	default:
+		return true
+	}
+}

--- a/cmd/mcp/schema_test.go
+++ b/cmd/mcp/schema_test.go
@@ -1,0 +1,230 @@
+package mcp
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestSchemaType(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		prop map[string]any
+		want string
+	}{
+		{
+			name: "plain string",
+			prop: map[string]any{"type": "object"},
+			want: "object",
+		},
+		{
+			name: "nullable list picks non null",
+			prop: map[string]any{"type": []any{"object", "null"}},
+			want: "object",
+		},
+		{
+			name: "null first in list",
+			prop: map[string]any{"type": []any{"null", "integer"}},
+			want: "integer",
+		},
+		{
+			name: "absent type",
+			prop: map[string]any{"description": "no type here"},
+			want: "",
+		},
+		{
+			name: "oneof not recognized",
+			prop: map[string]any{"oneOf": []any{}},
+			want: "",
+		},
+		{
+			name: "list of only null",
+			prop: map[string]any{"type": []any{"null"}},
+			want: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := schemaType(tc.prop); got != tc.want {
+				t.Errorf("schemaType = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCoerceValue(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		value        string
+		declaredType string
+		want         any
+		wantErr      bool
+	}{
+		{
+			name:         "object",
+			value:        `{"a":1}`,
+			declaredType: "object",
+			want:         map[string]any{"a": float64(1)},
+		},
+		{
+			name:         "array",
+			value:        `[1,2]`,
+			declaredType: "array",
+			want:         []any{float64(1), float64(2)},
+		},
+		{
+			name:         "number",
+			value:        "1.5",
+			declaredType: "number",
+			want:         1.5,
+		},
+		{
+			name:         "integer",
+			value:        "42",
+			declaredType: "integer",
+			want:         int64(42),
+		},
+		{
+			name:         "boolean",
+			value:        "true",
+			declaredType: "boolean",
+			want:         true,
+		},
+		{
+			name:         "string left as is",
+			value:        "hello",
+			declaredType: "string",
+			want:         "hello",
+		},
+		{
+			name:         "unknown type left as is",
+			value:        "hello",
+			declaredType: "",
+			want:         "hello",
+		},
+		{
+			name:         "json string stays string when typed string",
+			value:        `{"a":1}`,
+			declaredType: "string",
+			want:         `{"a":1}`,
+		},
+		{
+			name:         "invalid object",
+			value:        "not json",
+			declaredType: "object",
+			wantErr:      true,
+		},
+		{
+			name:         "scalar rejected for object",
+			value:        "42",
+			declaredType: "object",
+			wantErr:      true,
+		},
+		{
+			name:         "object rejected for array",
+			value:        `{"a":1}`,
+			declaredType: "array",
+			wantErr:      true,
+		},
+		{
+			name:         "nan rejected for number",
+			value:        "NaN",
+			declaredType: "number",
+			wantErr:      true,
+		},
+		{
+			name:         "inf rejected for number",
+			value:        "Inf",
+			declaredType: "number",
+			wantErr:      true,
+		},
+		{
+			name:         "invalid integer",
+			value:        "abc",
+			declaredType: "integer",
+			wantErr:      true,
+		},
+		{
+			name:         "invalid boolean",
+			value:        "maybe",
+			declaredType: "boolean",
+			wantErr:      true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := coerceValue(tc.value, tc.declaredType)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %#v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("coerceValue = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCoerceArgs(t *testing.T) {
+	schema := mcp.ToolInputSchema{
+		Properties: map[string]any{
+			"query_json": map[string]any{"type": "object"},
+			"limit":      map[string]any{"type": "integer"},
+			"dataset":    map[string]any{"type": "string"},
+		},
+	}
+
+	t.Run("coerces string values by declared type", func(t *testing.T) {
+		args := map[string]any{
+			"query_json": `{"calculations":[{"op":"COUNT"}]}`,
+			"limit":      "10",
+			"dataset":    "api",
+		}
+		if err := coerceArgs(args, schema); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, ok := args["query_json"].(map[string]any); !ok {
+			t.Errorf("query_json = %#v, want map[string]any", args["query_json"])
+		}
+		if args["limit"] != int64(10) {
+			t.Errorf("limit = %#v, want int64(10)", args["limit"])
+		}
+		if args["dataset"] != "api" {
+			t.Errorf("dataset = %#v, want string %q", args["dataset"], "api")
+		}
+	})
+
+	t.Run("leaves already typed values untouched", func(t *testing.T) {
+		nested := map[string]any{"sub": "value"}
+		args := map[string]any{"query_json": nested}
+		if err := coerceArgs(args, schema); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(args["query_json"], nested) {
+			t.Errorf("query_json = %#v, want it left as the original map", args["query_json"])
+		}
+	})
+
+	t.Run("leaves unknown keys as strings", func(t *testing.T) {
+		args := map[string]any{"unknown": `{"a":1}`}
+		if err := coerceArgs(args, schema); err != nil {
+			t.Fatal(err)
+		}
+		if args["unknown"] != `{"a":1}` {
+			t.Errorf("unknown = %#v, want it left as a string", args["unknown"])
+		}
+	})
+
+	t.Run("returns error for unparseable value", func(t *testing.T) {
+		args := map[string]any{"limit": "not-a-number"}
+		err := coerceArgs(args, schema)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}


### PR DESCRIPTION
Coerces each `honeycomb mcp call` argument to the type the tool declares in its input schema, so `-f query_json='{...}'` reaches the server as the object the tool expects instead of a string it silently rejects. This grounds coercion in what the tool actually declares rather than the syntactic `-F` guess #234 introduced.

Closes #237

## Changes

- After connecting, `runCall` resolves the tool via `findTool` (a `ListTools` lookup that also rejects an unknown tool name with a clear error before the call is built), then `coerceArgs` converts each string-valued argument to its declared type: `object`/`array` via `json.Unmarshal`, `number`/`integer` via `strconv`, `boolean` via `ParseBool`. A `string`, an untyped property, or a type the schema expresses through `oneOf`/`anyOf` stays a string.
- Coercion touches only top-level string values, so `-F` results and nested maps built by the `key[sub]=` syntax pass through untouched, and the `--input` path (user-authored full JSON) is sent as-is with no schema round trip.
- `schemaType` reads a plain string `type` or the first non-`null` entry of a `["T","null"]` list, matching how nullable properties appear in the schema.
- Updated the `-f` flag help to describe schema-driven coercion.

I left the `-F` JSON heuristic from #234 in the shared `internal/fields` package: `honeycomb api` depends on it, and it is idempotent with schema coercion for `mcp call` (a value `-F` already parsed to a map is a non-string, so `coerceArgs` skips it).

## Testing

- Unit tests for `schemaType` (plain string, nullable list, absent type, `oneOf`) and `coerceValue` (each type, plus rejection of a scalar passed where an `object`/`array` is declared and of non-finite numbers).
- Command tests: `-f query_json='{...}'` reaches an object-typed server argument as a parsed map (the #138 repro via `-f`), an unknown tool name errors before the call, and `--input` is not schema-coerced.

#### Draft

I could not verify end-to-end against the live Honeycomb MCP server here (no OAuth creds). Needs a `mcp call run_query -f query_json='{...}'` smoke test against a real account to confirm the schema types `query_json` as an object server-side.

## References

- #138 (original bug)
- #234 (the `-F` heuristic this supersedes)
