### PR TITLE
refactor(command): resolve flag-or-prompt inputs through one helper

### DIFF
--- a/cmd/board/create.go
+++ b/cmd/board/create.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -62,18 +61,20 @@ func runBoardCreate(cmd *cobra.Command, opts *options.RootOptions, file, name, d
 	}
 
 	if name == "" {
-		if !opts.IOStreams.CanPrompt() {
-			return fmt.Errorf("--name or --file is required in non-interactive mode")
-		}
-		name, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Board name: ")
+		promptable := opts.IOStreams.CanPrompt()
+		name, err = command.Resolve(opts.IOStreams, name, command.Field{
+			Prompt:            "Board name: ",
+			Required:          true,
+			NonInteractiveErr: fmt.Errorf("--name or --file is required in non-interactive mode"),
+			EmptyErr:          fmt.Errorf("board name is required"),
+		})
 		if err != nil {
 			return err
 		}
-		if name == "" {
-			return fmt.Errorf("board name is required")
-		}
-		if !cmd.Flags().Changed("description") {
-			desc, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Description (optional): ")
+		if promptable && !cmd.Flags().Changed("description") {
+			desc, err = command.Resolve(opts.IOStreams, desc, command.Field{
+				Prompt: "Description (optional): ",
+			})
 			if err != nil {
 				return err
 			}

--- a/cmd/board/view_create.go
+++ b/cmd/board/view_create.go
@@ -9,7 +9,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -60,17 +59,14 @@ func runViewCreate(cmd *cobra.Command, opts *options.RootOptions, boardID, file,
 		return createViewFromFile(ctx, client, opts, boardID, file)
 	}
 
-	if name == "" {
-		if !opts.IOStreams.CanPrompt() {
-			return fmt.Errorf("--name or --file is required in non-interactive mode")
-		}
-		name, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "View name: ")
-		if err != nil {
-			return err
-		}
-		if name == "" {
-			return fmt.Errorf("view name is required")
-		}
+	name, err = command.Resolve(opts.IOStreams, name, command.Field{
+		Prompt:            "View name: ",
+		Required:          true,
+		NonInteractiveErr: fmt.Errorf("--name or --file is required in non-interactive mode"),
+		EmptyErr:          fmt.Errorf("view name is required"),
+	})
+	if err != nil {
+		return err
 	}
 
 	filters, err := parseViewFilters(filterArgs)

--- a/cmd/column/calculated_create.go
+++ b/cmd/column/calculated_create.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -28,26 +27,22 @@ func NewCalculatedCreateCmd(opts *options.RootOptions, dataset *string) *cobra.C
 				return runCalculatedCreateFromFile(cmd.Context(), opts, *dataset, file)
 			}
 
-			if alias == "" {
-				if !opts.IOStreams.CanPrompt() {
-					return fmt.Errorf("--alias is required in non-interactive mode")
-				}
-				var err error
-				alias, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Alias: ")
-				if err != nil {
-					return err
-				}
+			alias, err := command.Resolve(opts.IOStreams, alias, command.Field{
+				Prompt:            "Alias: ",
+				Required:          true,
+				NonInteractiveErr: fmt.Errorf("--alias is required in non-interactive mode"),
+			})
+			if err != nil {
+				return err
 			}
 
-			if expression == "" {
-				if !opts.IOStreams.CanPrompt() {
-					return fmt.Errorf("--expression is required in non-interactive mode")
-				}
-				var err error
-				expression, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Expression: ")
-				if err != nil {
-					return err
-				}
+			expression, err := command.Resolve(opts.IOStreams, expression, command.Field{
+				Prompt:            "Expression: ",
+				Required:          true,
+				NonInteractiveErr: fmt.Errorf("--expression is required in non-interactive mode"),
+			})
+			if err != nil {
+				return err
 			}
 
 			body := api.CreateCalculatedFieldJSONRequestBody{

--- a/cmd/column/create.go
+++ b/cmd/column/create.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -37,23 +36,21 @@ func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 				return runColumnCreateFromFile(cmd.Context(), opts, *dataset, file)
 			}
 
-			if keyName == "" {
-				if !opts.IOStreams.CanPrompt() {
-					return fmt.Errorf("--key-name is required in non-interactive mode")
-				}
-				var err error
-				keyName, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Key name: ")
-				if err != nil {
-					return err
-				}
+			keyName, err := command.Resolve(opts.IOStreams, keyName, command.Field{
+				Prompt:            "Key name: ",
+				Required:          true,
+				NonInteractiveErr: fmt.Errorf("--key-name is required in non-interactive mode"),
+			})
+			if err != nil {
+				return err
 			}
 
-			if colType == "" && opts.IOStreams.CanPrompt() {
-				var err error
-				colType, err = prompt.Choice(opts.IOStreams.Err, opts.IOStreams.In, "Type (string/float/integer/boolean): ", []string{"string", "float", "integer", "boolean"})
-				if err != nil {
-					return err
-				}
+			colType, err := command.Resolve(opts.IOStreams, colType, command.Field{
+				Prompt:  "Type (string/float/integer/boolean): ",
+				Choices: []string{"string", "float", "integer", "boolean"},
+			})
+			if err != nil {
+				return err
 			}
 
 			return runColumnCreate(cmd, opts, *dataset, keyName, colType, description, hidden)

--- a/cmd/command/confirm.go
+++ b/cmd/command/confirm.go
@@ -1,5 +1,6 @@
 // Package command holds helpers shared by the resource CRUD commands: delete
-// confirmation, definition-file intake, and flag-override merging.
+// confirmation, definition-file intake, flag-override merging, and resolving a
+// missing flag value through an interactive prompt.
 package command
 
 import (

--- a/cmd/command/resolve.go
+++ b/cmd/command/resolve.go
@@ -1,0 +1,92 @@
+package command
+
+import (
+	"io"
+
+	"github.com/bendrucker/honeycomb-cli/internal/iostreams"
+	"github.com/bendrucker/honeycomb-cli/internal/prompt"
+)
+
+// Field describes a single create-command input that is supplied by a flag but
+// falls back to an interactive prompt when the flag is empty. Resolve consumes
+// it to collapse the flag-or-prompt branch that every create command would
+// otherwise hand-write.
+//
+// Prompt is the text shown when prompting. Choices, when non-empty, switches
+// the prompt to prompt.Choice (the value must match one of the options).
+// Required controls whether an empty result is an error: a required field that
+// cannot be prompted returns NonInteractiveErr, and a required field that is
+// prompted but left blank returns EmptyErr. An optional field (Required false)
+// prompts only when possible and accepts an empty result.
+//
+// Stream selects which writer the prompt text is written to. Most call sites
+// prompt on Err; a zero Stream defaults to Err so only the call sites that
+// prompt on Out (dataset create, query run) need to set it.
+type Field struct {
+	Prompt   string
+	Required bool
+	Choices  []string
+
+	NonInteractiveErr error
+	EmptyErr          error
+
+	Stream Stream
+}
+
+// Stream identifies which IOStreams writer a prompt is written to. The zero
+// value is StreamErr, matching the majority of call sites.
+type Stream int
+
+const (
+	StreamErr Stream = iota
+	StreamOut
+)
+
+// Resolve returns value when it is already set, otherwise prompts for it.
+//
+//   - value already set: returned as-is, no prompt.
+//   - value empty, required, cannot prompt: returns field.NonInteractiveErr.
+//   - value empty, can prompt: prompts (prompt.Choice when Choices is set,
+//     otherwise prompt.Line) and returns the answer.
+//   - value empty, required, prompted but still empty: returns field.EmptyErr.
+//   - value empty, optional, cannot prompt: returns "" with no error.
+func Resolve(ios *iostreams.IOStreams, value string, field Field) (string, error) {
+	if value != "" {
+		return value, nil
+	}
+
+	if !ios.CanPrompt() {
+		if field.Required {
+			return "", field.NonInteractiveErr
+		}
+		return "", nil
+	}
+
+	out := promptWriter(ios, field.Stream)
+
+	var (
+		answer string
+		err    error
+	)
+	if len(field.Choices) > 0 {
+		answer, err = prompt.Choice(out, ios.In, field.Prompt, field.Choices)
+	} else {
+		answer, err = prompt.Line(out, ios.In, field.Prompt)
+	}
+	if err != nil {
+		return "", err
+	}
+
+	if field.Required && answer == "" {
+		return "", field.EmptyErr
+	}
+
+	return answer, nil
+}
+
+func promptWriter(ios *iostreams.IOStreams, s Stream) io.Writer {
+	if s == StreamOut {
+		return ios.Out
+	}
+	return ios.Err
+}

--- a/cmd/command/resolve_test.go
+++ b/cmd/command/resolve_test.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/bendrucker/honeycomb-cli/internal/iostreams"
@@ -12,15 +13,16 @@ func TestResolve(t *testing.T) {
 	empty := errors.New("name is required")
 
 	for _, tc := range []struct {
-		name       string
-		value      string
-		promptable bool
-		input      string
-		field      Field
-		want       string
-		wantErr    error
-		wantPrompt string
-		wantStream Stream
+		name        string
+		value       string
+		promptable  bool
+		input       string
+		field       Field
+		want        string
+		wantErr     error
+		wantErrText string
+		wantPrompt  string
+		wantStream  Stream
 	}{
 		{
 			name:  "value present skips prompt",
@@ -111,6 +113,19 @@ func TestResolve(t *testing.T) {
 			wantStream: StreamErr,
 		},
 		{
+			name:       "prompt read error propagates",
+			value:      "",
+			promptable: true,
+			input:      "",
+			field: Field{
+				Prompt:            "Name: ",
+				Required:          true,
+				NonInteractiveErr: nonInteractive,
+				EmptyErr:          empty,
+			},
+			wantErrText: "unexpected end of input",
+		},
+		{
 			name:       "stream out writes prompt to stdout",
 			value:      "",
 			promptable: true,
@@ -137,6 +152,12 @@ func TestResolve(t *testing.T) {
 
 			got, err := Resolve(ts.IOStreams, tc.value, tc.field)
 
+			if tc.wantErrText != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrText) {
+					t.Fatalf("error = %v, want containing %q", err, tc.wantErrText)
+				}
+				return
+			}
 			if tc.wantErr != nil {
 				if !errors.Is(err, tc.wantErr) {
 					t.Fatalf("error = %v, want %v", err, tc.wantErr)

--- a/cmd/command/resolve_test.go
+++ b/cmd/command/resolve_test.go
@@ -1,0 +1,168 @@
+package command
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bendrucker/honeycomb-cli/internal/iostreams"
+)
+
+func TestResolve(t *testing.T) {
+	nonInteractive := errors.New("--name is required in non-interactive mode")
+	empty := errors.New("name is required")
+
+	for _, tc := range []struct {
+		name       string
+		value      string
+		promptable bool
+		input      string
+		field      Field
+		want       string
+		wantErr    error
+		wantPrompt string
+		wantStream Stream
+	}{
+		{
+			name:  "value present skips prompt",
+			value: "set",
+			field: Field{
+				Prompt:            "Name: ",
+				Required:          true,
+				NonInteractiveErr: nonInteractive,
+				EmptyErr:          empty,
+			},
+			want: "set",
+		},
+		{
+			name:       "required empty non-interactive returns error",
+			value:      "",
+			promptable: false,
+			field: Field{
+				Prompt:            "Name: ",
+				Required:          true,
+				NonInteractiveErr: nonInteractive,
+				EmptyErr:          empty,
+			},
+			wantErr: nonInteractive,
+		},
+		{
+			name:       "required empty prompts and returns answer",
+			value:      "",
+			promptable: true,
+			input:      "prompted\n",
+			field: Field{
+				Prompt:            "Name: ",
+				Required:          true,
+				NonInteractiveErr: nonInteractive,
+				EmptyErr:          empty,
+			},
+			want:       "prompted",
+			wantPrompt: "Name: ",
+			wantStream: StreamErr,
+		},
+		{
+			name:       "required prompted empty returns empty error",
+			value:      "",
+			promptable: true,
+			input:      "\n",
+			field: Field{
+				Prompt:            "Name: ",
+				Required:          true,
+				NonInteractiveErr: nonInteractive,
+				EmptyErr:          empty,
+			},
+			wantErr: empty,
+		},
+		{
+			name:       "optional empty non-interactive returns empty no error",
+			value:      "",
+			promptable: false,
+			field: Field{
+				Prompt: "Description (optional): ",
+			},
+			want: "",
+		},
+		{
+			name:       "optional empty prompts and accepts empty",
+			value:      "",
+			promptable: true,
+			input:      "\n",
+			field: Field{
+				Prompt: "Description (optional): ",
+			},
+			want:       "",
+			wantPrompt: "Description (optional): ",
+			wantStream: StreamErr,
+		},
+		{
+			name:       "choice path resolves matching option",
+			value:      "",
+			promptable: true,
+			input:      "slack\n",
+			field: Field{
+				Prompt:            "Type: ",
+				Required:          true,
+				Choices:           []string{"email", "slack"},
+				NonInteractiveErr: nonInteractive,
+				EmptyErr:          empty,
+			},
+			want:       "slack",
+			wantPrompt: "Type: ",
+			wantStream: StreamErr,
+		},
+		{
+			name:       "stream out writes prompt to stdout",
+			value:      "",
+			promptable: true,
+			input:      "prompted\n",
+			field: Field{
+				Prompt: "Dataset name: ",
+				Stream: StreamOut,
+			},
+			want:       "prompted",
+			wantPrompt: "Dataset name: ",
+			wantStream: StreamOut,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var ts *iostreams.TestStreams
+			if tc.promptable {
+				ts = iostreams.TestPromptable(t)
+			} else {
+				ts = iostreams.Test(t)
+			}
+			if tc.input != "" {
+				ts.InBuf.WriteString(tc.input)
+			}
+
+			got, err := Resolve(ts.IOStreams, tc.value, tc.field)
+
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("error = %v, want %v", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("value = %q, want %q", got, tc.want)
+			}
+
+			if tc.wantPrompt != "" {
+				stream := ts.ErrBuf.String()
+				other := ts.OutBuf.String()
+				if tc.wantStream == StreamOut {
+					stream, other = other, stream
+				}
+				if stream != tc.wantPrompt {
+					t.Errorf("prompt stream = %q, want %q", stream, tc.wantPrompt)
+				}
+				if other != "" {
+					t.Errorf("unexpected output on other stream = %q", other)
+				}
+			}
+		})
+	}
+}

--- a/cmd/dataset/create.go
+++ b/cmd/dataset/create.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -52,24 +52,22 @@ func NewCreateCmd(opts *options.RootOptions) *cobra.Command {
 func runDatasetCreate(ctx context.Context, opts *options.RootOptions, name, description string, expandJsonDepth *int, clearProtection bool) error {
 	ios := opts.IOStreams
 
-	if ios.CanPrompt() {
-		var err error
-		if name == "" {
-			name, err = prompt.Line(ios.Out, ios.In, "Dataset name: ")
-			if err != nil {
-				return fmt.Errorf("reading name: %w", err)
-			}
-		}
-		if description == "" {
-			description, err = prompt.Line(ios.Out, ios.In, "Description (optional): ")
-			if err != nil {
-				return fmt.Errorf("reading description: %w", err)
-			}
-		}
-	} else {
-		if name == "" {
-			return fmt.Errorf("--name is required in non-interactive mode")
-		}
+	name, err := command.Resolve(ios, name, command.Field{
+		Prompt:            "Dataset name: ",
+		Required:          true,
+		Stream:            command.StreamOut,
+		NonInteractiveErr: fmt.Errorf("--name is required in non-interactive mode"),
+	})
+	if err != nil {
+		return err
+	}
+
+	description, err = command.Resolve(ios, description, command.Field{
+		Prompt: "Description (optional): ",
+		Stream: command.StreamOut,
+	})
+	if err != nil {
+		return err
 	}
 
 	client, err := opts.ClientFor(nil, options.AuthConfig)

--- a/cmd/environment/create.go
+++ b/cmd/environment/create.go
@@ -6,7 +6,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -43,21 +42,22 @@ func NewCreateCmd(opts *options.RootOptions, team *string) *cobra.Command {
 }
 
 func runEnvironmentCreate(cmd *cobra.Command, opts *options.RootOptions, client *api.ClientWithResponses, team, name, desc, color string, clearProtection bool) error {
-	var err error
-
 	if name == "" {
-		if !opts.IOStreams.CanPrompt() {
-			return fmt.Errorf("--name is required in non-interactive mode")
-		}
-		name, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Environment name: ")
+		promptable := opts.IOStreams.CanPrompt()
+		var err error
+		name, err = command.Resolve(opts.IOStreams, name, command.Field{
+			Prompt:            "Environment name: ",
+			Required:          true,
+			NonInteractiveErr: fmt.Errorf("--name is required in non-interactive mode"),
+			EmptyErr:          fmt.Errorf("environment name is required"),
+		})
 		if err != nil {
 			return err
 		}
-		if name == "" {
-			return fmt.Errorf("environment name is required")
-		}
-		if !cmd.Flags().Changed("description") {
-			desc, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Description (optional): ")
+		if promptable && !cmd.Flags().Changed("description") {
+			desc, err = command.Resolve(opts.IOStreams, desc, command.Field{
+				Prompt: "Description (optional): ",
+			})
 			if err != nil {
 				return err
 			}

--- a/cmd/key/create.go
+++ b/cmd/key/create.go
@@ -11,7 +11,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
 	"github.com/bendrucker/honeycomb-cli/internal/deref"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -97,29 +96,24 @@ func runKeyCreateFromFile(ctx context.Context, opts *options.RootOptions, client
 }
 
 func runKeyCreateFromFlags(cmd *cobra.Command, opts *options.RootOptions, client *api.ClientWithResponses, team, name, keyType, environment string, permissions []string, allPermissions bool) error {
-	var err error
-
-	if name == "" {
-		if !opts.IOStreams.CanPrompt() {
-			return fmt.Errorf("--name is required in non-interactive mode")
-		}
-		name, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Key name: ")
-		if err != nil {
-			return err
-		}
-		if name == "" {
-			return fmt.Errorf("key name is required")
-		}
+	name, err := command.Resolve(opts.IOStreams, name, command.Field{
+		Prompt:            "Key name: ",
+		Required:          true,
+		NonInteractiveErr: fmt.Errorf("--name is required in non-interactive mode"),
+		EmptyErr:          fmt.Errorf("key name is required"),
+	})
+	if err != nil {
+		return err
 	}
 
-	if keyType == "" {
-		if !opts.IOStreams.CanPrompt() {
-			return fmt.Errorf("--key-type is required in non-interactive mode")
-		}
-		keyType, err = prompt.Choice(opts.IOStreams.Err, opts.IOStreams.In, "Key type (ingest, configuration): ", []string{"ingest", "configuration"})
-		if err != nil {
-			return err
-		}
+	keyType, err = command.Resolve(opts.IOStreams, keyType, command.Field{
+		Prompt:            "Key type (ingest, configuration): ",
+		Required:          true,
+		Choices:           []string{"ingest", "configuration"},
+		NonInteractiveErr: fmt.Errorf("--key-type is required in non-interactive mode"),
+	})
+	if err != nil {
+		return err
 	}
 
 	if keyType != "ingest" && keyType != "configuration" {
@@ -134,17 +128,14 @@ func runKeyCreateFromFlags(cmd *cobra.Command, opts *options.RootOptions, client
 		return err
 	}
 
-	if environment == "" {
-		if !opts.IOStreams.CanPrompt() {
-			return fmt.Errorf("--environment is required in non-interactive mode")
-		}
-		environment, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Environment ID or name: ")
-		if err != nil {
-			return err
-		}
-		if environment == "" {
-			return fmt.Errorf("environment ID is required")
-		}
+	environment, err = command.Resolve(opts.IOStreams, environment, command.Field{
+		Prompt:            "Environment ID or name: ",
+		Required:          true,
+		NonInteractiveErr: fmt.Errorf("--environment is required in non-interactive mode"),
+		EmptyErr:          fmt.Errorf("environment ID is required"),
+	})
+	if err != nil {
+		return err
 	}
 
 	environmentID, err := resolveEnvironment(cmd.Context(), client, team, environment)

--- a/cmd/marker/create.go
+++ b/cmd/marker/create.go
@@ -32,26 +32,21 @@ func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 			}
 
 			markerType, err := command.Resolve(opts.IOStreams, markerType, command.Field{
-				Prompt: "Type: ",
+				Prompt:            "Type: ",
+				Required:          true,
+				NonInteractiveErr: fmt.Errorf("--type is required in non-interactive mode"),
 			})
 			if err != nil {
 				return err
 			}
 
 			message, err := command.Resolve(opts.IOStreams, message, command.Field{
-				Prompt: "Message: ",
+				Prompt:            "Message: ",
+				Required:          true,
+				NonInteractiveErr: fmt.Errorf("--message is required in non-interactive mode"),
 			})
 			if err != nil {
 				return err
-			}
-
-			if !opts.IOStreams.CanPrompt() {
-				if markerType == "" {
-					return fmt.Errorf("--type is required in non-interactive mode")
-				}
-				if message == "" {
-					return fmt.Errorf("--message is required in non-interactive mode")
-				}
 			}
 
 			if !cmd.Flags().Changed("start-time") {

--- a/cmd/marker/create.go
+++ b/cmd/marker/create.go
@@ -9,7 +9,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -32,20 +31,18 @@ func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 				return runMarkerCreateFromFile(cmd.Context(), opts, *dataset, file)
 			}
 
-			if markerType == "" && opts.IOStreams.CanPrompt() {
-				v, err := prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Type: ")
-				if err != nil {
-					return err
-				}
-				markerType = v
+			markerType, err := command.Resolve(opts.IOStreams, markerType, command.Field{
+				Prompt: "Type: ",
+			})
+			if err != nil {
+				return err
 			}
 
-			if message == "" && opts.IOStreams.CanPrompt() {
-				v, err := prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Message: ")
-				if err != nil {
-					return err
-				}
-				message = v
+			message, err := command.Resolve(opts.IOStreams, message, command.Field{
+				Prompt: "Message: ",
+			})
+			if err != nil {
+				return err
 			}
 
 			if !opts.IOStreams.CanPrompt() {

--- a/cmd/marker/setting_create.go
+++ b/cmd/marker/setting_create.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -35,20 +34,18 @@ func NewSettingCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Comm
 				return runSettingCreate(cmd.Context(), opts, *dataset, body)
 			}
 
-			if settingType == "" && opts.IOStreams.CanPrompt() {
-				v, err := prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Type: ")
-				if err != nil {
-					return err
-				}
-				settingType = v
+			settingType, err := command.Resolve(opts.IOStreams, settingType, command.Field{
+				Prompt: "Type: ",
+			})
+			if err != nil {
+				return err
 			}
 
-			if color == "" && opts.IOStreams.CanPrompt() {
-				v, err := prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Color: ")
-				if err != nil {
-					return err
-				}
-				color = v
+			color, err := command.Resolve(opts.IOStreams, color, command.Field{
+				Prompt: "Color: ",
+			})
+			if err != nil {
+				return err
 			}
 
 			body := api.MarkerSetting{

--- a/cmd/query/annotation_create.go
+++ b/cmd/query/annotation_create.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -91,15 +90,14 @@ func runAnnotationCreate(cmd *cobra.Command, opts *options.RootOptions, dataset,
 			return fmt.Errorf("encoding query annotation: %w", err)
 		}
 	} else {
-		if !opts.IOStreams.CanPrompt() {
-			return fmt.Errorf("--file is required in non-interactive mode")
-		}
-		file, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Path to query annotation JSON file: ")
+		file, err = command.Resolve(opts.IOStreams, file, command.Field{
+			Prompt:            "Path to query annotation JSON file: ",
+			Required:          true,
+			NonInteractiveErr: fmt.Errorf("--file is required in non-interactive mode"),
+			EmptyErr:          fmt.Errorf("file path is required"),
+		})
 		if err != nil {
 			return err
-		}
-		if file == "" {
-			return fmt.Errorf("file path is required")
 		}
 		data, err = command.ReadDefinitionFile(opts.IOStreams, file)
 		if err != nil {

--- a/cmd/recipient/create.go
+++ b/cmd/recipient/create.go
@@ -11,7 +11,6 @@ import (
 	"github.com/bendrucker/honeycomb-cli/cmd/command"
 	"github.com/bendrucker/honeycomb-cli/cmd/options"
 	"github.com/bendrucker/honeycomb-cli/internal/api"
-	"github.com/bendrucker/honeycomb-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -87,15 +86,14 @@ func validateDetailFlags(cmd *cobra.Command, recipientType string) error {
 }
 
 func runCreate(ctx context.Context, opts *options.RootOptions, recipientType, target, channel, integrationKey, name, url string) error {
-	var err error
-	if recipientType == "" {
-		if !opts.IOStreams.CanPrompt() {
-			return fmt.Errorf("--type or --file is required in non-interactive mode")
-		}
-		recipientType, err = prompt.Choice(opts.IOStreams.Err, opts.IOStreams.In, "Type (email, slack, pagerduty, msteams, msteams_workflow, webhook): ", recipientTypes)
-		if err != nil {
-			return err
-		}
+	recipientType, err := command.Resolve(opts.IOStreams, recipientType, command.Field{
+		Prompt:            "Type (email, slack, pagerduty, msteams, msteams_workflow, webhook): ",
+		Required:          true,
+		Choices:           recipientTypes,
+		NonInteractiveErr: fmt.Errorf("--type or --file is required in non-interactive mode"),
+	})
+	if err != nil {
+		return err
 	}
 
 	body, err := buildRecipientBody(opts, recipientType, target, channel, integrationKey, name, url)
@@ -117,108 +115,90 @@ func buildRecipientBody(opts *options.RootOptions, recipientType, target, channe
 
 	switch recipientType {
 	case "email":
-		if target == "" {
-			if !opts.IOStreams.CanPrompt() {
-				return nil, fmt.Errorf("--target is required for email recipients in non-interactive mode")
-			}
-			target, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Email address: ")
-			if err != nil {
-				return nil, err
-			}
-		}
-		if target == "" {
-			return nil, fmt.Errorf("email address is required")
+		target, err = command.Resolve(opts.IOStreams, target, command.Field{
+			Prompt:            "Email address: ",
+			Required:          true,
+			NonInteractiveErr: fmt.Errorf("--target is required for email recipients in non-interactive mode"),
+			EmptyErr:          fmt.Errorf("email address is required"),
+		})
+		if err != nil {
+			return nil, err
 		}
 		details["email_address"] = target
 
 	case "slack":
-		if channel == "" {
-			if !opts.IOStreams.CanPrompt() {
-				return nil, fmt.Errorf("--channel is required for slack recipients in non-interactive mode")
-			}
-			channel, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Slack channel: ")
-			if err != nil {
-				return nil, err
-			}
-		}
-		if channel == "" {
-			return nil, fmt.Errorf("slack channel is required")
+		channel, err = command.Resolve(opts.IOStreams, channel, command.Field{
+			Prompt:            "Slack channel: ",
+			Required:          true,
+			NonInteractiveErr: fmt.Errorf("--channel is required for slack recipients in non-interactive mode"),
+			EmptyErr:          fmt.Errorf("slack channel is required"),
+		})
+		if err != nil {
+			return nil, err
 		}
 		details["slack_channel"] = channel
 
 	case "pagerduty":
-		if integrationKey == "" {
-			if !opts.IOStreams.CanPrompt() {
-				return nil, fmt.Errorf("--integration-key is required for pagerduty recipients in non-interactive mode")
-			}
-			integrationKey, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Integration key: ")
-			if err != nil {
-				return nil, err
-			}
-		}
-		if integrationKey == "" {
-			return nil, fmt.Errorf("integration key is required")
+		integrationKey, err = command.Resolve(opts.IOStreams, integrationKey, command.Field{
+			Prompt:            "Integration key: ",
+			Required:          true,
+			NonInteractiveErr: fmt.Errorf("--integration-key is required for pagerduty recipients in non-interactive mode"),
+			EmptyErr:          fmt.Errorf("integration key is required"),
+		})
+		if err != nil {
+			return nil, err
 		}
 		details["pagerduty_integration_key"] = integrationKey
-		if name == "" && opts.IOStreams.CanPrompt() {
-			name, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Integration name (optional): ")
-			if err != nil {
-				return nil, err
-			}
+		name, err = command.Resolve(opts.IOStreams, name, command.Field{
+			Prompt: "Integration name (optional): ",
+		})
+		if err != nil {
+			return nil, err
 		}
 		if name != "" {
 			details["pagerduty_integration_name"] = name
 		}
 
 	case "msteams", "msteams_workflow":
-		if url == "" {
-			if !opts.IOStreams.CanPrompt() {
-				return nil, fmt.Errorf("--url is required for %s recipients in non-interactive mode", recipientType)
-			}
-			url, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Webhook URL: ")
-			if err != nil {
-				return nil, err
-			}
-		}
-		if url == "" {
-			return nil, fmt.Errorf("webhook URL is required")
+		url, err = command.Resolve(opts.IOStreams, url, command.Field{
+			Prompt:            "Webhook URL: ",
+			Required:          true,
+			NonInteractiveErr: fmt.Errorf("--url is required for %s recipients in non-interactive mode", recipientType),
+			EmptyErr:          fmt.Errorf("webhook URL is required"),
+		})
+		if err != nil {
+			return nil, err
 		}
 		details["webhook_url"] = url
-		if name == "" && opts.IOStreams.CanPrompt() {
-			name, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Webhook name (optional): ")
-			if err != nil {
-				return nil, err
-			}
+		name, err = command.Resolve(opts.IOStreams, name, command.Field{
+			Prompt: "Webhook name (optional): ",
+		})
+		if err != nil {
+			return nil, err
 		}
 		if name != "" {
 			details["webhook_name"] = name
 		}
 
 	case "webhook":
-		if url == "" {
-			if !opts.IOStreams.CanPrompt() {
-				return nil, fmt.Errorf("--url is required for webhook recipients in non-interactive mode")
-			}
-			url, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Webhook URL: ")
-			if err != nil {
-				return nil, err
-			}
-		}
-		if url == "" {
-			return nil, fmt.Errorf("webhook URL is required")
+		url, err = command.Resolve(opts.IOStreams, url, command.Field{
+			Prompt:            "Webhook URL: ",
+			Required:          true,
+			NonInteractiveErr: fmt.Errorf("--url is required for webhook recipients in non-interactive mode"),
+			EmptyErr:          fmt.Errorf("webhook URL is required"),
+		})
+		if err != nil {
+			return nil, err
 		}
 		details["webhook_url"] = url
-		if name == "" {
-			if !opts.IOStreams.CanPrompt() {
-				return nil, fmt.Errorf("--name is required for webhook recipients in non-interactive mode")
-			}
-			name, err = prompt.Line(opts.IOStreams.Err, opts.IOStreams.In, "Webhook name: ")
-			if err != nil {
-				return nil, err
-			}
-		}
-		if name == "" {
-			return nil, fmt.Errorf("webhook name is required")
+		name, err = command.Resolve(opts.IOStreams, name, command.Field{
+			Prompt:            "Webhook name: ",
+			Required:          true,
+			NonInteractiveErr: fmt.Errorf("--name is required for webhook recipients in non-interactive mode"),
+			EmptyErr:          fmt.Errorf("webhook name is required"),
+		})
+		if err != nil {
+			return nil, err
 		}
 		details["webhook_name"] = name
 

--- a/internal/iostreams/iostreams.go
+++ b/internal/iostreams/iostreams.go
@@ -58,6 +58,16 @@ func Test(tb testing.TB) *TestStreams {
 	}
 }
 
+// TestPromptable returns test streams whose CanPrompt reports true, so tests
+// can exercise interactive prompt paths. Write prompt answers to InBuf.
+func TestPromptable(tb testing.TB) *TestStreams {
+	tb.Helper()
+	ts := Test(tb)
+	ts.stdinIsTTY = true
+	ts.stdoutIsTTY = true
+	return ts
+}
+
 type testLogWriter struct {
 	tb testing.TB
 }


### PR DESCRIPTION
Adds a `command.Resolve(ios, value, Field)` helper and routes every create command's missing-input handling through it.

Each create command resolved a missing required input with the same hand-written branch: return a non-interactive error when the flag is unset and prompting isn't possible, otherwise prompt and re-validate. That branch was copied across roughly eleven commands (`recipient create` alone ran it six times). This collapses it into one module: callers declare a `Field` (prompt text, required/optional, `Choices` to switch to `prompt.Choice`, the exact error to return, and which stream to prompt on) and `Resolve` owns the control flow.

I kept the caller-supplied error values rather than deriving messages inside `Resolve`. The existing messages are genuinely per-site (`--type or --file is required` vs `--name is required`, `email address is required` vs `webhook name is required`) and the flag name isn't available to the helper, so deriving them would mean a worse interface and still couldn't reproduce the existing wording. Behavior is preserved exactly at every converted site: prompt strings, error messages, target stream (`Err`/`Out`), required-vs-optional semantics, and `Choice`-vs-`Line`.

## Changes

- Add `cmd/command/resolve.go`: `Resolve` plus the `Field` and `Stream` types.
- Convert the create commands for `board`, `board view`, `recipient`, `column`, `column calculated`, `key`, `environment`, `marker`, `marker setting`, `query annotation`, and `dataset`.
- Add `iostreams.TestPromptable` so tests can drive the interactive prompt path.

## Testing

- Table-driven tests for `Resolve` cover value-present, non-interactive required error, interactive `Line`/`Choice` success, prompted-blank required error, optional-empty, `Stream` selection, and the prompt read-error path.
- Existing per-command tests pass unchanged, which is what pins the behavioral parity.

First of a five-PR stack from an architecture review focused on deepening shallow modules. The rest stack on top.
