### PR TITLE
refactor(output): render non-primitive detail fields via a Formatter seam

### DIFF
--- a/cmd/board/board.go
+++ b/cmd/board/board.go
@@ -46,33 +46,41 @@ type boardListItem struct {
 }
 
 type boardDetail struct {
-	ID            string          `json:"id" detail:"ID"`
-	Name          string          `json:"name" detail:"Name"`
-	Description   string          `json:"description,omitempty" detail:"Description"`
-	Type          string          `json:"type" detail:"Type"`
-	URL           string          `json:"url,omitempty" detail:"URL"`
-	PresetFilters json.RawMessage `json:"preset_filters,omitempty"`
-	Panels        json.RawMessage `json:"panels,omitempty"`
+	ID            string        `json:"id" detail:"ID"`
+	Name          string        `json:"name" detail:"Name"`
+	Description   string        `json:"description,omitempty" detail:"Description"`
+	Type          string        `json:"type" detail:"Type"`
+	URL           string        `json:"url,omitempty" detail:"URL"`
+	PresetFilters presetFilters `json:"preset_filters,omitempty" detail:"Preset Filters"`
+	Panels        panels        `json:"panels,omitempty" detail:"Panels"`
 }
 
 func writeBoardDetail(opts *options.RootOptions, detail boardDetail) error {
-	fields := output.FieldsFromTags(detail)
-	fields = append(fields,
-		output.Field{Label: "Panels", Value: formatPanels(detail.Panels)},
-		output.Field{Label: "Preset Filters", Value: string(detail.PresetFilters)},
-	)
-	return opts.OutputWriter().WriteFields(detail, fields)
+	return opts.OutputWriter().WriteFields(detail, output.FieldsFromTags(detail))
 }
 
-// formatPanels summarizes a board's panels as one line per panel, pairing each
+// panels wraps a board's raw panels JSON. It preserves RawMessage's JSON
+// passthrough via MarshalJSON while carrying its own table rendering.
+type panels json.RawMessage
+
+func (p panels) MarshalJSON() ([]byte, error) {
+	return json.RawMessage(p).MarshalJSON()
+}
+
+func (p *panels) UnmarshalJSON(data []byte) error {
+	return (*json.RawMessage)(p).UnmarshalJSON(data)
+}
+
+// FormatField summarizes a board's panels as one line per panel, pairing each
 // panel's type with the query, SLO, or text it references. An empty raw message
 // (no panels) renders as an em-dash.
-func formatPanels(raw json.RawMessage) string {
+func (p panels) FormatField() string {
+	raw := json.RawMessage(p)
 	if len(raw) == 0 {
 		return "—"
 	}
 
-	var panels []struct {
+	var parsed []struct {
 		Type       string `json:"type"`
 		QueryPanel *struct {
 			QueryId string `json:"query_id"`
@@ -84,15 +92,15 @@ func formatPanels(raw json.RawMessage) string {
 			Content string `json:"content"`
 		} `json:"text_panel"`
 	}
-	if err := json.Unmarshal(raw, &panels); err != nil {
+	if err := json.Unmarshal(raw, &parsed); err != nil {
 		return string(raw)
 	}
-	if len(panels) == 0 {
+	if len(parsed) == 0 {
 		return "—"
 	}
 
-	lines := make([]string, len(panels))
-	for i, p := range panels {
+	lines := make([]string, len(parsed))
+	for i, p := range parsed {
 		switch {
 		case p.QueryPanel != nil:
 			lines[i] = fmt.Sprintf("%s (query %s)", p.Type, p.QueryPanel.QueryId)
@@ -103,6 +111,23 @@ func formatPanels(raw json.RawMessage) string {
 		}
 	}
 	return strings.Join(lines, "\n")
+}
+
+// presetFilters wraps a board's raw preset_filters JSON. It preserves
+// RawMessage's JSON passthrough while rendering as its raw string in tables,
+// matching the previous string(rawMessage) behavior.
+type presetFilters json.RawMessage
+
+func (p presetFilters) MarshalJSON() ([]byte, error) {
+	return json.RawMessage(p).MarshalJSON()
+}
+
+func (p *presetFilters) UnmarshalJSON(data []byte) error {
+	return (*json.RawMessage)(p).UnmarshalJSON(data)
+}
+
+func (p presetFilters) FormatField() string {
+	return string(p)
 }
 
 func boardToDetail(b api.Board) boardDetail {
@@ -117,11 +142,11 @@ func boardToDetail(b api.Board) boardDetail {
 	}
 	if b.PresetFilters != nil {
 		raw, _ := json.Marshal(b.PresetFilters)
-		d.PresetFilters = raw
+		d.PresetFilters = presetFilters(raw)
 	}
 	if b.Panels != nil {
 		raw, _ := json.Marshal(b.Panels)
-		d.Panels = raw
+		d.Panels = panels(raw)
 	}
 	return d
 }

--- a/cmd/board/board.go
+++ b/cmd/board/board.go
@@ -46,17 +46,19 @@ type boardListItem struct {
 }
 
 type boardDetail struct {
-	ID            string        `json:"id" detail:"ID"`
-	Name          string        `json:"name" detail:"Name"`
-	Description   string        `json:"description,omitempty" detail:"Description"`
-	Type          string        `json:"type" detail:"Type"`
-	URL           string        `json:"url,omitempty" detail:"URL"`
-	PresetFilters presetFilters `json:"preset_filters,omitempty" detail:"Preset Filters"`
-	Panels        panels        `json:"panels,omitempty" detail:"Panels"`
+	ID            string          `json:"id" detail:"ID"`
+	Name          string          `json:"name" detail:"Name"`
+	Description   string          `json:"description,omitempty" detail:"Description"`
+	Type          string          `json:"type" detail:"Type"`
+	URL           string          `json:"url,omitempty" detail:"URL"`
+	PresetFilters json.RawMessage `json:"preset_filters,omitempty"`
+	Panels        panels          `json:"panels,omitempty" detail:"Panels"`
 }
 
 func writeBoardDetail(opts *options.RootOptions, detail boardDetail) error {
-	return opts.OutputWriter().WriteFields(detail, output.FieldsFromTags(detail))
+	fields := output.FieldsFromTags(detail)
+	fields = append(fields, output.Field{Label: "Preset Filters", Value: string(detail.PresetFilters)})
+	return opts.OutputWriter().WriteFields(detail, fields)
 }
 
 // panels wraps a board's raw panels JSON. It preserves RawMessage's JSON
@@ -113,23 +115,6 @@ func (p panels) FormatField() string {
 	return strings.Join(lines, "\n")
 }
 
-// presetFilters wraps a board's raw preset_filters JSON. It preserves
-// RawMessage's JSON passthrough while rendering as its raw string in tables,
-// matching the previous string(rawMessage) behavior.
-type presetFilters json.RawMessage
-
-func (p presetFilters) MarshalJSON() ([]byte, error) {
-	return json.RawMessage(p).MarshalJSON()
-}
-
-func (p *presetFilters) UnmarshalJSON(data []byte) error {
-	return (*json.RawMessage)(p).UnmarshalJSON(data)
-}
-
-func (p presetFilters) FormatField() string {
-	return string(p)
-}
-
 func boardToDetail(b api.Board) boardDetail {
 	d := boardDetail{
 		ID:          deref.String(b.Id),
@@ -142,7 +127,7 @@ func boardToDetail(b api.Board) boardDetail {
 	}
 	if b.PresetFilters != nil {
 		raw, _ := json.Marshal(b.PresetFilters)
-		d.PresetFilters = presetFilters(raw)
+		d.PresetFilters = raw
 	}
 	if b.Panels != nil {
 		raw, _ := json.Marshal(b.Panels)

--- a/cmd/board/view.go
+++ b/cmd/board/view.go
@@ -19,9 +19,9 @@ type viewItem struct {
 }
 
 type viewDetail struct {
-	ID      string          `json:"id" detail:"ID"`
-	Name    string          `json:"name" detail:"Name"`
-	Filters json.RawMessage `json:"filters,omitempty"`
+	ID      string  `json:"id" detail:"ID"`
+	Name    string  `json:"name" detail:"Name"`
+	Filters filters `json:"filters,omitempty" detail:"Filters"`
 }
 
 var viewListTable = output.TableFromTags[viewItem]()
@@ -40,42 +40,53 @@ func viewResponseToDetail(v api.BoardViewResponse) viewDetail {
 	}
 	if v.Filters != nil {
 		raw, _ := json.Marshal(v.Filters)
-		d.Filters = raw
+		d.Filters = filters(raw)
 	}
 	return d
 }
 
 func writeViewDetail(opts *options.RootOptions, detail viewDetail) error {
-	fields := output.FieldsFromTags(detail)
-	fields = append(fields, output.Field{Label: "Filters", Value: formatFilters(detail.Filters)})
-	return opts.OutputWriter().WriteFields(detail, fields)
+	return opts.OutputWriter().WriteFields(detail, output.FieldsFromTags(detail))
 }
 
-// formatFilters renders a view's filters as one "column operation value" line
+// filters wraps a view's raw filters JSON. It preserves RawMessage's JSON
+// passthrough via MarshalJSON while carrying its own table rendering.
+type filters json.RawMessage
+
+func (f filters) MarshalJSON() ([]byte, error) {
+	return json.RawMessage(f).MarshalJSON()
+}
+
+func (f *filters) UnmarshalJSON(data []byte) error {
+	return (*json.RawMessage)(f).UnmarshalJSON(data)
+}
+
+// FormatField renders a view's filters as one "column operation value" line
 // per filter. An empty raw message (no filters) renders as an em-dash.
-func formatFilters(raw json.RawMessage) string {
+func (f filters) FormatField() string {
+	raw := json.RawMessage(f)
 	if len(raw) == 0 {
 		return "—"
 	}
 
-	var filters []struct {
+	var parsed []struct {
 		Column    string `json:"column"`
 		Operation string `json:"operation"`
 		Value     any    `json:"value,omitempty"`
 	}
-	if err := json.Unmarshal(raw, &filters); err != nil {
+	if err := json.Unmarshal(raw, &parsed); err != nil {
 		return string(raw)
 	}
-	if len(filters) == 0 {
+	if len(parsed) == 0 {
 		return "—"
 	}
 
-	lines := make([]string, len(filters))
-	for i, f := range filters {
-		if f.Value != nil {
-			lines[i] = fmt.Sprintf("%s %s %v", f.Column, f.Operation, f.Value)
+	lines := make([]string, len(parsed))
+	for i, p := range parsed {
+		if p.Value != nil {
+			lines[i] = fmt.Sprintf("%s %s %v", p.Column, p.Operation, p.Value)
 		} else {
-			lines[i] = fmt.Sprintf("%s %s", f.Column, f.Operation)
+			lines[i] = fmt.Sprintf("%s %s", p.Column, p.Operation)
 		}
 	}
 	return strings.Join(lines, "\n")

--- a/cmd/options/options.go
+++ b/cmd/options/options.go
@@ -79,14 +79,27 @@ func (o *RootOptions) inferTeam() (string, bool) {
 	return "", false
 }
 
-func (o *RootOptions) ResolveFormat() string {
+// outputKind selects how an unset --format flag resolves. Detail output follows
+// the terminal: a table when interactive, JSON when piped, so scripts and agents
+// get structured output by default. List output defaults to a table in both
+// modes, since a collection reads best as a table.
+type outputKind int
+
+const (
+	detailOutput outputKind = iota
+	listOutput
+)
+
+// resolveFormat picks the concrete output format for kind. An explicit --format
+// flag always wins; otherwise the per-kind default applies.
+func (o *RootOptions) resolveFormat(kind outputKind) string {
 	if o.Format != "" {
 		return o.Format
 	}
-	if o.IOStreams.IsStdoutTTY() {
-		return output.FormatTable
+	if kind == detailOutput && !o.IOStreams.IsStdoutTTY() {
+		return output.FormatJSON
 	}
-	return output.FormatJSON
+	return output.FormatTable
 }
 
 func (o *RootOptions) RequireKey(kt config.KeyType) (string, error) {
@@ -128,15 +141,11 @@ func (o *RootOptions) Client(kt config.KeyType) (*api.ClientWithResponses, error
 }
 
 func (o *RootOptions) OutputWriter() *output.Writer {
-	return output.New(o.IOStreams.Out, o.ResolveFormat())
+	return output.New(o.IOStreams.Out, o.resolveFormat(detailOutput))
 }
 
 func (o *RootOptions) OutputWriterList() *output.Writer {
-	format := o.Format
-	if format == "" {
-		format = output.FormatTable
-	}
-	return output.New(o.IOStreams.Out, format)
+	return output.New(o.IOStreams.Out, o.resolveFormat(listOutput))
 }
 
 func (o *RootOptions) ResolveMCPUrl() string {

--- a/cmd/options/options_test.go
+++ b/cmd/options/options_test.go
@@ -1,0 +1,70 @@
+package options
+
+import (
+	"testing"
+
+	"github.com/bendrucker/honeycomb-cli/internal/iostreams"
+	"github.com/bendrucker/honeycomb-cli/internal/output"
+)
+
+func TestResolveFormat(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		format string
+		tty    bool
+		kind   outputKind
+		want   string
+	}{
+		{
+			name: "detail follows tty to a table",
+			tty:  true,
+			kind: detailOutput,
+			want: output.FormatTable,
+		},
+		{
+			name: "detail defaults to json when piped",
+			tty:  false,
+			kind: detailOutput,
+			want: output.FormatJSON,
+		},
+		{
+			name: "list defaults to a table on a tty",
+			tty:  true,
+			kind: listOutput,
+			want: output.FormatTable,
+		},
+		{
+			name: "list defaults to a table when piped",
+			tty:  false,
+			kind: listOutput,
+			want: output.FormatTable,
+		},
+		{
+			name:   "explicit format wins for detail",
+			format: output.FormatJSON,
+			tty:    true,
+			kind:   detailOutput,
+			want:   output.FormatJSON,
+		},
+		{
+			name:   "explicit format wins for list",
+			format: output.FormatJSON,
+			tty:    false,
+			kind:   listOutput,
+			want:   output.FormatJSON,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var ts *iostreams.TestStreams
+			if tc.tty {
+				ts = iostreams.TestPromptable(t)
+			} else {
+				ts = iostreams.Test(t)
+			}
+			o := &RootOptions{IOStreams: ts.IOStreams, Format: tc.format}
+			if got := o.resolveFormat(tc.kind); got != tc.want {
+				t.Errorf("resolveFormat = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/slo/format.go
+++ b/cmd/slo/format.go
@@ -10,13 +10,21 @@ import (
 	"github.com/bendrucker/honeycomb-cli/internal/output"
 )
 
-func formatTarget(targetPerMillion int) string {
-	pct := float64(targetPerMillion) / 10000.0
+// targetPerMillion is an SLO target expressed in parts per million. It marshals
+// as its underlying integer while rendering as a percentage in detail tables.
+type targetPerMillion int
+
+func (t targetPerMillion) FormatField() string {
+	pct := float64(t) / 10000.0
 	return fmt.Sprintf("%g%%", pct)
 }
 
-func formatTimePeriod(days int) string {
-	return fmt.Sprintf("%dd", days)
+// timePeriodDays is an SLO time period in days. It marshals as its underlying
+// integer while rendering with a trailing "d" in detail tables.
+type timePeriodDays int
+
+func (d timePeriodDays) FormatField() string {
+	return fmt.Sprintf("%dd", d)
 }
 
 type sloItem struct {
@@ -29,16 +37,16 @@ type sloItem struct {
 }
 
 type sloDetail struct {
-	ID               string   `json:"id" detail:"ID"`
-	Name             string   `json:"name" detail:"Name"`
-	Description      string   `json:"description,omitempty" detail:"Description"`
-	TargetPerMillion int      `json:"target_per_million"`
-	TimePeriodDays   int      `json:"time_period_days"`
-	SLIAlias         string   `json:"sli_alias" detail:"SLI Alias"`
-	DatasetSlugs     []string `json:"dataset_slugs,omitempty"`
-	CreatedAt        string   `json:"created_at,omitempty"`
-	UpdatedAt        string   `json:"updated_at,omitempty"`
-	ResetAt          string   `json:"reset_at,omitempty"`
+	ID               string           `json:"id" detail:"ID"`
+	Name             string           `json:"name" detail:"Name"`
+	Description      string           `json:"description,omitempty" detail:"Description"`
+	TargetPerMillion targetPerMillion `json:"target_per_million" detail:"Target"`
+	TimePeriodDays   timePeriodDays   `json:"time_period_days" detail:"Time Period"`
+	SLIAlias         string           `json:"sli_alias" detail:"SLI Alias"`
+	DatasetSlugs     []string         `json:"dataset_slugs,omitempty"`
+	CreatedAt        string           `json:"created_at,omitempty"`
+	UpdatedAt        string           `json:"updated_at,omitempty"`
+	ResetAt          string           `json:"reset_at,omitempty"`
 
 	// Detailed fields (only populated with --detailed)
 	Compliance      *float64 `json:"compliance,omitempty"`
@@ -58,8 +66,8 @@ func sloToDetail(s api.SLO) sloDetail {
 		ID:               deref.String(s.Id),
 		Name:             s.Name,
 		Description:      deref.String(s.Description),
-		TargetPerMillion: s.TargetPerMillion,
-		TimePeriodDays:   s.TimePeriodDays,
+		TargetPerMillion: targetPerMillion(s.TargetPerMillion),
+		TimePeriodDays:   timePeriodDays(s.TimePeriodDays),
 		SLIAlias:         s.Sli.Alias,
 		CreatedAt:        deref.Time(s.CreatedAt),
 		UpdatedAt:        deref.Time(s.UpdatedAt),
@@ -86,10 +94,6 @@ func detailedToDetail(s sloDetailedResponse) sloDetail {
 
 func writeSloDetail(opts *options.RootOptions, detail sloDetail) error {
 	fields := output.FieldsFromTags(detail)
-	fields = append(fields,
-		output.Field{Label: "Target", Value: formatTarget(detail.TargetPerMillion)},
-		output.Field{Label: "Time Period", Value: formatTimePeriod(detail.TimePeriodDays)},
-	)
 	if len(detail.DatasetSlugs) > 0 {
 		fields = append(fields, output.Field{Label: "Datasets", Value: strings.Join(detail.DatasetSlugs, ", ")})
 	}

--- a/cmd/slo/list.go
+++ b/cmd/slo/list.go
@@ -15,8 +15,8 @@ var sloListTable = output.TableDef{
 	Columns: []output.Column{
 		output.Col("ID", func(s sloItem) string { return s.ID }),
 		output.Col("Name", func(s sloItem) string { return s.Name }),
-		output.Col("Target", func(s sloItem) string { return formatTarget(s.TargetPerMillion) }),
-		output.Col("Time Period", func(s sloItem) string { return formatTimePeriod(s.TimePeriodDays) }),
+		output.Col("Target", func(s sloItem) string { return targetPerMillion(s.TargetPerMillion).FormatField() }),
+		output.Col("Time Period", func(s sloItem) string { return timePeriodDays(s.TimePeriodDays).FormatField() }),
 		output.Col("SLI Alias", func(s sloItem) string { return s.SLIAlias }),
 		output.Col("Description", func(s sloItem) string { return output.Truncate(s.Description, 40) }),
 	},

--- a/cmd/trigger/trigger.go
+++ b/cmd/trigger/trigger.go
@@ -57,7 +57,7 @@ type triggerDetail struct {
 	Triggered   bool              `json:"triggered" detail:"Triggered"`
 	AlertType   string            `json:"alert_type,omitempty" detail:"Alert Type"`
 	Frequency   int               `json:"frequency,omitempty" detail:"Frequency"`
-	Threshold   *triggerThreshold `json:"threshold,omitempty"`
+	Threshold   *triggerThreshold `json:"threshold,omitempty" detail:"Threshold"`
 	QueryID     string            `json:"query_id,omitempty"`
 	HasQuery    bool              `json:"has_query,omitempty"`
 	Recipients  []recipientItem   `json:"recipients,omitempty"`
@@ -70,6 +70,15 @@ type triggerThreshold struct {
 	Op            string  `json:"op"`
 	Value         float64 `json:"value"`
 	ExceededLimit int     `json:"exceeded_limit,omitempty"`
+}
+
+// FormatField renders the threshold as "op value" for detail table output. A
+// nil pointer is handled by the output package and renders as an empty string.
+func (t *triggerThreshold) FormatField() string {
+	if t == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s %g", t.Op, t.Value)
 }
 
 type recipientItem struct {
@@ -144,8 +153,6 @@ func toDetail(t api.TriggerResponse) triggerDetail {
 func writeTriggerDetail(opts *options.RootOptions, detail triggerDetail) error {
 	fields := output.FieldsFromTags(detail)
 
-	fields = append(fields, output.Field{Label: "Threshold", Value: formatThresholdDetail(detail.Threshold)})
-
 	if detail.QueryID != "" {
 		fields = append(fields, output.Field{Label: "Query ID", Value: detail.QueryID})
 	} else if detail.HasQuery {
@@ -169,11 +176,4 @@ func writeTriggerDetail(opts *options.RootOptions, detail triggerDetail) error {
 	}
 
 	return opts.OutputWriter().WriteFields(detail, fields)
-}
-
-func formatThresholdDetail(t *triggerThreshold) string {
-	if t == nil {
-		return ""
-	}
-	return fmt.Sprintf("%s %g", t.Op, t.Value)
 }

--- a/internal/output/tags.go
+++ b/internal/output/tags.go
@@ -45,7 +45,25 @@ func FieldsFromTags(v any) []Field {
 	return fields
 }
 
+// Formatter renders a detail field value as a single string. A field whose
+// value implements Formatter is rendered via FormatField instead of the
+// primitive switch in formatField, letting non-primitive types carry their own
+// table representation while keeping JSON output governed by their json tags.
+type Formatter interface {
+	FormatField() string
+}
+
 func formatField(rv reflect.Value) string {
+	if rv.Kind() == reflect.Pointer && rv.IsNil() {
+		if _, ok := reflect.Zero(rv.Type()).Interface().(Formatter); ok {
+			return ""
+		}
+	}
+	if rv.CanInterface() {
+		if f, ok := rv.Interface().(Formatter); ok {
+			return f.FormatField()
+		}
+	}
 	switch rv.Kind() {
 	case reflect.String:
 		return rv.String()

--- a/internal/output/tags_test.go
+++ b/internal/output/tags_test.go
@@ -64,6 +64,56 @@ func TestFieldsFromTags_Float(t *testing.T) {
 	}
 }
 
+type formatterValue struct {
+	Op string
+}
+
+func (f formatterValue) FormatField() string {
+	return "op=" + f.Op
+}
+
+func TestFieldsFromTags_Formatter(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		item any
+		want []Field
+	}{
+		{
+			name: "value formatter",
+			item: struct {
+				F formatterValue `detail:"F"`
+			}{F: formatterValue{Op: ">"}},
+			want: []Field{{Label: "F", Value: "op=>"}},
+		},
+		{
+			name: "non-nil pointer formatter",
+			item: struct {
+				F *formatterValue `detail:"F"`
+			}{F: &formatterValue{Op: "<"}},
+			want: []Field{{Label: "F", Value: "op=<"}},
+		},
+		{
+			name: "nil pointer formatter",
+			item: struct {
+				F *formatterValue `detail:"F"`
+			}{F: nil},
+			want: []Field{{Label: "F", Value: ""}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fields := FieldsFromTags(tc.item)
+			if len(fields) != len(tc.want) {
+				t.Fatalf("got %d fields, want %d", len(fields), len(tc.want))
+			}
+			for i, f := range fields {
+				if f != tc.want[i] {
+					t.Errorf("field %d = %+v, want %+v", i, f, tc.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestTableFromTags_RendersThroughWrite(t *testing.T) {
 	var buf strings.Builder
 	w := New(&buf, FormatTable)


### PR DESCRIPTION
Adds an `output.Formatter` seam so non-primitive detail fields carry their own table rendering through the struct-tag mechanism, instead of each command appending a hand-formatted `output.Field` after `FieldsFromTags`.

`FieldsFromTags` only knew how to render primitives, so every detail command formatted its non-primitive fields by hand and appended them. This teaches `formatField` to honor a `Formatter` interface (`FormatField() string`), nil-safe for pointer fields, and moves the always-on single-value formatters onto their types:

- `*triggerThreshold` gets `FormatField` (was `formatThresholdDetail`).
- board `panels` and board-view `filters` become named `json.RawMessage` types that preserve raw JSON passthrough (`MarshalJSON`/`UnmarshalJSON`) and carry their multi-line summary in `FormatField` (were `formatPanels`/`formatFilters`).
- slo `Target`/`Time Period` become named `int` types rendering as a percentage and `Nd` (were `formatTarget`/`formatTimePeriod`).

JSON output stays byte-identical: the named wrappers marshal exactly as before (raw passthrough for `RawMessage`, plain numbers for the ints), which the existing detail tests pin. Conditional and slice-join fields (Query ID, Recipients, Tags, slo Datasets, timestamps, compliance) stay explicit appends. They don't belong behind a single-value formatter.

I kept `preset_filters` as an explicit append rather than a wrapper type. Its formatting was just `string(raw)`, so a named type plus three passthrough methods would earn nothing over the one-line append.

This is the deliberately scoped version. In JSON mode `WriteFields` ignores the `fields` slice and marshals the struct, so this only changes how non-primitive fields render in the human-facing table, and the sweeping "render the whole struct" rewrite would have reordered table output for no JSON benefit.

## Changes

- Add `output.Formatter` and `Formatter` support in `formatField` (`internal/output/tags.go`), with tests.
- Move the trigger, board, board-view, and slo single-value formatters onto types behind the seam.

## Testing

- New `internal/output` tests cover value-type, non-nil-pointer, and nil-pointer (renders `""`) `Formatter` cases.
- Existing detail-command tests pass unchanged, pinning JSON parity.

Third of a five-PR stack, on #243.
