### PR TITLE
build: harden GoReleaser config and document install paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,17 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+      - uses: actions/create-github-app-token@v2
+        id: tap-token
+        with:
+          app-id: ${{ vars.TAP_APP_ID }}
+          private-key: ${{ secrets.TAP_APP_PRIVATE_KEY }}
+          owner: bendrucker
+          repositories: homebrew-tap
       - uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAP_GITHUB_TOKEN: ${{ steps.tap-token.outputs.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,8 @@ go.work.sum
 # Build output
 /honeycomb
 
+# GoReleaser output
+/dist/
+
 # Temporary files
 tmp/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,11 @@ builds:
     binary: honeycomb
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
     goarch:
       - amd64
       - arm64
@@ -14,6 +19,26 @@ archives:
       - goos: windows
         formats:
           - zip
+
+homebrew_casks:
+  - name: honeycomb
+    repository:
+      owner: bendrucker
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+    homepage: https://github.com/bendrucker/honeycomb-cli
+    description: Unofficial CLI for Honeycomb, modeled after the GitHub CLI
+    binaries:
+      - honeycomb
+    # The binary is unsigned, so strip the quarantine flag Homebrew sets on
+    # download to avoid Gatekeeper blocking the first run.
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/honeycomb"]
+          end
 
 checksum:
   name_template: checksums.txt

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,11 +5,6 @@ builds:
     binary: honeycomb
     env:
       - CGO_ENABLED=0
-    ldflags:
-      - -s -w
-      - -X main.version={{.Version}}
-      - -X main.commit={{.Commit}}
-      - -X main.date={{.Date}}
     goarch:
       - amd64
       - arm64

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ Unofficial CLI for [Honeycomb](https://www.honeycomb.io/), modeled after the [Gi
 
 ## Installation
 
+### Homebrew
+
+```
+brew install bendrucker/tap/honeycomb
+```
+
+### Prebuilt Binary
+
+Download an archive for your platform from the [latest release](https://github.com/bendrucker/honeycomb-cli/releases/latest), extract it, and move the `honeycomb` binary onto your `PATH`.
+
+### Go
+
 ```
 go install github.com/bendrucker/honeycomb-cli/cmd/honeycomb@latest
 ```


### PR DESCRIPTION
Hardens the release pipeline and adds a non-Go install path. Closes #158.

## Changes

- Adds a `homebrew_casks` block that publishes a cask to `bendrucker/homebrew-tap`, giving macOS users `brew install bendrucker/tap/honeycomb`. A post-install hook strips the quarantine flag since the binary is unsigned, so Gatekeeper doesn't block the first run.
- Documents Homebrew, prebuilt-binary download, and `go install` in the README so coworkers without a Go toolchain have a path.
- Ignores GoReleaser's `dist/` output.

The `checksum` and conventional-commit `changelog` blocks the issue asks for already landed on `main`, so they're not in this diff.

## Distribution Decision

The tap publishes from a separate `bendrucker/homebrew-tap` repo (already created, with a README) rather than this repo. A self-contained tap isn't reachable with the default `GITHUB_TOKEN`: it's scoped to this repo so it can't push cross-repo, and it can't push to a protected `main` here (the `github-actions` bot can't be added to a ruleset bypass list, and a PR it opens never triggers the required status checks). The remaining no-PAT option is a GitHub App installation token, which the release workflow mints with `actions/create-github-app-token` and hands to GoReleaser as `TAP_GITHUB_TOKEN`. Tokens are short-lived and repo-scoped, and there's no long-lived PAT to rotate.

This is written as `homebrew_casks` rather than `brews` because `brews` is deprecated in GoReleaser v2 and slated for removal in v3.

## Manual Setup Required Before the Next Release

The workflow references a GitHub App that doesn't exist yet. Before cutting a release:

- Create a GitHub App with **Contents: read and write**, install it on `bendrucker/homebrew-tap`.
- Add repo variable `TAP_APP_ID` and repo secret `TAP_APP_PRIVATE_KEY` to this repo.

## Testing

`goreleaser check` passes, and `goreleaser release --snapshot --clean` produces the archives, checksums, and the `honeycomb` cask locally. Ran the built `darwin_arm64` binary and confirmed `--version` prints the stamped version, commit, and date.
