### PR TITLE
refactor(config): own MCP OAuth credentials in an MCPStore

### DIFF
--- a/cmd/auth/logout.go
+++ b/cmd/auth/logout.go
@@ -65,14 +65,15 @@ func runAuthLogout(opts *options.RootOptions, keyType string) error {
 	// A full logout (no --key-type) also clears any stored MCP OAuth token set
 	// and the persisted DCR client ID.
 	if keyType == "" {
-		err := config.DeleteMCPToken(profile)
+		store := config.NewMCPStore(profile)
+		err := store.DeleteToken()
 		if err == nil {
 			deleted = append(deleted, logoutResult{Type: "mcp"})
 		} else if !errors.Is(err, keyring.ErrNotFound) {
 			return fmt.Errorf("deleting MCP token: %w", err)
 		}
 
-		if err := config.DeleteMCPClientID(profile); err != nil && !errors.Is(err, keyring.ErrNotFound) {
+		if err := store.DeleteClientID(); err != nil && !errors.Is(err, keyring.ErrNotFound) {
 			return fmt.Errorf("deleting MCP client ID: %w", err)
 		}
 	}

--- a/cmd/auth/logout_test.go
+++ b/cmd/auth/logout_test.go
@@ -91,10 +91,10 @@ func TestAuthLogout_ClearsMCPToken(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = config.DeleteKey("default", config.KeyConfig) })
-	if err := config.SetMCPToken("default", map[string]string{"access_token": "tok"}); err != nil {
+	if err := config.NewMCPStore("default").SetToken(map[string]string{"access_token": "tok"}); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = config.DeleteMCPToken("default") })
+	t.Cleanup(func() { _ = config.NewMCPStore("default").DeleteToken() })
 
 	if err := runAuthLogout(opts, ""); err != nil {
 		t.Fatal(err)
@@ -116,7 +116,7 @@ func TestAuthLogout_ClearsMCPToken(t *testing.T) {
 	}
 
 	var tok map[string]string
-	if err := config.GetMCPToken("default", &tok); err == nil {
+	if err := config.NewMCPStore("default").Token(&tok); err == nil {
 		t.Error("expected MCP token to be deleted")
 	}
 }
@@ -133,10 +133,10 @@ func TestAuthLogout_KeyTypeLeavesMCPToken(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = config.DeleteKey("default", config.KeyConfig) })
-	if err := config.SetMCPToken("default", map[string]string{"access_token": "tok"}); err != nil {
+	if err := config.NewMCPStore("default").SetToken(map[string]string{"access_token": "tok"}); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = config.DeleteMCPToken("default") })
+	t.Cleanup(func() { _ = config.NewMCPStore("default").DeleteToken() })
 
 	// A targeted logout only removes the named key type. The MCP token is left
 	// intact so logging out a single API key does not silently drop the
@@ -156,7 +156,7 @@ func TestAuthLogout_KeyTypeLeavesMCPToken(t *testing.T) {
 	}
 
 	var tok map[string]string
-	if err := config.GetMCPToken("default", &tok); err != nil {
+	if err := config.NewMCPStore("default").Token(&tok); err != nil {
 		t.Errorf("expected MCP token to remain, got error: %v", err)
 	}
 }

--- a/cmd/mcp/oauth.go
+++ b/cmd/mcp/oauth.go
@@ -29,11 +29,11 @@ var oauthScopes = []string{"mcp:read", "mcp:write"}
 // persisting the OAuth token set under the {profile}:mcp entry. Tokens never
 // touch disk in plaintext and are never logged.
 type keyringTokenStore struct {
-	profile string
+	store config.MCPStore
 }
 
 func newKeyringTokenStore(profile string) *keyringTokenStore {
-	return &keyringTokenStore{profile: profile}
+	return &keyringTokenStore{store: config.NewMCPStore(profile)}
 }
 
 func (s *keyringTokenStore) GetToken(ctx context.Context) (*transport.Token, error) {
@@ -41,7 +41,7 @@ func (s *keyringTokenStore) GetToken(ctx context.Context) (*transport.Token, err
 		return nil, err
 	}
 	var token transport.Token
-	err := config.GetMCPToken(s.profile, &token)
+	err := s.store.Token(&token)
 	if errors.Is(err, keyring.ErrNotFound) {
 		return nil, transport.ErrNoToken
 	}
@@ -61,7 +61,7 @@ func (s *keyringTokenStore) SaveToken(ctx context.Context, token *transport.Toke
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if err := config.SetMCPToken(s.profile, token); err != nil {
+	if err := s.store.SetToken(token); err != nil {
 		return fmt.Errorf("saving MCP token: %w", err)
 	}
 	return nil
@@ -75,7 +75,7 @@ func (s *keyringTokenStore) SaveToken(ctx context.Context, token *transport.Toke
 // send a stable client_id across CLI invocations. A missing or unreadable entry
 // leaves the client ID empty, which triggers a fresh registration.
 func oauthConfig(profile, redirectURI string) transport.OAuthConfig {
-	clientID, _ := config.GetMCPClientID(profile)
+	clientID, _ := config.NewMCPStore(profile).ClientID()
 	return transport.OAuthConfig{
 		ClientID:    clientID,
 		ClientURI:   "https://github.com/bendrucker/honeycomb-cli",
@@ -127,7 +127,7 @@ func authorizeInteractive(ctx context.Context, ios *iostreams.IOStreams, profile
 		// failure here is non-fatal: the in-memory handler still works for this
 		// session.
 		if id := handler.GetClientID(); id != "" {
-			_ = config.SetMCPClientID(profile, id)
+			_ = config.NewMCPStore(profile).SetClientID(id)
 		}
 	}
 

--- a/cmd/mcp/oauth_test.go
+++ b/cmd/mcp/oauth_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestKeyringTokenStore(t *testing.T) {
 	const profile = "tokenstore-test"
-	t.Cleanup(func() { _ = config.DeleteMCPToken(profile) })
+	t.Cleanup(func() { _ = config.NewMCPStore(profile).DeleteToken() })
 
 	store := newKeyringTokenStore(profile)
 	ctx := context.Background()
@@ -221,12 +221,12 @@ func TestCallbackHandler(t *testing.T) {
 
 func TestKeyringTokenStore_CorruptJSON(t *testing.T) {
 	const profile = "corrupt-token-test"
-	t.Cleanup(func() { _ = config.DeleteMCPToken(profile) })
+	t.Cleanup(func() { _ = config.NewMCPStore(profile).DeleteToken() })
 
 	// Store an entry whose JSON is valid but cannot decode into a Token: a
 	// non-RFC3339 string for the time-typed expires_at field.
-	if err := config.SetMCPToken(profile, map[string]any{"expires_at": "not-a-time"}); err != nil {
-		t.Fatalf("SetMCPToken: %v", err)
+	if err := config.NewMCPStore(profile).SetToken(map[string]any{"expires_at": "not-a-time"}); err != nil {
+		t.Fatalf("SetToken: %v", err)
 	}
 
 	store := newKeyringTokenStore(profile)

--- a/internal/config/keyring.go
+++ b/internal/config/keyring.go
@@ -1,19 +1,12 @@
 package config
 
 import (
-	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/zalando/go-keyring"
 )
-
-// ErrMCPTokenCorrupt indicates a stored MCP token entry exists but could not be
-// decoded. Callers treat this like a missing token: the entry is unusable, so
-// re-authorizing is the only recovery.
-var ErrMCPTokenCorrupt = errors.New("stored MCP token is corrupt")
 
 const (
 	keyringService = "honeycomb-cli"
@@ -59,89 +52,6 @@ func ApplyAuth(req *http.Request, kt KeyType, key string) {
 
 func keyringKey(profile string, kt KeyType) string {
 	return fmt.Sprintf("%s:%s", profile, kt)
-}
-
-// mcpTokenSuffix is the keyring sub-key under which the MCP OAuth token set is
-// stored. It is deliberately not a KeyType: the token is a JSON document, not a
-// raw credential, so it stays out of the login/status/KeyTypes machinery.
-const mcpTokenSuffix = "mcp"
-
-func mcpTokenKey(profile string) string {
-	return fmt.Sprintf("%s:%s", profile, mcpTokenSuffix)
-}
-
-// SetMCPToken stores the OAuth token set for a profile, JSON-encoded under the
-// {profile}:mcp keyring entry.
-func SetMCPToken(profile string, v any) error {
-	data, err := json.Marshal(v)
-	if err != nil {
-		return fmt.Errorf("encoding MCP token: %w", err)
-	}
-	return withTimeout(func() error {
-		return keyring.Set(keyringService, mcpTokenKey(profile), string(data))
-	})
-}
-
-// GetMCPToken decodes the stored OAuth token set for a profile into v. It
-// returns keyring.ErrNotFound when no token has been stored and
-// ErrMCPTokenCorrupt when the stored entry cannot be decoded.
-func GetMCPToken(profile string, v any) error {
-	var raw string
-	err := withTimeout(func() error {
-		var e error
-		raw, e = keyring.Get(keyringService, mcpTokenKey(profile))
-		return e
-	})
-	if err != nil {
-		return err
-	}
-	if err := json.Unmarshal([]byte(raw), v); err != nil {
-		return fmt.Errorf("%w: %w", ErrMCPTokenCorrupt, err)
-	}
-	return nil
-}
-
-// DeleteMCPToken removes the stored OAuth token set for a profile.
-func DeleteMCPToken(profile string) error {
-	return withTimeout(func() error {
-		return keyring.Delete(keyringService, mcpTokenKey(profile))
-	})
-}
-
-// mcpClientIDSuffix is the keyring sub-key under which the Dynamic Client
-// Registration client ID is stored. Persisting it lets the refresh-token grant
-// send a stable client_id across CLI invocations instead of re-registering and
-// forcing a fresh browser flow on every token expiry.
-const mcpClientIDSuffix = "mcp-client"
-
-func mcpClientIDKey(profile string) string {
-	return fmt.Sprintf("%s:%s", profile, mcpClientIDSuffix)
-}
-
-// SetMCPClientID stores the DCR-registered OAuth client ID for a profile.
-func SetMCPClientID(profile, clientID string) error {
-	return withTimeout(func() error {
-		return keyring.Set(keyringService, mcpClientIDKey(profile), clientID)
-	})
-}
-
-// GetMCPClientID returns the stored OAuth client ID for a profile, or
-// keyring.ErrNotFound when none has been registered.
-func GetMCPClientID(profile string) (string, error) {
-	var val string
-	err := withTimeout(func() error {
-		var e error
-		val, e = keyring.Get(keyringService, mcpClientIDKey(profile))
-		return e
-	})
-	return val, err
-}
-
-// DeleteMCPClientID removes the stored OAuth client ID for a profile.
-func DeleteMCPClientID(profile string) error {
-	return withTimeout(func() error {
-		return keyring.Delete(keyringService, mcpClientIDKey(profile))
-	})
 }
 
 func SetKey(profile string, kt KeyType, value string) error {

--- a/internal/config/keyring_test.go
+++ b/internal/config/keyring_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"errors"
 	"net/http"
 	"testing"
 
@@ -67,49 +66,6 @@ func TestSetManagementKey(t *testing.T) {
 	}
 	if got != "id-123:secret-456" {
 		t.Errorf("stored value = %q, want %q", got, "id-123:secret-456")
-	}
-}
-
-func TestMCPToken(t *testing.T) {
-	keyring.MockInit()
-
-	type tokenSet struct {
-		AccessToken  string `json:"access_token"`
-		RefreshToken string `json:"refresh_token"`
-	}
-
-	const profile = "mcp-test"
-	t.Cleanup(func() { _ = DeleteMCPToken(profile) })
-
-	var empty tokenSet
-	if err := GetMCPToken(profile, &empty); !errors.Is(err, keyring.ErrNotFound) {
-		t.Fatalf("GetMCPToken on empty = %v, want ErrNotFound", err)
-	}
-
-	want := tokenSet{AccessToken: "a-tok", RefreshToken: "r-tok"}
-	if err := SetMCPToken(profile, want); err != nil {
-		t.Fatalf("SetMCPToken() error = %v", err)
-	}
-
-	var got tokenSet
-	if err := GetMCPToken(profile, &got); err != nil {
-		t.Fatalf("GetMCPToken() error = %v", err)
-	}
-	if got != want {
-		t.Errorf("GetMCPToken() = %+v, want %+v", got, want)
-	}
-
-	if err := DeleteMCPToken(profile); err != nil {
-		t.Fatalf("DeleteMCPToken() error = %v", err)
-	}
-	if err := GetMCPToken(profile, &got); !errors.Is(err, keyring.ErrNotFound) {
-		t.Errorf("GetMCPToken after delete = %v, want ErrNotFound", err)
-	}
-}
-
-func TestMCPTokenKey(t *testing.T) {
-	if got := mcpTokenKey("alice"); got != "alice:mcp" {
-		t.Errorf("mcpTokenKey() = %q, want %q", got, "alice:mcp")
 	}
 }
 

--- a/internal/config/mcp_oauth.go
+++ b/internal/config/mcp_oauth.go
@@ -1,0 +1,110 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/zalando/go-keyring"
+)
+
+// ErrMCPTokenCorrupt indicates a stored MCP token entry exists but could not be
+// decoded. Callers treat this like a missing token: the entry is unusable, so
+// re-authorizing is the only recovery.
+var ErrMCPTokenCorrupt = errors.New("stored MCP token is corrupt")
+
+// MCPStore persists the OAuth credentials for the Honeycomb MCP server in the OS
+// keyring, scoped to a profile. The token set and the Dynamic Client
+// Registration client ID are OAuth artifacts, not raw Honeycomb credentials, so
+// they live behind their own store rather than in the KeyType vault and stay out
+// of the login/status/KeyTypes machinery.
+type MCPStore struct {
+	profile string
+}
+
+// NewMCPStore returns the OAuth credential store for a profile.
+func NewMCPStore(profile string) MCPStore {
+	return MCPStore{profile: profile}
+}
+
+// mcpTokenSuffix is the keyring sub-key under which the OAuth token set is
+// stored, and mcpClientIDSuffix the sub-key for the DCR client ID. Persisting
+// the client ID lets the refresh-token grant send a stable client_id across CLI
+// invocations instead of re-registering and forcing a fresh browser flow on
+// every token expiry.
+const (
+	mcpTokenSuffix    = "mcp"
+	mcpClientIDSuffix = "mcp-client"
+)
+
+func (s MCPStore) tokenKey() string {
+	return fmt.Sprintf("%s:%s", s.profile, mcpTokenSuffix)
+}
+
+func (s MCPStore) clientIDKey() string {
+	return fmt.Sprintf("%s:%s", s.profile, mcpClientIDSuffix)
+}
+
+// SetToken stores the OAuth token set, JSON-encoded under the {profile}:mcp
+// keyring entry.
+func (s MCPStore) SetToken(v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("encoding MCP token: %w", err)
+	}
+	return withTimeout(func() error {
+		return keyring.Set(keyringService, s.tokenKey(), string(data))
+	})
+}
+
+// Token decodes the stored OAuth token set into v. It returns
+// keyring.ErrNotFound when no token has been stored and ErrMCPTokenCorrupt when
+// the stored entry cannot be decoded.
+func (s MCPStore) Token(v any) error {
+	var raw string
+	err := withTimeout(func() error {
+		var e error
+		raw, e = keyring.Get(keyringService, s.tokenKey())
+		return e
+	})
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal([]byte(raw), v); err != nil {
+		return fmt.Errorf("%w: %w", ErrMCPTokenCorrupt, err)
+	}
+	return nil
+}
+
+// DeleteToken removes the stored OAuth token set.
+func (s MCPStore) DeleteToken() error {
+	return withTimeout(func() error {
+		return keyring.Delete(keyringService, s.tokenKey())
+	})
+}
+
+// SetClientID stores the DCR-registered OAuth client ID.
+func (s MCPStore) SetClientID(clientID string) error {
+	return withTimeout(func() error {
+		return keyring.Set(keyringService, s.clientIDKey(), clientID)
+	})
+}
+
+// ClientID returns the stored OAuth client ID, or keyring.ErrNotFound when none
+// has been registered.
+func (s MCPStore) ClientID() (string, error) {
+	var val string
+	err := withTimeout(func() error {
+		var e error
+		val, e = keyring.Get(keyringService, s.clientIDKey())
+		return e
+	})
+	return val, err
+}
+
+// DeleteClientID removes the stored OAuth client ID.
+func (s MCPStore) DeleteClientID() error {
+	return withTimeout(func() error {
+		return keyring.Delete(keyringService, s.clientIDKey())
+	})
+}

--- a/internal/config/mcp_oauth_test.go
+++ b/internal/config/mcp_oauth_test.go
@@ -1,0 +1,94 @@
+package config
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/zalando/go-keyring"
+)
+
+func TestMCPStoreToken(t *testing.T) {
+	keyring.MockInit()
+
+	type tokenSet struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+	}
+
+	store := NewMCPStore("mcp-test")
+	t.Cleanup(func() { _ = store.DeleteToken() })
+
+	var empty tokenSet
+	if err := store.Token(&empty); !errors.Is(err, keyring.ErrNotFound) {
+		t.Fatalf("Token on empty = %v, want ErrNotFound", err)
+	}
+
+	want := tokenSet{AccessToken: "a-tok", RefreshToken: "r-tok"}
+	if err := store.SetToken(want); err != nil {
+		t.Fatalf("SetToken() error = %v", err)
+	}
+
+	var got tokenSet
+	if err := store.Token(&got); err != nil {
+		t.Fatalf("Token() error = %v", err)
+	}
+	if got != want {
+		t.Errorf("Token() = %+v, want %+v", got, want)
+	}
+
+	if err := store.DeleteToken(); err != nil {
+		t.Fatalf("DeleteToken() error = %v", err)
+	}
+	if err := store.Token(&got); !errors.Is(err, keyring.ErrNotFound) {
+		t.Errorf("Token after delete = %v, want ErrNotFound", err)
+	}
+}
+
+func TestMCPStoreCorruptToken(t *testing.T) {
+	keyring.MockInit()
+
+	store := NewMCPStore("mcp-corrupt")
+	t.Cleanup(func() { _ = store.DeleteToken() })
+
+	if err := keyring.Set(keyringService, store.tokenKey(), "not json"); err != nil {
+		t.Fatalf("seeding corrupt entry: %v", err)
+	}
+
+	var got map[string]any
+	if err := store.Token(&got); !errors.Is(err, ErrMCPTokenCorrupt) {
+		t.Errorf("Token on corrupt entry = %v, want ErrMCPTokenCorrupt", err)
+	}
+}
+
+func TestMCPStoreClientID(t *testing.T) {
+	keyring.MockInit()
+
+	store := NewMCPStore("mcp-test")
+	t.Cleanup(func() { _ = store.DeleteClientID() })
+
+	if _, err := store.ClientID(); !errors.Is(err, keyring.ErrNotFound) {
+		t.Fatalf("ClientID on empty = %v, want ErrNotFound", err)
+	}
+
+	if err := store.SetClientID("client-123"); err != nil {
+		t.Fatalf("SetClientID() error = %v", err)
+	}
+
+	got, err := store.ClientID()
+	if err != nil {
+		t.Fatalf("ClientID() error = %v", err)
+	}
+	if got != "client-123" {
+		t.Errorf("ClientID() = %q, want %q", got, "client-123")
+	}
+}
+
+func TestMCPStoreKeys(t *testing.T) {
+	store := NewMCPStore("alice")
+	if got := store.tokenKey(); got != "alice:mcp" {
+		t.Errorf("tokenKey() = %q, want %q", got, "alice:mcp")
+	}
+	if got := store.clientIDKey(); got != "alice:mcp-client" {
+		t.Errorf("clientIDKey() = %q, want %q", got, "alice:mcp-client")
+	}
+}


### PR DESCRIPTION
Gives the MCP OAuth credentials their own owner. The token set and the Dynamic Client Registration client ID were six free functions in `keyring.go`, sitting next to the API-key vault and each threading a `profile` string. This groups them behind a profile-scoped `config.MCPStore` in a new `mcp_oauth.go`, so the MCP transport depends on one store object and `keyring.go` keeps only the `KeyType` vault.

The keyring entries are unchanged (`{profile}:mcp` for the token, `{profile}:mcp-client` for the client ID), so credentials stored by earlier versions stay readable. `keyringTokenStore` in the mcp package now wraps an `MCPStore` instead of a bare profile, and `auth logout` builds one store for both deletes.

This is the modest version. There is no second storage backend, so it isn't a true seam. The win is locality: one owner for OAuth credential storage, with the profile baked in, separating OAuth artifacts from the raw Honeycomb credentials in the vault.

## Changes

- Add `internal/config/mcp_oauth.go`: `MCPStore` with `Token`/`SetToken`/`DeleteToken`/`ClientID`/`SetClientID`/`DeleteClientID`.
- Remove the six `*MCP*` free functions from `keyring.go` and move `ErrMCPTokenCorrupt` and the suffix constants across.
- Update the `cmd/mcp/oauth.go` and `cmd/auth/logout.go` callers.

## Testing

- `mcp_oauth_test.go` covers a token round-trip, a corrupt-token entry decoding to `ErrMCPTokenCorrupt`, a client-ID round-trip, and the keyring key formats.

Fifth and last of the stack, on #244.
