### PR TITLE
refactor(command): share AnyChanged and drop parallel flag structs

### DIFF
--- a/cmd/board/update.go
+++ b/cmd/board/update.go
@@ -64,7 +64,7 @@ func runBoardUpdate(cmd *cobra.Command, opts *options.RootOptions, boardID, file
 		return updateFromFile(ctx, client, opts, boardID, file, replace)
 	}
 
-	if !cmd.Flags().Changed("name") && !cmd.Flags().Changed("description") {
+	if !command.AnyChanged(cmd, "name", "description") {
 		return fmt.Errorf("--file, --name, or --description is required")
 	}
 

--- a/cmd/board/view_update.go
+++ b/cmd/board/view_update.go
@@ -56,7 +56,7 @@ func runViewUpdate(cmd *cobra.Command, opts *options.RootOptions, boardID, viewI
 		return updateViewFromFile(ctx, client, opts, boardID, viewID, file)
 	}
 
-	if !cmd.Flags().Changed("name") && !cmd.Flags().Changed("filter") {
+	if !command.AnyChanged(cmd, "name", "filter") {
 		return fmt.Errorf("--file, --name, or --filter is required")
 	}
 

--- a/cmd/column/calculated_update.go
+++ b/cmd/column/calculated_update.go
@@ -2,7 +2,6 @@ package column
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 
@@ -25,25 +24,11 @@ func NewCalculatedUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.C
 		Short: "Update a calculated column",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			hasFile := cmd.Flags().Changed("file")
-			hasAlias := cmd.Flags().Changed("alias")
-			hasExpr := cmd.Flags().Changed("expression")
-			hasDesc := cmd.Flags().Changed("description")
-
-			if !hasFile && !hasAlias && !hasExpr && !hasDesc {
+			if !command.AnyChanged(cmd, "file", "alias", "expression", "description") {
 				return fmt.Errorf("provide --file or at least one of --alias, --expression, --description")
 			}
 
-			return runCalculatedUpdate(cmd.Context(), opts, *dataset, args[0], calculatedUpdateFlags{
-				file:        file,
-				hasFile:     hasFile,
-				alias:       alias,
-				hasAlias:    hasAlias,
-				expression:  expression,
-				hasExpr:     hasExpr,
-				description: description,
-				hasDesc:     hasDesc,
-			})
+			return runCalculatedUpdate(cmd, opts, *dataset, args[0], file, alias, expression, description)
 		},
 	}
 
@@ -59,27 +44,18 @@ func NewCalculatedUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.C
 	return cmd
 }
 
-type calculatedUpdateFlags struct {
-	file        string
-	hasFile     bool
-	alias       string
-	hasAlias    bool
-	expression  string
-	hasExpr     bool
-	description string
-	hasDesc     bool
-}
-
-func runCalculatedUpdate(ctx context.Context, opts *options.RootOptions, dataset, id string, flags calculatedUpdateFlags) error {
+func runCalculatedUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, id, file, alias, expression, description string) error {
 	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}
 
+	ctx := cmd.Context()
+
 	var body api.CalculatedField
 
-	if flags.hasFile {
-		data, err := command.ReadDefinitionFile(opts.IOStreams, flags.file)
+	if cmd.Flags().Changed("file") {
+		data, err := command.ReadDefinitionFile(opts.IOStreams, file)
 		if err != nil {
 			return err
 		}
@@ -97,14 +73,14 @@ func runCalculatedUpdate(ctx context.Context, opts *options.RootOptions, dataset
 		}
 		body = *current
 
-		if flags.hasAlias {
-			body.Alias = flags.alias
+		if cmd.Flags().Changed("alias") {
+			body.Alias = alias
 		}
-		if flags.hasExpr {
-			body.Expression = flags.expression
+		if cmd.Flags().Changed("expression") {
+			body.Expression = expression
 		}
-		if flags.hasDesc {
-			body.Description = &flags.description
+		if cmd.Flags().Changed("description") {
+			body.Description = &description
 		}
 	}
 

--- a/cmd/column/update.go
+++ b/cmd/column/update.go
@@ -2,7 +2,6 @@ package column
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 
@@ -24,22 +23,11 @@ func NewUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 		Short: "Update a column",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			hasFile := cmd.Flags().Changed("file")
-			hasDesc := cmd.Flags().Changed("description")
-			hasHidden := cmd.Flags().Changed("hidden")
-
-			if !hasFile && !hasDesc && !hasHidden {
+			if !command.AnyChanged(cmd, "file", "description", "hidden") {
 				return fmt.Errorf("provide --file or at least one of --description, --hidden")
 			}
 
-			return runColumnUpdate(cmd.Context(), opts, *dataset, args[0], columnUpdateFlags{
-				file:        file,
-				hasFile:     hasFile,
-				description: description,
-				hasDesc:     hasDesc,
-				hidden:      hidden,
-				hasHidden:   hasHidden,
-			})
+			return runColumnUpdate(cmd, opts, *dataset, args[0], file, description, hidden)
 		},
 	}
 
@@ -53,25 +41,18 @@ func NewUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	return cmd
 }
 
-type columnUpdateFlags struct {
-	file        string
-	hasFile     bool
-	description string
-	hasDesc     bool
-	hidden      bool
-	hasHidden   bool
-}
-
-func runColumnUpdate(ctx context.Context, opts *options.RootOptions, dataset, columnID string, flags columnUpdateFlags) error {
+func runColumnUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, columnID, file, description string, hidden bool) error {
 	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}
 
+	ctx := cmd.Context()
+
 	var col api.Column
 
-	if flags.hasFile {
-		data, err := command.ReadDefinitionFile(opts.IOStreams, flags.file)
+	if cmd.Flags().Changed("file") {
+		data, err := command.ReadDefinitionFile(opts.IOStreams, file)
 		if err != nil {
 			return err
 		}
@@ -89,11 +70,11 @@ func runColumnUpdate(ctx context.Context, opts *options.RootOptions, dataset, co
 		}
 		col = *current
 
-		if flags.hasDesc {
-			col.Description = &flags.description
+		if cmd.Flags().Changed("description") {
+			col.Description = &description
 		}
-		if flags.hasHidden {
-			col.Hidden = &flags.hidden
+		if cmd.Flags().Changed("hidden") {
+			col.Hidden = &hidden
 		}
 	}
 

--- a/cmd/command/flags.go
+++ b/cmd/command/flags.go
@@ -1,0 +1,16 @@
+package command
+
+import "github.com/spf13/cobra"
+
+// AnyChanged reports whether the user set any of the named flags on cmd. It
+// backs the "provide --file or at least one of ..." guards that several update
+// commands share, reading cobra's own change tracking instead of a parallel
+// set of has-X booleans.
+func AnyChanged(cmd *cobra.Command, names ...string) bool {
+	for _, n := range names {
+		if cmd.Flags().Changed(n) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/command/flags_test.go
+++ b/cmd/command/flags_test.go
@@ -1,0 +1,66 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestAnyChanged(t *testing.T) {
+	tests := []struct {
+		name  string
+		args  []string
+		names []string
+		want  bool
+	}{
+		{
+			name:  "no flags changed",
+			args:  nil,
+			names: []string{"name", "description"},
+			want:  false,
+		},
+		{
+			name:  "one named flag changed",
+			args:  []string{"--name", "foo"},
+			names: []string{"name", "description"},
+			want:  true,
+		},
+		{
+			name:  "another named flag changed",
+			args:  []string{"--description", "bar"},
+			names: []string{"name", "description"},
+			want:  true,
+		},
+		{
+			name:  "changed flag not in names",
+			args:  []string{"--other", "baz"},
+			names: []string{"name", "description"},
+			want:  false,
+		},
+		{
+			name:  "no names given",
+			args:  []string{"--name", "foo"},
+			names: nil,
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "test", RunE: func(*cobra.Command, []string) error { return nil }}
+			var name, description, other string
+			cmd.Flags().StringVar(&name, "name", "", "")
+			cmd.Flags().StringVar(&description, "description", "", "")
+			cmd.Flags().StringVar(&other, "other", "", "")
+
+			cmd.SetArgs(tt.args)
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+
+			if got := AnyChanged(cmd, tt.names...); got != tt.want {
+				t.Errorf("AnyChanged(%v) = %v, want %v", tt.names, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/environment/update.go
+++ b/cmd/environment/update.go
@@ -40,7 +40,7 @@ func NewUpdateCmd(opts *options.RootOptions, team *string) *cobra.Command {
 }
 
 func runEnvironmentUpdate(cmd *cobra.Command, opts *options.RootOptions, client *api.ClientWithResponses, team, envID, desc, color string, deleteProtected bool) error {
-	if !cmd.Flags().Changed("description") && !cmd.Flags().Changed("color") && !cmd.Flags().Changed("delete-protected") {
+	if !command.AnyChanged(cmd, "description", "color", "delete-protected") {
 		return fmt.Errorf("--description, --color, or --delete-protected is required")
 	}
 

--- a/cmd/key/update.go
+++ b/cmd/key/update.go
@@ -73,7 +73,7 @@ func runKeyUpdateFromFile(ctx context.Context, opts *options.RootOptions, client
 }
 
 func runKeyUpdateFromFlags(cmd *cobra.Command, opts *options.RootOptions, client *api.ClientWithResponses, team, id, name string) error {
-	if !cmd.Flags().Changed("name") && !cmd.Flags().Changed("disabled") && !cmd.Flags().Changed("enabled") {
+	if !command.AnyChanged(cmd, "name", "disabled", "enabled") {
 		return fmt.Errorf("--file, --name, --disabled, or --enabled is required")
 	}
 

--- a/cmd/query/annotation_update.go
+++ b/cmd/query/annotation_update.go
@@ -56,7 +56,7 @@ func runAnnotationUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset,
 		return updateAnnotationFromFile(ctx, client, opts, dataset, annotationID, file)
 	}
 
-	if !cmd.Flags().Changed("name") && !cmd.Flags().Changed("description") {
+	if !command.AnyChanged(cmd, "name", "description") {
 		return fmt.Errorf("--file, --name, or --description is required")
 	}
 

--- a/cmd/recipient/update.go
+++ b/cmd/recipient/update.go
@@ -60,7 +60,7 @@ func runUpdate(cmd *cobra.Command, opts *options.RootOptions, recipientID, file,
 		if err != nil {
 			return err
 		}
-	} else if hasAnyFlag(cmd, "type", "target", "channel", "integration-key", "name", "url") {
+	} else if command.AnyChanged(cmd, "type", "target", "channel", "integration-key", "name", "url") {
 		resp, err := client.GetRecipientWithResponse(ctx, recipientID)
 		if err != nil {
 			return fmt.Errorf("getting recipient: %w", err)
@@ -99,15 +99,6 @@ func runUpdate(cmd *cobra.Command, opts *options.RootOptions, recipientID, file,
 	}
 
 	return writeRecipientDetail(opts, detail)
-}
-
-func hasAnyFlag(cmd *cobra.Command, names ...string) bool {
-	for _, n := range names {
-		if cmd.Flags().Changed(n) {
-			return true
-		}
-	}
-	return false
 }
 
 func applyRecipientFlags(cmd *cobra.Command, current map[string]any, recipientType, target, channel, integrationKey, name, url string) {

--- a/cmd/slo/burn_alert_update.go
+++ b/cmd/slo/burn_alert_update.go
@@ -60,7 +60,7 @@ func runBurnAlertUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, 
 		if err != nil {
 			return err
 		}
-	} else if hasAnyFlag(cmd, burnAlertUpdateFlags...) {
+	} else if command.AnyChanged(cmd, burnAlertUpdateFlags...) {
 		resp, err := client.GetBurnAlertWithResponse(ctx, dataset, burnAlertID)
 		if err != nil {
 			return fmt.Errorf("getting burn alert: %w", err)
@@ -99,15 +99,6 @@ func runBurnAlertUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, 
 	}
 
 	return writeBurnAlertDetail(opts, detail)
-}
-
-func hasAnyFlag(cmd *cobra.Command, names ...string) bool {
-	for _, n := range names {
-		if cmd.Flags().Changed(n) {
-			return true
-		}
-	}
-	return false
 }
 
 func applyBurnAlertFlags(cmd *cobra.Command, current map[string]any, exhaustionMinutes, budgetRateWindow, budgetRateThreshold int, recipients []string, description string) {

--- a/cmd/slo/update.go
+++ b/cmd/slo/update.go
@@ -56,7 +56,7 @@ func runSLOUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, sloID,
 		return updateFromFile(ctx, client, opts, dataset, sloID, file)
 	}
 
-	if !cmd.Flags().Changed("name") && !cmd.Flags().Changed("description") && !cmd.Flags().Changed("target") && !cmd.Flags().Changed("time-period") {
+	if !command.AnyChanged(cmd, "name", "description", "target", "time-period") {
 		return fmt.Errorf("--file, --name, --description, --target, or --time-period is required")
 	}
 

--- a/cmd/trigger/create.go
+++ b/cmd/trigger/create.go
@@ -33,17 +33,7 @@ func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 				return fmt.Errorf("--file is required")
 			}
 
-			return runCreate(cmd, opts, *dataset, createFlags{
-				file:        file,
-				name:        name,
-				hasName:     cmd.Flags().Changed("name"),
-				description: description,
-				hasDesc:     cmd.Flags().Changed("description"),
-				disabled:    disabled,
-				hasDisabled: cmd.Flags().Changed("disabled"),
-				enabled:     enabled,
-				hasEnabled:  cmd.Flags().Changed("enabled"),
-			})
+			return runCreate(cmd, opts, *dataset, file, name, description, disabled)
 		},
 	}
 
@@ -58,40 +48,28 @@ func NewCreateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	return cmd
 }
 
-type createFlags struct {
-	file        string
-	name        string
-	hasName     bool
-	description string
-	hasDesc     bool
-	disabled    bool
-	hasDisabled bool
-	enabled     bool
-	hasEnabled  bool
-}
-
-func runCreate(cmd *cobra.Command, opts *options.RootOptions, dataset string, flags createFlags) error {
+func runCreate(cmd *cobra.Command, opts *options.RootOptions, dataset, file, name, description string, disabled bool) error {
 	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}
 
-	data, err := command.ReadDefinitionFile(opts.IOStreams, flags.file)
+	data, err := command.ReadDefinitionFile(opts.IOStreams, file)
 	if err != nil {
 		return err
 	}
 
 	overrides := map[string]any{}
-	if flags.hasName {
-		overrides["name"] = flags.name
+	if cmd.Flags().Changed("name") {
+		overrides["name"] = name
 	}
-	if flags.hasDesc {
-		overrides["description"] = flags.description
+	if cmd.Flags().Changed("description") {
+		overrides["description"] = description
 	}
-	if flags.hasDisabled {
-		overrides["disabled"] = flags.disabled
+	if cmd.Flags().Changed("disabled") {
+		overrides["disabled"] = disabled
 	}
-	if flags.hasEnabled {
+	if cmd.Flags().Changed("enabled") {
 		overrides["disabled"] = false
 	}
 

--- a/cmd/trigger/update.go
+++ b/cmd/trigger/update.go
@@ -2,7 +2,6 @@ package trigger
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 
@@ -31,28 +30,11 @@ func NewUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
   honeycomb trigger update abc123 --dataset my-dataset --file trigger.json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			hasFile := cmd.Flags().Changed("file")
-			hasName := cmd.Flags().Changed("name")
-			hasDesc := cmd.Flags().Changed("description")
-			hasDisabled := cmd.Flags().Changed("disabled")
-			hasEnabled := cmd.Flags().Changed("enabled")
-
-			if !hasFile && !hasName && !hasDesc && !hasDisabled && !hasEnabled {
+			if !command.AnyChanged(cmd, "file", "name", "description", "disabled", "enabled") {
 				return fmt.Errorf("provide --file or at least one of --name, --description, --disabled, --enabled")
 			}
 
-			return runUpdate(cmd.Context(), opts, *dataset, args[0], updateFlags{
-				file:        file,
-				hasFile:     hasFile,
-				name:        name,
-				hasName:     hasName,
-				description: description,
-				hasDesc:     hasDesc,
-				disabled:    disabled,
-				hasDisabled: hasDisabled,
-				enabled:     enabled,
-				hasEnabled:  hasEnabled,
-			})
+			return runUpdate(cmd, opts, *dataset, args[0], file, name, description, disabled)
 		},
 	}
 
@@ -71,29 +53,18 @@ func NewUpdateCmd(opts *options.RootOptions, dataset *string) *cobra.Command {
 	return cmd
 }
 
-type updateFlags struct {
-	file        string
-	hasFile     bool
-	name        string
-	hasName     bool
-	description string
-	hasDesc     bool
-	disabled    bool
-	hasDisabled bool
-	enabled     bool
-	hasEnabled  bool
-}
-
-func runUpdate(ctx context.Context, opts *options.RootOptions, dataset, triggerID string, flags updateFlags) error {
+func runUpdate(cmd *cobra.Command, opts *options.RootOptions, dataset, triggerID, file, name, description string, disabled bool) error {
 	client, err := opts.ClientFor(nil, options.AuthConfig)
 	if err != nil {
 		return err
 	}
 
+	ctx := cmd.Context()
+
 	var body api.TriggerResponse
 
-	if flags.hasFile {
-		data, err := command.ReadDefinitionFile(opts.IOStreams, flags.file)
+	if cmd.Flags().Changed("file") {
+		data, err := command.ReadDefinitionFile(opts.IOStreams, file)
 		if err != nil {
 			return err
 		}
@@ -111,16 +82,16 @@ func runUpdate(ctx context.Context, opts *options.RootOptions, dataset, triggerI
 		}
 		body = *current
 
-		if flags.hasName {
-			body.Name = &flags.name
+		if cmd.Flags().Changed("name") {
+			body.Name = &name
 		}
-		if flags.hasDesc {
-			body.Description = &flags.description
+		if cmd.Flags().Changed("description") {
+			body.Description = &description
 		}
-		if flags.hasDisabled {
-			body.Disabled = &flags.disabled
+		if cmd.Flags().Changed("disabled") {
+			body.Disabled = &disabled
 		}
-		if flags.hasEnabled {
+		if cmd.Flags().Changed("enabled") {
 			v := false
 			body.Disabled = &v
 		}


### PR DESCRIPTION
Routes the "did the user set any of these flags" question through one shared `command.AnyChanged(cmd, names...)` helper and deletes the parallel `hasX` flag structs that several create/update commands hand-built.

cobra already tracks which flags changed. Yet `trigger create`/`update`, `column update`, and `calculated column update` each re-encoded that into a struct of `value` + `hasX bool` fields, threaded it into a run function, then re-checked each `hasX` to apply the field. This drops those four structs (`createFlags`, `updateFlags`, `columnUpdateFlags`, `calculatedUpdateFlags`) and applies each field inline with `cmd.Flags().Changed(...)` at the point of use, the same idiom `recipient`/`board` update already used. The repeated `!Changed(a) && !Changed(b)` require-one guards and two duplicate local `hasAnyFlag` helpers (recipient, slo burn-alert) collapse into `command.AnyChanged`, now with 11 callers.

I kept `trigger create`'s overrides map inline rather than adding a builder helper. Only that one command uses the map path, so a dedicated helper would be a seam nothing else crosses. Request bodies and every error message are unchanged. The `trigger --enabled`/`--disabled` inversion, file-vs-flags branching, and GET-then-patch logic are preserved.

## Changes

- Add `cmd/command/flags.go`: `AnyChanged`.
- Delete `createFlags`, `updateFlags`, `columnUpdateFlags`, `calculatedUpdateFlags`; apply fields inline via `Changed`.
- Replace require-one guards and the local `hasAnyFlag` helpers with `command.AnyChanged` across `board`, `board view`, `column`, `calculated column`, `environment`, `key`, `query annotation`, `recipient`, `slo`, `slo burn-alert`, and `trigger` update commands.

## Testing

- Table-driven test for `AnyChanged` (no flags, one of many changed, only unrelated changed, empty names).
- Existing create/update command tests pass unchanged, pinning request-body parity.

Second of a five-PR stack. Builds on #242 (merged), so it targets `main`.
