### PR TITLE
refactor(options): resolve output format by intent

### DIFF
--- a/cmd/options/options.go
+++ b/cmd/options/options.go
@@ -79,14 +79,27 @@ func (o *RootOptions) inferTeam() (string, bool) {
 	return "", false
 }
 
-func (o *RootOptions) ResolveFormat() string {
+// outputKind selects how an unset --format flag resolves. Detail output follows
+// the terminal: a table when interactive, JSON when piped, so scripts and agents
+// get structured output by default. List output defaults to a table in both
+// modes, since a collection reads best as a table.
+type outputKind int
+
+const (
+	detailOutput outputKind = iota
+	listOutput
+)
+
+// resolveFormat picks the concrete output format for kind. An explicit --format
+// flag always wins; otherwise the per-kind default applies.
+func (o *RootOptions) resolveFormat(kind outputKind) string {
 	if o.Format != "" {
 		return o.Format
 	}
-	if o.IOStreams.IsStdoutTTY() {
-		return output.FormatTable
+	if kind == detailOutput && !o.IOStreams.IsStdoutTTY() {
+		return output.FormatJSON
 	}
-	return output.FormatJSON
+	return output.FormatTable
 }
 
 func (o *RootOptions) RequireKey(kt config.KeyType) (string, error) {
@@ -128,15 +141,11 @@ func (o *RootOptions) Client(kt config.KeyType) (*api.ClientWithResponses, error
 }
 
 func (o *RootOptions) OutputWriter() *output.Writer {
-	return output.New(o.IOStreams.Out, o.ResolveFormat())
+	return output.New(o.IOStreams.Out, o.resolveFormat(detailOutput))
 }
 
 func (o *RootOptions) OutputWriterList() *output.Writer {
-	format := o.Format
-	if format == "" {
-		format = output.FormatTable
-	}
-	return output.New(o.IOStreams.Out, format)
+	return output.New(o.IOStreams.Out, o.resolveFormat(listOutput))
 }
 
 func (o *RootOptions) ResolveMCPUrl() string {

--- a/cmd/options/options_test.go
+++ b/cmd/options/options_test.go
@@ -1,0 +1,70 @@
+package options
+
+import (
+	"testing"
+
+	"github.com/bendrucker/honeycomb-cli/internal/iostreams"
+	"github.com/bendrucker/honeycomb-cli/internal/output"
+)
+
+func TestResolveFormat(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		format string
+		tty    bool
+		kind   outputKind
+		want   string
+	}{
+		{
+			name: "detail follows tty to a table",
+			tty:  true,
+			kind: detailOutput,
+			want: output.FormatTable,
+		},
+		{
+			name: "detail defaults to json when piped",
+			tty:  false,
+			kind: detailOutput,
+			want: output.FormatJSON,
+		},
+		{
+			name: "list defaults to a table on a tty",
+			tty:  true,
+			kind: listOutput,
+			want: output.FormatTable,
+		},
+		{
+			name: "list defaults to a table when piped",
+			tty:  false,
+			kind: listOutput,
+			want: output.FormatTable,
+		},
+		{
+			name:   "explicit format wins for detail",
+			format: output.FormatJSON,
+			tty:    true,
+			kind:   detailOutput,
+			want:   output.FormatJSON,
+		},
+		{
+			name:   "explicit format wins for list",
+			format: output.FormatJSON,
+			tty:    false,
+			kind:   listOutput,
+			want:   output.FormatJSON,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var ts *iostreams.TestStreams
+			if tc.tty {
+				ts = iostreams.TestPromptable(t)
+			} else {
+				ts = iostreams.Test(t)
+			}
+			o := &RootOptions{IOStreams: ts.IOStreams, Format: tc.format}
+			if got := o.resolveFormat(tc.kind); got != tc.want {
+				t.Errorf("resolveFormat = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Folds `OutputWriter` and `OutputWriterList` format resolution into one intent-keyed `resolveFormat`.

The two writer constructors differed only in how an unset `--format` resolves: detail output follows the terminal (a table when interactive, JSON when piped, so scripts and agents get structured output by default), while a list defaults to a table in both modes. That asymmetry lived in two near-duplicate methods plus a separate `ResolveFormat`, so you had to read both to see that lists ignore the TTY. `resolveFormat(kind)` now owns the rule, with an `outputKind` (detail/list) naming the intent and a comment explaining why the defaults differ. The two public methods stay as the readable call-site interface, so none of the ~55 call sites change.

Behavior is unchanged across every case. I removed the exported `ResolveFormat`, which had no callers.

## Changes

- Replace `ResolveFormat` and the inline list-format block with `resolveFormat(kind outputKind)` in `cmd/options/options.go`.
- Add `TestResolveFormat` covering detail/list against TTY/piped plus explicit `--format`.

## Testing

- `TestResolveFormat` exercises both detail and list intents against a TTY and a piped stream, plus an explicit `--format` overriding each.

Fourth of a five-PR stack, on #244.
