### PR TITLE
fix(hooks): run golangci-lint once in go-fix Stop hook

### DIFF
--- a/.claude/hooks/go-fix.sh
+++ b/.claude/hooks/go-fix.sh
@@ -7,9 +7,8 @@ stop_hook_active=$(echo "$input" | jq -r '.stop_hook_active // empty')
 export GOLANGCI_LINT_CACHE="${GOLANGCI_LINT_CACHE:-/tmp/claude/golangci-lint}"
 
 gofmt -w .
-golangci-lint run --fix ./... 2>/dev/null
 
-remaining=$(golangci-lint run ./... 2>&1 | grep -v '^level=')
+remaining=$(golangci-lint run --fix ./... 2>&1 | grep -v '^level=')
 if [ -n "$remaining" ]; then
   echo "$remaining" | jq -Rs '{hookSpecificOutput:{hookEventName:"Stop",additionalContext:("unfixed lint issues:\n" + .)}}'
 fi


### PR DESCRIPTION
Collapses the two golangci-lint runs in the `go-fix.sh` Stop hook into a single `--fix` pass and stops the first pass's issue listing from leaking into hook stdout ahead of the JSON payload.

## Issue

The hook ran golangci-lint twice on every Stop: a `--fix` pass, then a plain pass to collect remaining issues. golangci-lint v2 reports unfixable issues in the same `--fix` run, so the second pass was pure overhead. The `--fix` pass also redirected only stderr, so its issue listing printed to hook stdout before the JSON, which is supposed to be the only stdout content.

## Changes

- Capture the single `--fix` pass's combined output into `remaining` instead of running a second plain pass
- Hook stdout now carries only the JSON `hookSpecificOutput` payload

## Testing

Ran the hook manually from the repo root with a fixture containing one fixable issue (staticcheck `S1002`, `if x == true`) and one unfixable issue (errcheck on `f.Close()`):

- stdout is a single valid JSON document (verified with `jq -e`)
- the fixable issue gets fixed in place; the unfixable one appears in `additionalContext`
- warm wall time on a clean tree drops from ~1.4s to ~0.7s

Original Task: [[discovery] go-fix.sh](https://things.bendrucker.me/show?id=WbHS6uW9ZPApPJM5yvFGcv)
